### PR TITLE
fix(api-proxy): serve ai.txt at canonical /.well-known/ai.txt

### DIFF
--- a/workers/api-proxy/worker.js
+++ b/workers/api-proxy/worker.js
@@ -501,7 +501,7 @@ export default {
         });
       }
 
-      if (pathname === "/ai.txt") {
+      if (pathname === "/ai.txt" || pathname === "/.well-known/ai.txt") {
         return new Response(AI_TXT, {
           headers: {
             "Content-Type": "text/plain; charset=utf-8",


### PR DESCRIPTION
## Summary

Worker serves ai.txt at `/ai.txt` only. LLM crawlers check the canonical RFC8615 path `/.well-known/ai.txt` — that path falls through to upstream publicApi proxy and returns 401.

Alias both paths to same content.

## Verification

```
# Before (this PR)
curl -A Googlebot https://api.frihet.io/.well-known/ai.txt → 401

# After deploy
curl -A Googlebot https://api.frihet.io/.well-known/ai.txt → 200
```

## Note

ERP PR #337 added `/.well-known/ai.txt` handler in `publicApi.ts` (deployed prod 9-may-PM). But the `frihet-api-proxy` Cloudflare Worker intercepts requests BEFORE they reach upstream — so this Worker fix is the actual production path. Worker fix alone is sufficient.

Part of V2 brutal sprint Wave 1 — AI-distribution moat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)