### PR TITLE
docs: bootstrap CLAUDE.md + AGENTS.md for AI agent alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 mcp-registry-key.pem
 mcp-registry-auth
 mcp-registry-private-key.txt
+SOUL.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,137 @@
+# Frihet MCP Server
+
+Open-source MCP server for Frihet ERP. TypeScript, Node >= 18, MIT license. Distributed via npm + Cloudflare Worker (mcp.frihet.io) + Smithery + Anthropic registry.
+
+## Build & Test
+
+```bash
+npm install                      # Install deps
+npm run build                    # tsc → dist/
+npm test                         # Run native node test suite
+npm start                        # Run server via stdio (local debug)
+npm publish --tag beta           # Publish beta release
+npm publish                      # Publish stable release
+```
+
+**Pre-commit**: `npm run build` must succeed. `npm test` must pass.
+
+## Code Style
+
+- TypeScript strict mode (`strict: true`)
+- ES2022 target, NodeNext module resolution
+- Tools follow `frihet.<resource>.<action>` naming
+- Structured output (JSON) on every tool, NOT prose
+- Zod schemas on `inputSchema` (strict)
+- Errors: throw `McpError` with cause + suggestion
+- One tool per logical operation — no batching unless explicit
+- Async/await throughout, no callbacks
+- Logger from `src/logger.ts` — never `console.log` in tool code
+- Observability: every tool wrapped via `src/observability.ts` (Langfuse)
+
+## Conventions
+
+- Commit messages: `feat(tools): add <family> CRUD` / `fix(invoices): handle null totals`
+- Branch names: `feat/<descriptive-slug>`
+- Atomic commits — one tool family per commit minimum
+- Update README.md tool count badge when adding tools
+- Update CHANGELOG.md on every release
+- Bump version semver: feat=minor, fix=patch, breaking=major
+- Tool descriptions in English (LLM understanding)
+- Test fixtures in `src/__tests__/fixtures/`
+
+## Gotchas
+
+- **NEVER mutate `process.env`** — read once into config object
+- **API client must respect `Idempotency-Key`** — propagate from tool input when present
+- **Don't log full request bodies** — PII (NIF/IBAN/email). Use `mask()` from logger
+- **Cloudflare Worker is separate** — `mcp.frihet.io` deployment is in a different repo. Pinging Worker is not a substitute for testing the npm package locally
+- **Smithery rebuilds on push** — verify Smithery config (`smithery.yaml`) when changing entry points
+- **MCP SDK breaking changes** — pin `@modelcontextprotocol/sdk` minor; major bumps require manual review
+- **Beta tag rules** — `1.x.x-beta.N` for prerelease, `1.x.x` for stable. NEVER publish stable from a `feat/*` branch
+- **Postinstall script** — `node scripts/postinstall.js || true` runs harmlessly. Do not make required
+
+## Security
+
+- API key (`FRIHET_API_KEY`) read from env at server start, never logged
+- Bearer token sent only to `https://api.frihet.io/v1`
+- No third-party HTTP outside Frihet API + Langfuse
+- Worker (mcp.frihet.io) handles OAuth + key exchange separately
+- Errors include cause but never echo full Authorization header
+
+---
+
+## Multi-agent dispatch + LiteLLM cost rules
+
+For tool-batch tasks (adding 8 tools in one family, refactoring across 13 files), dispatch parallel Sonnet workers in worktrees.
+
+### Worker prompt template
+
+```
+Sonnet worker, worktree, repo Frihet-io/frihet-mcp.
+
+Files in scope (verified):
+  - src/tools/<family>.ts (new file)
+  - src/tools/register-all.ts (add registration)
+  - src/__tests__/<family>.test.ts (new file)
+  - README.md (bump tool count badge)
+  - CHANGELOG.md (add entry)
+
+Task: Add <N> tools for <family>: <list>. Each tool follows frihet.<family>.<action>
+naming, structured JSON output, Zod inputSchema strict, McpError on failure,
+Idempotency-Key support on mutations.
+
+Constraints:
+  - Pre-commit: npm run build && npm test
+  - Branch: feat/<family>-tools
+  - Commits: 1 per tool minimum, semantic messages
+  - Use ~/.claude/bin/llm --code for tool scaffolding from existing patterns
+    (see src/tools/invoices.ts as canonical example)
+  - Use ~/.claude/bin/llm --grunt for JSDoc comments + test scaffolds
+  - DO NOT use llm router for: error handling logic, idempotency,
+    auth/scope, anything touching real customer money
+
+Trust Area: YES (this repo is Trust Area — tool errors propagate to agents
+acting on user data). Spend final 10% as adversarial reviewer.
+
+Report: branch, PR URL, build + test output.
+```
+
+### LiteLLM router (cost-optim)
+
+CLI: `~/.claude/bin/llm --grunt|--code|--pro|--reason "<prompt>"`. Use for:
+
+- Tool boilerplate from existing pattern (input schema, registration, output shaping)
+- JSDoc comments
+- README badge updates
+- CHANGELOG entries (Conventional Commits style)
+- OpenAPI fragment generation (matching API V1)
+- Test scaffolds with mocked client
+
+NEVER use LiteLLM for:
+- Auth/scope logic
+- Idempotency implementation
+- Error handling (must be hand-written for predictability)
+- Worker (mcp.frihet.io) routing logic
+- Any tool that touches real customer money
+
+### Trust Area gates (MCP-specific)
+
+- Every mutating tool must have at least 1 idempotency test
+- Every tool must have at least 1 schema rejection test (bad input)
+- Every tool must have at least 1 happy path test
+- Coverage target: > 80% lines, 100% on auth/scope branches
+- Pre-publish: smoke install from npm tarball + run against staging API
+
+### Worker-side static surface (Cloudflare Worker, separate repo)
+
+The Cloudflare Worker serving `mcp.frihet.io` MUST also serve:
+- `/llms.txt` (200, plain text, brief overview)
+- `/llms-full.txt` (200, plain text, full reference)
+- `/robots.txt` (200, allow AI crawlers explicit)
+- `/sitemap.xml` (200, single URL or full)
+- `/openapi.json` (200, mirror of api.frihet.io v1)
+- `/mcp.json` (200, MCP server manifest)
+- `/.well-known/mcp` (200, well-known endpoint discovery)
+- `/.well-known/ai-plugin.json` (200, ChatGPT plugin spec)
+
+Wave 1 sprint includes this fix. Audit table in CLAUDE.md.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,213 @@
+# CLAUDE.md — Frihet MCP Server
+
+See also: `SOUL.md` (symlink → `Frihet-ERP/SOUL.md`) for product voice, branding, V2 AI-distribution moat doctrine. `AGENTS.md` for build commands, multi-agent dispatch, LiteLLM cost rules. `~/SOUL.md` for Viktor's personal context.
+
+## What is this
+
+MCP server that connects AI assistants (Claude Code, Cursor, Copilot, Codex, Windsurf, Gemini CLI, ChatGPT Desktop) to Frihet ERP. Natural language → invoices, expenses, clients, fiscal reports.
+
+**Live:**
+- npm: https://www.npmjs.com/package/@frihet/mcp-server (v1.7.0-beta.1, 62 tools)
+- MCP remote: https://mcp.frihet.io (Cloudflare Worker)
+- Smithery: https://smithery.ai/server/frihet/frihet-mcp
+- Anthropic registry: https://registry.modelcontextprotocol.io/?q=io.frihet
+- License: MIT
+
+**Repo:** `Frihet-io/frihet-mcp`
+**Sister repos:** `berthelius/Frihet-ERP`, `berthelius/Frihet-Saas-Website`, `berthelius/frihet-docs`
+
+---
+
+## Stack
+
+- Node.js >= 18
+- TypeScript (strict, target ES2022)
+- `@modelcontextprotocol/sdk` (peer dep)
+- Zero runtime deps (only 1 in package.json — minimal surface)
+- Distribution: npm + Cloudflare Worker (mcp.frihet.io) + Smithery
+- Tests: native `node --test` runner
+
+---
+
+## V2 Brutal — north star (mayo 2026)
+
+**This is the moat surface.** When a developer or agent asks "MCP for ERP / facturación / Spanish e-invoice", we want @frihet/mcp-server as the top result.
+
+### Discoverability targets
+
+| Channel | Status | Action |
+|---|---|---|
+| npm package | LIVE 62 tools | Bump to v2.0.0 with 110+ tools |
+| Smithery installs | LIVE | Track install rate weekly |
+| MCP Registry (anthropic) | LIVE | Verify keep updated on major release |
+| ChatGPT MCP marketplace | not submitted | Wave 4 submission |
+| Cursor MCP marketplace | not submitted | Wave 4 submission |
+| Claude Desktop MCP gallery | not submitted | Wave 4 submission |
+| GitHub stars | track | Weekly update |
+| `mcp.frihet.io/llms.txt` | **404** | Wave 1: Worker static surface |
+| `mcp.frihet.io/openapi.json` | **404** | Wave 1: serve from Worker |
+| `mcp.frihet.io/.well-known/mcp` | **404** | Wave 1: serve from Worker |
+| `mcp.frihet.io/robots.txt` | **404** | Wave 1: serve from Worker |
+
+**Wave 1 PR**: `feat(worker): static AI-discoverability surface`. Cloudflare Worker should serve static files for crawlers AND handle MCP JSON-RPC for clients.
+
+### Tool coverage targets (62 → 110+)
+
+Current (v1.7.0-beta.1, 62 tools):
+
+| File | Tools | Coverage |
+|---|---|---|
+| invoices | 12 | CRUD + send + pay + PDF + drafts |
+| crm | 8 | activities + notes + leads |
+| deposits | 7 | CRUD + apply + refund |
+| quotes | 6 | CRUD + accept + convert |
+| clients | 5 | CRUD + import |
+| expenses | 5 | CRUD + OCR |
+| products | 5 | CRUD + pricing |
+| vendors | 5 | CRUD + sync |
+| webhooks | 5 | CRUD + replay |
+| einvoice | 4 | send + status + validate + DATEV (beta) |
+| intelligence | 4 | summary + insights + anomalies + forecast |
+| register-all | 3 | meta-tools |
+
+**Missing for V2 (target 110+ tools)**:
+- banking (5+): accounts list/get, tx list/categorize/match, payments send
+- fiscal (8+): modelo 303/130/390/180/347, verifactu status/resubmit, ticketbai status/submit
+- time (6+): timesheets CRUD + attendance checkin/out + projects
+- recurring (4+): recurring_invoices CRUD + run_now + pause
+- team (4+): members + roles + invites
+- integrations (5+): list + connect + disconnect + run + status
+- ai_copilot (3+): explain + suggest + optimize (meta-tools)
+- webhooks v2 (3+): signing rotation + replay + filter expressions
+
+Total V2 target: ~38 new tools across 8 new files. v2.0.0 release.
+
+---
+
+## Architecture
+
+```
+src/
+  index.ts             — MCP server entry (Server + transport)
+  client.ts            — Frihet API HTTP client (Bearer auth)
+  client-interface.ts  — Typed interface for client mocking
+  types.ts             — Shared TypeScript types
+  logger.ts            — Structured logging
+  observability.ts     — Langfuse LLM observability
+  metrics.ts           — Tool call metrics
+  openai-profile.ts    — OpenAI compatibility profile
+  tools/
+    register-all.ts    — Tool registration entry
+    invoices.ts        — 12 invoice tools
+    expenses.ts        — 5 expense tools
+    clients.ts         — 5 client tools
+    products.ts        — 5 product tools
+    quotes.ts          — 6 quote tools
+    crm.ts             — 8 CRM tools
+    deposits.ts        — 7 deposit tools
+    vendors.ts         — 5 vendor tools
+    webhooks.ts        — 5 webhook tools
+    einvoice.ts        — 4 einvoice tools (beta)
+    intelligence.ts    — 4 AI insights tools
+    shared.ts          — Cross-tool helpers
+  resources/
+    register-all.ts    — MCP resources (read-only context)
+  prompts/
+    register-all.ts    — MCP prompts (templated)
+```
+
+---
+
+## Cross-references
+
+- API client: hits `https://api.frihet.io/v1` (managed in `src/client.ts`)
+- Auth: Bearer token from env `FRIHET_API_KEY` (format `fri_*`)
+- Observability: Langfuse wired (env `LANGFUSE_PUBLIC_KEY` + `LANGFUSE_SECRET_KEY`)
+- Worker: `mcp.frihet.io` is Cloudflare Worker — separate deployment surface (NOT in this repo, see ops)
+
+---
+
+## Tool design pattern
+
+Every tool follows this contract:
+
+```typescript
+server.registerTool(
+  'frihet.invoices.create',
+  {
+    title: 'Create invoice',
+    description: 'Create a new invoice for a client. Returns invoice ID + total + PDF URL.',
+    inputSchema: { /* Zod or JSON schema */ },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+  },
+  async (input) => {
+    // 1. Validate input (Zod)
+    // 2. Call Frihet API V1 via client
+    // 3. Return structured output (NOT prose)
+    return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+  }
+);
+```
+
+**Rules**:
+- Tool name: `frihet.<resource>.<action>` (dot-separated, lowercase)
+- `description` clear in 1 line, mentions input + output
+- `inputSchema` strictly typed
+- Output: structured JSON, NOT prose
+- Idempotency where possible (use `Idempotency-Key` HTTP header)
+- Errors: throw `McpError` with cause + suggestion
+
+---
+
+## Build & Test
+
+```bash
+npm run build          # tsc → dist/
+npm test               # npm run build && node --test dist/__tests__/*.test.js
+npm start              # node dist/index.js (local stdio)
+npm publish --tag beta # publish beta
+npm publish            # publish stable (v2.0.0+)
+```
+
+**Pre-publish checklist**:
+- [ ] `npm run build` clean
+- [ ] `npm test` all pass
+- [ ] Tool count in README badge matches actual count
+- [ ] CHANGELOG.md updated
+- [ ] Version bumped (semver)
+- [ ] Smoke test: install fresh from npm in temp dir + run
+
+---
+
+## Trust Areas
+
+This repo is itself a Trust Area. Tool errors propagate to user agents which act on user's business data.
+
+- **Idempotency** — every mutating tool MUST support `Idempotency-Key`. Test it.
+- **Input validation** — strict Zod schemas. Reject ambiguous input rather than infer.
+- **Auth scope** — tools must respect API key scope. No privilege escalation.
+- **Rate limiting** — client-side backoff on 429. Don't burn user's quota.
+- **PII** — never log full request bodies. Mask NIF/IBAN/email in logs.
+- **Side effects** — destructive tools (delete, refund) need explicit confirmation pattern.
+
+---
+
+## V2 release plan
+
+1. Sprint Wave 1 (this week): static AI surface for `mcp.frihet.io` Worker
+2. Sprint Wave 2 (next week): banking + fiscal + time tool families (+25 tools)
+3. Sprint Wave 3: recurring + team + integrations + ai_copilot + webhooks v2 (+13 tools)
+4. v2.0.0 release: 110+ tools, OpenAPI v2 alignment, Langfuse instrumentation
+5. Wave 4: marketplace submissions (Cursor, ChatGPT, Claude Desktop)
+
+---
+
+## Contact
+
+**Owner:** Viktor / BRTHLS
+**Sister projects:** see `Frihet-ERP/CLAUDE.md` for ERP, `Frihet-Saas-Website/CLAUDE.md` for marketing, `frihet-docs/CLAUDE.md` for docs.


### PR DESCRIPTION
## Summary
NEW: CLAUDE.md + AGENTS.md (this repo previously had neither).
- Stack overview, V2 brutal north star, tool coverage targets (62→110+)
- Build & test, code style, conventions, gotchas, security
- Multi-agent dispatch + LiteLLM cost rules
- Trust Area gates (idempotency, schema rejection, happy path tests)
- Worker prompt template + worker-side static surface targets for mcp.frihet.io

Updates .gitignore to exclude SOUL.md (symlink to Frihet-ERP canonical).

Doc-only.

## Test plan
- [x] No code paths touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)