### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,3 +488,8 @@ npm run build   # must pass before submitting
 MIT. See [LICENSE](./LICENSE).
 
 Built by [Frihet](https://frihet.io).
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/frihet-mcp-server).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/frihet-mcp-server).