### PR TITLE
feat(mcp): Wave 6 — banking (5) + fiscal (8) + time (4) + recurring (2) = 19 tools (75→94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to `@frihet/mcp-server` are documented here.
 
+## [1.9.0-beta.1] — 2026-05-10
+
+### Added
+
+- **Wave 6 — Banking (5 tools)**: `list_bank_accounts`, `get_bank_account`, `list_transactions`, `categorize_transaction`, `match_transaction_to_invoice` (Trust Area: requires `confirm=true`). REST surface: `/v1/banking/*`.
+- **Wave 6 — Fiscal (8 tools)**: `get_modelo_303_summary` (IVA quarterly), `get_modelo_130_summary` (IRPF estimated), `get_modelo_390_summary` (IVA annual), `get_modelo_180_summary` (IRPF rentals annual), `get_modelo_347_summary` (operations >€3,005 recap), `verifactu_status`, `verifactu_resubmit` (Trust Area + audit trail: requires `confirm=true`), `ticketbai_status` (Basque Country, province field). REST surface: `/v1/fiscal/*`.
+- **Wave 6 — Time Tracking (4 tools)**: `list_time_entries`, `create_time_entry`, `update_time_entry`, `delete_time_entry` (soft-delete, Trust Area: requires `confirm=true`). REST surface: `/v1/time/entries`.
+- **Wave 6 — Recurring Invoices (2 tools)**: `list_recurring_invoices`, `run_recurring_now` (manual trigger, `draftOnly` flag). REST surface: `/v1/recurring/invoices`.
+- 7 new output schemas added to `shared.ts`: `BankAccount`, `BankTransaction`, `FiscalModeloSummary`, `VeriFactuStatus`, `TicketBaiStatus`, `TimeEntry`, `RecurringInvoice`.
+- 19 new interface methods in `IFrihetClient` and HTTP implementations in `FrihetClient`.
+- 4 new test files: `banking-tools.test.ts`, `fiscal-tools.test.ts`, `time-tools.test.ts`, `recurring-tools.test.ts` (~35 new tests).
+
+### Changed
+
+- Total tool count: 75 → **94 tools**.
+- Updated package description, README badge, and `register-all.ts` to wire all 4 new families.
+
+### Notes
+
+- ERP backend endpoints `/v1/banking/*`, `/v1/fiscal/*`, `/v1/time/*`, `/v1/recurring/*` are planned. Tools are wired now and will surface 404 errors until the backend ships.
+- Trust Area tools (`match_transaction_to_invoice`, `verifactu_resubmit`, `delete_time_entry`) require explicit `confirm=true` and fail-open with clear error messages.
+
+---
+
 ## [1.8.0-beta.1] — 2026-05-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <a href="https://smithery.ai/server/frihet/frihet-mcp"><img src="https://smithery.ai/badge/frihet/frihet-mcp" alt="Smithery installs"></a>
   <a href="https://registry.modelcontextprotocol.io/?q=io.frihet"><img src="https://img.shields.io/badge/MCP_Registry-io.frihet%2Ferp-4A90D9?style=flat&logo=anthropic&logoColor=white" alt="MCP Registry"></a>
   <a href="https://github.com/Frihet-io/frihet-mcp/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-18181b?style=flat&labelColor=09090b" alt="license"></a>
-  <img src="https://img.shields.io/badge/tools-75-18181b?style=flat&labelColor=09090b" alt="75 tools">
+  <img src="https://img.shields.io/badge/tools-94-18181b?style=flat&labelColor=09090b" alt="94 tools">
   <img src="https://img.shields.io/badge/node-%3E%3D18-18181b?style=flat&labelColor=09090b" alt="node >=18">
   <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-18181b?style=flat&labelColor=09090b" alt="TypeScript"></a>
 </p>
@@ -33,7 +33,7 @@ You:     "Create an invoice for TechStart SL, 40 hours of consulting at 75 EUR/h
 Claude:  Done. Invoice INV-2026-089 created. Total: 3,000.00 EUR + 21% IVA = 3,630.00 EUR.
 ```
 
-75 tools. 8 resources. 7 prompts. Structured output on every tool. Zero boilerplate.
+94 tools. 8 resources. 7 prompts. Structured output on every tool. Zero boilerplate.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@frihet/mcp-server",
-  "version": "1.8.0-beta.1",
-  "description": "AI-native MCP server for business management — invoices, expenses, deposits, clients, products, quotes, webhooks, CRM, e-invoicing, vacation rentals, POS. 75 tools. Remote endpoint at mcp.frihet.io (zero install). Works with Claude, Cursor, Windsurf, Cline.",
+  "version": "1.9.0-beta.1",
+  "description": "AI-native MCP server for business management — invoices, expenses, deposits, clients, products, quotes, webhooks, CRM, e-invoicing, vacation rentals, POS, banking, fiscal (Modelo 303/130/390/180/347, VeriFactu, TicketBAI), time tracking, recurring invoices. 94 tools. Remote endpoint at mcp.frihet.io (zero install). Works with Claude, Cursor, Windsurf, Cline.",
   "type": "module",
   "main": "./dist/index.js",
   "bin": {
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "npm run build && node --test dist/__tests__/einvoice-tools.test.js dist/__tests__/stay-tools.test.js dist/__tests__/pos-tools.test.js",
+    "test": "npm run build && node --test dist/__tests__/einvoice-tools.test.js dist/__tests__/stay-tools.test.js dist/__tests__/pos-tools.test.js dist/__tests__/banking-tools.test.js dist/__tests__/fiscal-tools.test.js dist/__tests__/time-tools.test.js dist/__tests__/recurring-tools.test.js",
     "start": "node dist/index.js",
     "postinstall": "node scripts/postinstall.js || true",
     "prepublishOnly": "npm run build"

--- a/src/__tests__/banking-tools.test.ts
+++ b/src/__tests__/banking-tools.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Tests for Banking MCP tools — Wave 6 (5 tools).
+ *
+ * Uses Node.js built-in test runner (node:test + node:assert).
+ * Run: npm test (after build)
+ *
+ * Coverage:
+ *   1. Tool registration — all 5 banking tools registered
+ *   2. list_bank_accounts — success path + structuredContent shape
+ *   3. get_bank_account — success path
+ *   4. list_transactions — success path + filters
+ *   5. categorize_transaction — success path + update response
+ *   6. match_transaction_to_invoice — confirm=false gate
+ *   7. match_transaction_to_invoice — confirm=true success path
+ *   8. API error — 404 propagated as isError=true
+ */
+
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+// ── Minimal McpServer stub ───────────────────────────────────────────────────
+
+interface ToolConfig {
+  title: string;
+  description: string;
+  annotations?: Record<string, unknown>;
+  inputSchema: Record<string, unknown>;
+  outputSchema?: unknown;
+}
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+}>;
+
+interface RegisteredTool {
+  name: string;
+  config: ToolConfig;
+  handler: ToolHandler;
+}
+
+class StubMcpServer {
+  tools: Map<string, RegisteredTool> = new Map();
+
+  registerTool(name: string, config: ToolConfig, handler: ToolHandler): void {
+    this.tools.set(name, { name, config, handler });
+  }
+}
+
+// ── Mock data ────────────────────────────────────────────────────────────────
+
+const MOCK_ACCOUNT = {
+  id: "acct_001",
+  alias: "Cuenta corriente BRTHLS",
+  ibanLast4: "4321",
+  currency: "EUR",
+  balance: 12345.67,
+  lastSyncedAt: "2026-05-10T08:00:00Z",
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+const MOCK_ACCOUNTS_LIST = {
+  data: [MOCK_ACCOUNT],
+  total: 1,
+  limit: 20,
+  offset: 0,
+};
+
+const MOCK_TRANSACTION = {
+  id: "tx_abc123",
+  accountId: "acct_001",
+  amount: -250.0,
+  currency: "EUR",
+  description: "Pago proveedor Acme",
+  postedAt: "2026-05-09T14:23:00Z",
+  category: "supplies",
+  status: "posted",
+  matchedDocId: null,
+};
+
+const MOCK_TRANSACTIONS_LIST = {
+  data: [MOCK_TRANSACTION],
+  total: 1,
+  limit: 20,
+  offset: 0,
+};
+
+// ── Client stubs ─────────────────────────────────────────────────────────────
+
+function makeSuccessClient(): import("../client-interface.js").IFrihetClient {
+  return {
+    listBankAccounts: async () => MOCK_ACCOUNTS_LIST,
+    getBankAccount: async (_id: string) => MOCK_ACCOUNT,
+    listTransactions: async () => MOCK_TRANSACTIONS_LIST,
+    categorizeTransaction: async (_id: string, data: Record<string, unknown>) => ({ ...MOCK_TRANSACTION, category: data["category"] }),
+    matchTransactionToDocument: async (_txId: string, data: Record<string, unknown>) => ({
+      ...MOCK_TRANSACTION,
+      matchedDocId: data["documentId"],
+    }),
+  } as unknown as import("../client-interface.js").IFrihetClient;
+}
+
+function make404Client(): import("../client-interface.js").IFrihetClient {
+  const notFound = () => {
+    const err = Object.assign(new Error("Not Found"), { statusCode: 404, errorCode: "not_found" });
+    return Promise.reject(err);
+  };
+  return {
+    listBankAccounts: notFound,
+    getBankAccount: notFound,
+    listTransactions: notFound,
+    categorizeTransaction: notFound,
+    matchTransactionToDocument: notFound,
+  } as unknown as import("../client-interface.js").IFrihetClient;
+}
+
+// ── Helper ───────────────────────────────────────────────────────────────────
+
+async function makeServer(
+  clientFn: () => import("../client-interface.js").IFrihetClient,
+): Promise<StubMcpServer> {
+  const server = new StubMcpServer();
+  const { registerBankingTools } = await import("../tools/banking.js");
+  registerBankingTools(
+    server as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer,
+    clientFn(),
+  );
+  return server;
+}
+
+// ── Registration tests ───────────────────────────────────────────────────────
+
+describe("Banking Tools — Registration", () => {
+  let server: StubMcpServer;
+
+  beforeEach(async () => {
+    server = await makeServer(makeSuccessClient);
+  });
+
+  test("registers exactly 5 banking tools", () => {
+    assert.equal(server.tools.size, 5);
+  });
+
+  test("registers list_bank_accounts", () => {
+    assert.ok(server.tools.has("list_bank_accounts"));
+  });
+
+  test("registers get_bank_account", () => {
+    assert.ok(server.tools.has("get_bank_account"));
+  });
+
+  test("registers list_transactions", () => {
+    assert.ok(server.tools.has("list_transactions"));
+  });
+
+  test("registers categorize_transaction", () => {
+    assert.ok(server.tools.has("categorize_transaction"));
+  });
+
+  test("registers match_transaction_to_invoice", () => {
+    assert.ok(server.tools.has("match_transaction_to_invoice"));
+  });
+});
+
+// ── list_bank_accounts ───────────────────────────────────────────────────────
+
+describe("list_bank_accounts — success path", () => {
+  test("returns structuredContent with data array", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_bank_accounts")!;
+    const result = await tool.handler({});
+
+    assert.ok(!result.isError);
+    assert.ok(result.structuredContent);
+    const sc = result.structuredContent!;
+    assert.ok(Array.isArray(sc["data"]));
+    assert.equal((sc["data"] as unknown[]).length, 1);
+    assert.equal(sc["total"], 1);
+  });
+
+  test("first account has IBAN last 4 and balance", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_bank_accounts")!;
+    const result = await tool.handler({});
+
+    const first = (result.structuredContent!["data"] as Record<string, unknown>[])[0]!;
+    assert.equal(first["id"], "acct_001");
+    assert.equal(first["ibanLast4"], "4321");
+    assert.equal(first["currency"], "EUR");
+    assert.equal(first["balance"], 12345.67);
+  });
+
+  test("content block has type text and mentions bank_accounts", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_bank_accounts")!;
+    const result = await tool.handler({});
+    assert.equal(result.content[0]!.type, "text");
+    assert.ok(result.content[0]!.text.includes("bank_accounts"));
+  });
+});
+
+// ── get_bank_account ─────────────────────────────────────────────────────────
+
+describe("get_bank_account — success path", () => {
+  test("returns single account by ID", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("get_bank_account")!;
+    const result = await tool.handler({ id: "acct_001" });
+
+    assert.ok(!result.isError);
+    const sc = result.structuredContent!;
+    assert.equal(sc["id"], "acct_001");
+    assert.equal(sc["alias"], "Cuenta corriente BRTHLS");
+  });
+
+  test("404 propagates as isError=true", async () => {
+    const server = await makeServer(make404Client);
+    const tool = server.tools.get("get_bank_account")!;
+    const result = await tool.handler({ id: "acct_missing" });
+    assert.ok(result.isError);
+    assert.ok(result.content[0]!.text.includes("Error:"));
+  });
+});
+
+// ── list_transactions ────────────────────────────────────────────────────────
+
+describe("list_transactions — success path", () => {
+  test("returns transactions list", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_transactions")!;
+    const result = await tool.handler({ accountId: "acct_001", from: "2026-05-01", to: "2026-05-31" });
+
+    assert.ok(!result.isError);
+    const sc = result.structuredContent!;
+    assert.ok(Array.isArray(sc["data"]));
+    assert.equal(sc["total"], 1);
+  });
+
+  test("first transaction has expected fields", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_transactions")!;
+    const result = await tool.handler({});
+
+    const first = (result.structuredContent!["data"] as Record<string, unknown>[])[0]!;
+    assert.equal(first["id"], "tx_abc123");
+    assert.equal(first["amount"], -250.0);
+    assert.equal(first["status"], "posted");
+    assert.equal(first["category"], "supplies");
+  });
+
+  test("accepts status filter without error", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_transactions")!;
+    const result = await tool.handler({ status: "posted" });
+    assert.ok(!result.isError);
+  });
+});
+
+// ── categorize_transaction ───────────────────────────────────────────────────
+
+describe("categorize_transaction — success path", () => {
+  test("returns updated transaction with new category", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("categorize_transaction")!;
+    const result = await tool.handler({ id: "tx_abc123", category: "travel" });
+
+    assert.ok(!result.isError);
+    const sc = result.structuredContent!;
+    assert.equal(sc["id"], "tx_abc123");
+    assert.equal(sc["category"], "travel");
+  });
+
+  test("content block mentions categorized", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("categorize_transaction")!;
+    const result = await tool.handler({ id: "tx_abc123", category: "software", notes: "SaaS Q2" });
+    assert.ok(result.content[0]!.text.includes("categorized"));
+  });
+});
+
+// ── match_transaction_to_invoice ─────────────────────────────────────────────
+
+describe("match_transaction_to_invoice — trust area gate", () => {
+  test("confirm=false returns isError=true without calling API", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("match_transaction_to_invoice")!;
+    const result = await tool.handler({
+      transactionId: "tx_abc123",
+      documentId: "inv_xyz",
+      documentType: "invoice",
+      confirm: false,
+    });
+
+    assert.ok(result.isError, "should be isError when confirm=false");
+    assert.ok(result.content[0]!.text.includes("confirm=true"));
+  });
+
+  test("confirm=true success path returns matched transaction", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("match_transaction_to_invoice")!;
+    const result = await tool.handler({
+      transactionId: "tx_abc123",
+      documentId: "inv_xyz456",
+      documentType: "invoice",
+      confirm: true,
+    });
+
+    assert.ok(!result.isError);
+    const sc = result.structuredContent!;
+    assert.equal(sc["id"], "tx_abc123");
+    assert.equal(sc["matchedDocId"], "inv_xyz456");
+  });
+
+  test("confirm=true with expense type works", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("match_transaction_to_invoice")!;
+    const result = await tool.handler({
+      transactionId: "tx_abc123",
+      documentId: "exp_abc",
+      documentType: "expense",
+      confirm: true,
+    });
+    assert.ok(!result.isError);
+  });
+});

--- a/src/__tests__/fiscal-tools.test.ts
+++ b/src/__tests__/fiscal-tools.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Tests for Fiscal MCP tools — Wave 6 (8 tools).
+ *
+ * Uses Node.js built-in test runner (node:test + node:assert).
+ * Run: npm test (after build)
+ *
+ * Coverage:
+ *   1. Tool registration — all 8 fiscal tools registered
+ *   2. get_modelo_303_summary — success path + period param
+ *   3. get_modelo_130_summary — success path
+ *   4. get_modelo_390_summary — success path
+ *   5. get_modelo_180_summary — success path
+ *   6. get_modelo_347_summary — success path
+ *   7. verifactu_status — success path
+ *   8. verifactu_resubmit — confirm=false gate + confirm=true success
+ *   9. ticketbai_status — success path + province field
+ *  10. API error — 404 propagated as isError=true
+ */
+
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+// ── Minimal McpServer stub ───────────────────────────────────────────────────
+
+interface ToolConfig {
+  title: string;
+  description: string;
+  annotations?: Record<string, unknown>;
+  inputSchema: Record<string, unknown>;
+  outputSchema?: unknown;
+}
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+}>;
+
+interface RegisteredTool {
+  name: string;
+  config: ToolConfig;
+  handler: ToolHandler;
+}
+
+class StubMcpServer {
+  tools: Map<string, RegisteredTool> = new Map();
+
+  registerTool(name: string, config: ToolConfig, handler: ToolHandler): void {
+    this.tools.set(name, { name, config, handler });
+  }
+}
+
+// ── Mock data ────────────────────────────────────────────────────────────────
+
+const MOCK_MODELO_SUMMARY = {
+  modeloCode: "303",
+  period: "2026-Q1",
+  totalsByRate: { "21": 4200.0, "10": 350.0, "4": 80.0 },
+  totalDeductible: 1200.0,
+  totalDue: 3430.0,
+  deadline: "2026-04-20",
+};
+
+const MOCK_VERIFACTU_STATUS = {
+  invoiceId: "inv_abc123",
+  lastSubmissionAt: "2026-05-09T10:00:00Z",
+  hash: "sha256:abcdef1234567890",
+  status: "success",
+  aeatResponse: "0000",
+  qrUrl: "https://www2.agenciatributaria.gob.es/wlpl/TIKE-CONT/ValidarQR?nif=B12345678&numserie=2026-001&fecha=2026-05-09&importe=1210.00",
+};
+
+const MOCK_TICKETBAI_STATUS = {
+  invoiceId: "inv_def456",
+  lastSubmissionAt: "2026-05-09T11:00:00Z",
+  hash: "sha256:xyz9876543210",
+  status: "success",
+  aeatResponse: "0000",
+  qrUrl: "https://tbai.ehu.eus/qr/...",
+  province: "bizkaia",
+};
+
+// ── Client stubs ─────────────────────────────────────────────────────────────
+
+function makeSuccessClient(): import("../client-interface.js").IFrihetClient {
+  return {
+    getFiscalModeloSummary: async (modeloCode: string, period?: string) => ({
+      ...MOCK_MODELO_SUMMARY,
+      modeloCode,
+      period: period ?? "2026-Q1",
+    }),
+    getVerifactuStatus: async (_invoiceId: string) => MOCK_VERIFACTU_STATUS,
+    resubmitVerifactu: async (_invoiceId: string) => ({ ...MOCK_VERIFACTU_STATUS, status: "pending" }),
+    getTicketbaiStatus: async (_invoiceId: string) => MOCK_TICKETBAI_STATUS,
+  } as unknown as import("../client-interface.js").IFrihetClient;
+}
+
+function make404Client(): import("../client-interface.js").IFrihetClient {
+  const notFound = () => {
+    const err = Object.assign(new Error("Not Found"), { statusCode: 404, errorCode: "not_found" });
+    return Promise.reject(err);
+  };
+  return {
+    getFiscalModeloSummary: notFound,
+    getVerifactuStatus: notFound,
+    resubmitVerifactu: notFound,
+    getTicketbaiStatus: notFound,
+  } as unknown as import("../client-interface.js").IFrihetClient;
+}
+
+// ── Helper ───────────────────────────────────────────────────────────────────
+
+async function makeServer(
+  clientFn: () => import("../client-interface.js").IFrihetClient,
+): Promise<StubMcpServer> {
+  const server = new StubMcpServer();
+  const { registerFiscalTools } = await import("../tools/fiscal.js");
+  registerFiscalTools(
+    server as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer,
+    clientFn(),
+  );
+  return server;
+}
+
+// ── Registration tests ───────────────────────────────────────────────────────
+
+describe("Fiscal Tools — Registration", () => {
+  let server: StubMcpServer;
+
+  beforeEach(async () => {
+    server = await makeServer(makeSuccessClient);
+  });
+
+  test("registers exactly 8 fiscal tools", () => {
+    assert.equal(server.tools.size, 8);
+  });
+
+  for (const name of [
+    "get_modelo_303_summary",
+    "get_modelo_130_summary",
+    "get_modelo_390_summary",
+    "get_modelo_180_summary",
+    "get_modelo_347_summary",
+    "verifactu_status",
+    "verifactu_resubmit",
+    "ticketbai_status",
+  ]) {
+    test(`registers ${name}`, () => {
+      assert.ok(server.tools.has(name), `${name} not registered`);
+    });
+  }
+});
+
+// ── Modelo summaries ─────────────────────────────────────────────────────────
+
+describe("get_modelo_303_summary — success path", () => {
+  test("returns summary with totalsDue and period", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("get_modelo_303_summary")!;
+    const result = await tool.handler({ period: "2026-Q1" });
+
+    assert.ok(!result.isError);
+    const sc = result.structuredContent!;
+    assert.equal(sc["modeloCode"], "303");
+    assert.equal(sc["period"], "2026-Q1");
+    assert.equal(sc["totalDue"], 3430.0);
+    assert.ok(typeof sc["totalsByRate"] === "object");
+  });
+
+  test("content block mentions Modelo 303", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("get_modelo_303_summary")!;
+    const result = await tool.handler({});
+    assert.ok(result.content[0]!.text.includes("303"));
+  });
+
+  test("404 propagates as isError=true", async () => {
+    const server = await makeServer(make404Client);
+    const tool = server.tools.get("get_modelo_303_summary")!;
+    const result = await tool.handler({ period: "2026-Q1" });
+    assert.ok(result.isError);
+  });
+});
+
+describe("get_modelo_130_summary — success path", () => {
+  test("returns modeloCode 130", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("get_modelo_130_summary")!;
+    const result = await tool.handler({ period: "2026-Q1" });
+    assert.ok(!result.isError);
+    assert.equal(result.structuredContent!["modeloCode"], "130");
+  });
+});
+
+describe("get_modelo_390_summary — success path", () => {
+  test("returns modeloCode 390", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("get_modelo_390_summary")!;
+    const result = await tool.handler({ period: "2025" });
+    assert.ok(!result.isError);
+    assert.equal(result.structuredContent!["modeloCode"], "390");
+  });
+});
+
+describe("get_modelo_180_summary — success path", () => {
+  test("returns modeloCode 180", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("get_modelo_180_summary")!;
+    const result = await tool.handler({ period: "2025" });
+    assert.ok(!result.isError);
+    assert.equal(result.structuredContent!["modeloCode"], "180");
+  });
+});
+
+describe("get_modelo_347_summary — success path", () => {
+  test("returns modeloCode 347", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("get_modelo_347_summary")!;
+    const result = await tool.handler({ period: "2025" });
+    assert.ok(!result.isError);
+    assert.equal(result.structuredContent!["modeloCode"], "347");
+  });
+});
+
+// ── verifactu_status ─────────────────────────────────────────────────────────
+
+describe("verifactu_status — success path", () => {
+  test("returns status with hash and qrUrl", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("verifactu_status")!;
+    const result = await tool.handler({ invoiceId: "inv_abc123" });
+
+    assert.ok(!result.isError);
+    const sc = result.structuredContent!;
+    assert.equal(sc["invoiceId"], "inv_abc123");
+    assert.equal(sc["status"], "success");
+    assert.ok(typeof sc["hash"] === "string");
+    assert.ok(typeof sc["qrUrl"] === "string");
+  });
+
+  test("aeatResponse is present", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("verifactu_status")!;
+    const result = await tool.handler({ invoiceId: "inv_abc123" });
+    assert.equal(result.structuredContent!["aeatResponse"], "0000");
+  });
+});
+
+// ── verifactu_resubmit ───────────────────────────────────────────────────────
+
+describe("verifactu_resubmit — trust area gate", () => {
+  test("confirm=false returns isError=true", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("verifactu_resubmit")!;
+    const result = await tool.handler({ invoiceId: "inv_abc123", confirm: false });
+    assert.ok(result.isError);
+    assert.ok(result.content[0]!.text.includes("confirm=true"));
+  });
+
+  test("confirm=true proceeds and returns pending status", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("verifactu_resubmit")!;
+    const result = await tool.handler({ invoiceId: "inv_abc123", confirm: true });
+    assert.ok(!result.isError);
+    assert.equal(result.structuredContent!["status"], "pending");
+  });
+
+  test("confirm=true with 404 propagates isError=true", async () => {
+    const server = await makeServer(make404Client);
+    const tool = server.tools.get("verifactu_resubmit")!;
+    const result = await tool.handler({ invoiceId: "inv_missing", confirm: true });
+    assert.ok(result.isError);
+  });
+});
+
+// ── ticketbai_status ─────────────────────────────────────────────────────────
+
+describe("ticketbai_status — success path", () => {
+  test("returns status with province field", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("ticketbai_status")!;
+    const result = await tool.handler({ invoiceId: "inv_def456" });
+
+    assert.ok(!result.isError);
+    const sc = result.structuredContent!;
+    assert.equal(sc["invoiceId"], "inv_def456");
+    assert.equal(sc["province"], "bizkaia");
+    assert.equal(sc["status"], "success");
+  });
+
+  test("404 propagates as isError=true", async () => {
+    const server = await makeServer(make404Client);
+    const tool = server.tools.get("ticketbai_status")!;
+    const result = await tool.handler({ invoiceId: "inv_missing" });
+    assert.ok(result.isError);
+  });
+});

--- a/src/__tests__/recurring-tools.test.ts
+++ b/src/__tests__/recurring-tools.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for Recurring Invoice MCP tools — Wave 6 (2 tools).
+ *
+ * Uses Node.js built-in test runner (node:test + node:assert).
+ * Run: npm test (after build)
+ *
+ * Coverage:
+ *   1. Tool registration — both recurring tools registered
+ *   2. list_recurring_invoices — success path + structuredContent shape
+ *   3. list_recurring_invoices — status filter accepted
+ *   4. run_recurring_now — success path (default draftOnly=true)
+ *   5. run_recurring_now — draftOnly=false passes through
+ *   6. API error — 404 propagated as isError=true
+ */
+
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+// ── Minimal McpServer stub ───────────────────────────────────────────────────
+
+interface ToolConfig {
+  title: string;
+  description: string;
+  annotations?: Record<string, unknown>;
+  inputSchema: Record<string, unknown>;
+  outputSchema?: unknown;
+}
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+}>;
+
+interface RegisteredTool {
+  name: string;
+  config: ToolConfig;
+  handler: ToolHandler;
+}
+
+class StubMcpServer {
+  tools: Map<string, RegisteredTool> = new Map();
+
+  registerTool(name: string, config: ToolConfig, handler: ToolHandler): void {
+    this.tools.set(name, { name, config, handler });
+  }
+}
+
+// ── Mock data ────────────────────────────────────────────────────────────────
+
+const MOCK_RECURRING_INVOICE = {
+  id: "rec_abc123",
+  templateName: "Factura mensual Acme",
+  frequency: "monthly",
+  nextRun: "2026-06-01",
+  recipient: "billing@acme.com",
+  lineItems: [
+    { description: "Servicio SaaS", quantity: 1, unitPrice: 299.0 },
+  ],
+  status: "active",
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+const MOCK_RECURRING_LIST = {
+  data: [MOCK_RECURRING_INVOICE],
+  total: 1,
+  limit: 20,
+  offset: 0,
+};
+
+const MOCK_RUN_RESULT = {
+  success: true,
+  id: "inv_new_001",
+  message: "Invoice draft created from template rec_abc123",
+};
+
+// ── Client stubs ─────────────────────────────────────────────────────────────
+
+function makeSuccessClient(): import("../client-interface.js").IFrihetClient {
+  return {
+    listRecurringInvoices: async () => MOCK_RECURRING_LIST,
+    runRecurringNow: async (_templateId: string, _options?: Record<string, unknown>) => MOCK_RUN_RESULT,
+  } as unknown as import("../client-interface.js").IFrihetClient;
+}
+
+function make404Client(): import("../client-interface.js").IFrihetClient {
+  const notFound = () => {
+    const err = Object.assign(new Error("Not Found"), { statusCode: 404, errorCode: "not_found" });
+    return Promise.reject(err);
+  };
+  return {
+    listRecurringInvoices: notFound,
+    runRecurringNow: notFound,
+  } as unknown as import("../client-interface.js").IFrihetClient;
+}
+
+// ── Helper ───────────────────────────────────────────────────────────────────
+
+async function makeServer(
+  clientFn: () => import("../client-interface.js").IFrihetClient,
+): Promise<StubMcpServer> {
+  const server = new StubMcpServer();
+  const { registerRecurringTools } = await import("../tools/recurring.js");
+  registerRecurringTools(
+    server as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer,
+    clientFn(),
+  );
+  return server;
+}
+
+// ── Registration tests ───────────────────────────────────────────────────────
+
+describe("Recurring Tools — Registration", () => {
+  let server: StubMcpServer;
+
+  beforeEach(async () => {
+    server = await makeServer(makeSuccessClient);
+  });
+
+  test("registers exactly 2 recurring tools", () => {
+    assert.equal(server.tools.size, 2);
+  });
+
+  test("registers list_recurring_invoices", () => {
+    assert.ok(server.tools.has("list_recurring_invoices"));
+  });
+
+  test("registers run_recurring_now", () => {
+    assert.ok(server.tools.has("run_recurring_now"));
+  });
+});
+
+// ── list_recurring_invoices ──────────────────────────────────────────────────
+
+describe("list_recurring_invoices — success path", () => {
+  test("returns structuredContent with data array", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_recurring_invoices")!;
+    const result = await tool.handler({});
+
+    assert.ok(!result.isError);
+    const sc = result.structuredContent!;
+    assert.ok(Array.isArray(sc["data"]));
+    assert.equal(sc["total"], 1);
+  });
+
+  test("first template has expected fields", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_recurring_invoices")!;
+    const result = await tool.handler({});
+
+    const first = (result.structuredContent!["data"] as Record<string, unknown>[])[0]!;
+    assert.equal(first["id"], "rec_abc123");
+    assert.equal(first["templateName"], "Factura mensual Acme");
+    assert.equal(first["frequency"], "monthly");
+    assert.equal(first["status"], "active");
+    assert.equal(first["nextRun"], "2026-06-01");
+  });
+
+  test("content block has type text and mentions recurring_invoices", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_recurring_invoices")!;
+    const result = await tool.handler({});
+    assert.equal(result.content[0]!.type, "text");
+    assert.ok(result.content[0]!.text.includes("recurring_invoices"));
+  });
+
+  test("status=active filter accepted without error", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_recurring_invoices")!;
+    const result = await tool.handler({ status: "active" });
+    assert.ok(!result.isError);
+  });
+
+  test("status=paused filter accepted without error", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_recurring_invoices")!;
+    const result = await tool.handler({ status: "paused" });
+    assert.ok(!result.isError);
+  });
+
+  test("404 propagates as isError=true", async () => {
+    const server = await makeServer(make404Client);
+    const tool = server.tools.get("list_recurring_invoices")!;
+    const result = await tool.handler({});
+    assert.ok(result.isError);
+  });
+});
+
+// ── run_recurring_now ────────────────────────────────────────────────────────
+
+describe("run_recurring_now — success path", () => {
+  test("returns action result with success=true and new invoice ID", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("run_recurring_now")!;
+    const result = await tool.handler({ templateId: "rec_abc123" });
+
+    assert.ok(!result.isError);
+    const sc = result.structuredContent!;
+    assert.equal(sc["success"], true);
+    assert.equal(sc["id"], "inv_new_001");
+    assert.ok(typeof sc["message"] === "string");
+  });
+
+  test("draftOnly=false accepted without error", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("run_recurring_now")!;
+    const result = await tool.handler({ templateId: "rec_abc123", draftOnly: false });
+    assert.ok(!result.isError);
+  });
+
+  test("content block mentions triggered", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("run_recurring_now")!;
+    const result = await tool.handler({ templateId: "rec_abc123" });
+    assert.ok(result.content[0]!.text.includes("triggered"));
+  });
+
+  test("404 propagates as isError=true", async () => {
+    const server = await makeServer(make404Client);
+    const tool = server.tools.get("run_recurring_now")!;
+    const result = await tool.handler({ templateId: "rec_missing" });
+    assert.ok(result.isError);
+  });
+});

--- a/src/__tests__/time-tools.test.ts
+++ b/src/__tests__/time-tools.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Tests for Time Tracking MCP tools — Wave 6 (4 tools).
+ *
+ * Uses Node.js built-in test runner (node:test + node:assert).
+ * Run: npm test (after build)
+ *
+ * Coverage:
+ *   1. Tool registration — all 4 time tools registered
+ *   2. list_time_entries — success path + structuredContent shape
+ *   3. create_time_entry — success path
+ *   4. update_time_entry — success path + partial update
+ *   5. delete_time_entry — confirm=false gate
+ *   6. delete_time_entry — confirm=true success path
+ *   7. API error — 404 propagated as isError=true
+ */
+
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+// ── Minimal McpServer stub ───────────────────────────────────────────────────
+
+interface ToolConfig {
+  title: string;
+  description: string;
+  annotations?: Record<string, unknown>;
+  inputSchema: Record<string, unknown>;
+  outputSchema?: unknown;
+}
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+}>;
+
+interface RegisteredTool {
+  name: string;
+  config: ToolConfig;
+  handler: ToolHandler;
+}
+
+class StubMcpServer {
+  tools: Map<string, RegisteredTool> = new Map();
+
+  registerTool(name: string, config: ToolConfig, handler: ToolHandler): void {
+    this.tools.set(name, { name, config, handler });
+  }
+}
+
+// ── Mock data ────────────────────────────────────────────────────────────────
+
+const MOCK_ENTRY = {
+  id: "te_abc123",
+  userId: "usr_viktor",
+  projectId: "proj_xyz",
+  hours: 2.5,
+  description: "Frontend code review",
+  billable: true,
+  date: "2026-05-10",
+  status: "logged",
+  createdAt: "2026-05-10T09:00:00Z",
+};
+
+const MOCK_ENTRIES_LIST = {
+  data: [MOCK_ENTRY],
+  total: 1,
+  limit: 20,
+  offset: 0,
+};
+
+// ── Client stubs ─────────────────────────────────────────────────────────────
+
+function makeSuccessClient(): import("../client-interface.js").IFrihetClient {
+  return {
+    listTimeEntries: async () => MOCK_ENTRIES_LIST,
+    createTimeEntry: async (_data: Record<string, unknown>) => MOCK_ENTRY,
+    updateTimeEntry: async (_id: string, data: Record<string, unknown>) => ({ ...MOCK_ENTRY, ...data }),
+    deleteTimeEntry: async (_id: string) => undefined,
+  } as unknown as import("../client-interface.js").IFrihetClient;
+}
+
+function make404Client(): import("../client-interface.js").IFrihetClient {
+  const notFound = () => {
+    const err = Object.assign(new Error("Not Found"), { statusCode: 404, errorCode: "not_found" });
+    return Promise.reject(err);
+  };
+  return {
+    listTimeEntries: notFound,
+    createTimeEntry: notFound,
+    updateTimeEntry: notFound,
+    deleteTimeEntry: notFound,
+  } as unknown as import("../client-interface.js").IFrihetClient;
+}
+
+// ── Helper ───────────────────────────────────────────────────────────────────
+
+async function makeServer(
+  clientFn: () => import("../client-interface.js").IFrihetClient,
+): Promise<StubMcpServer> {
+  const server = new StubMcpServer();
+  const { registerTimeTools } = await import("../tools/time.js");
+  registerTimeTools(
+    server as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer,
+    clientFn(),
+  );
+  return server;
+}
+
+// ── Registration tests ───────────────────────────────────────────────────────
+
+describe("Time Tools — Registration", () => {
+  let server: StubMcpServer;
+
+  beforeEach(async () => {
+    server = await makeServer(makeSuccessClient);
+  });
+
+  test("registers exactly 4 time tools", () => {
+    assert.equal(server.tools.size, 4);
+  });
+
+  test("registers list_time_entries", () => {
+    assert.ok(server.tools.has("list_time_entries"));
+  });
+
+  test("registers create_time_entry", () => {
+    assert.ok(server.tools.has("create_time_entry"));
+  });
+
+  test("registers update_time_entry", () => {
+    assert.ok(server.tools.has("update_time_entry"));
+  });
+
+  test("registers delete_time_entry", () => {
+    assert.ok(server.tools.has("delete_time_entry"));
+  });
+});
+
+// ── list_time_entries ────────────────────────────────────────────────────────
+
+describe("list_time_entries — success path", () => {
+  test("returns structuredContent with data array", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_time_entries")!;
+    const result = await tool.handler({ projectId: "proj_xyz", from: "2026-05-01", to: "2026-05-31" });
+
+    assert.ok(!result.isError);
+    const sc = result.structuredContent!;
+    assert.ok(Array.isArray(sc["data"]));
+    assert.equal(sc["total"], 1);
+  });
+
+  test("first entry has expected fields", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_time_entries")!;
+    const result = await tool.handler({});
+
+    const first = (result.structuredContent!["data"] as Record<string, unknown>[])[0]!;
+    assert.equal(first["id"], "te_abc123");
+    assert.equal(first["hours"], 2.5);
+    assert.equal(first["billable"], true);
+    assert.equal(first["date"], "2026-05-10");
+  });
+
+  test("content block has type text and mentions time_entries", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_time_entries")!;
+    const result = await tool.handler({});
+    assert.equal(result.content[0]!.type, "text");
+    assert.ok(result.content[0]!.text.includes("time_entries"));
+  });
+
+  test("billable filter accepted without error", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_time_entries")!;
+    const result = await tool.handler({ billable: true });
+    assert.ok(!result.isError);
+  });
+});
+
+// ── create_time_entry ────────────────────────────────────────────────────────
+
+describe("create_time_entry — success path", () => {
+  test("returns created entry with expected fields", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("create_time_entry")!;
+    const result = await tool.handler({
+      projectId: "proj_xyz",
+      hours: 2.5,
+      date: "2026-05-10",
+      description: "Frontend code review",
+      billable: true,
+    });
+
+    assert.ok(!result.isError);
+    const sc = result.structuredContent!;
+    assert.equal(sc["id"], "te_abc123");
+    assert.equal(sc["hours"], 2.5);
+    assert.equal(sc["billable"], true);
+  });
+
+  test("content block mentions time entry created", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("create_time_entry")!;
+    const result = await tool.handler({ projectId: "proj_xyz", hours: 1.0, date: "2026-05-10" });
+    assert.ok(result.content[0]!.text.includes("created"));
+  });
+
+  test("404 propagates as isError=true", async () => {
+    const server = await makeServer(make404Client);
+    const tool = server.tools.get("create_time_entry")!;
+    const result = await tool.handler({ projectId: "proj_xyz", hours: 1.0, date: "2026-05-10" });
+    assert.ok(result.isError);
+  });
+});
+
+// ── update_time_entry ────────────────────────────────────────────────────────
+
+describe("update_time_entry — success path", () => {
+  test("returns updated entry with new hours", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("update_time_entry")!;
+    const result = await tool.handler({ id: "te_abc123", hours: 3.0 });
+
+    assert.ok(!result.isError);
+    const sc = result.structuredContent!;
+    assert.equal(sc["hours"], 3.0);
+  });
+
+  test("content block mentions updated", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("update_time_entry")!;
+    const result = await tool.handler({ id: "te_abc123", description: "Updated description" });
+    assert.ok(result.content[0]!.text.includes("updated"));
+  });
+});
+
+// ── delete_time_entry ────────────────────────────────────────────────────────
+
+describe("delete_time_entry — trust area gate", () => {
+  test("confirm=false returns isError=true without calling API", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("delete_time_entry")!;
+    const result = await tool.handler({ id: "te_abc123", confirm: false });
+
+    assert.ok(result.isError);
+    assert.ok(result.content[0]!.text.includes("confirm=true"));
+  });
+
+  test("confirm=true succeeds and returns success=true", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("delete_time_entry")!;
+    const result = await tool.handler({ id: "te_abc123", confirm: true });
+
+    assert.ok(!result.isError);
+    assert.equal(result.structuredContent!["success"], true);
+    assert.equal(result.structuredContent!["id"], "te_abc123");
+  });
+
+  test("confirm=true with 404 propagates isError=true", async () => {
+    const server = await makeServer(make404Client);
+    const tool = server.tools.get("delete_time_entry")!;
+    const result = await tool.handler({ id: "te_missing", confirm: true });
+    assert.ok(result.isError);
+  });
+});

--- a/src/client-interface.ts
+++ b/src/client-interface.ts
@@ -116,4 +116,27 @@ export interface IFrihetClient {
   getSale(id: string): Promise<Record<string, unknown>>;
   listSales(params?: { terminalId?: string; status?: string; from?: string; to?: string; limit?: number; offset?: number; after?: string }): Promise<PaginatedResponse<Record<string, unknown>>>;
   refundSale(id: string, data?: { amountCents?: number; reason?: string }): Promise<Record<string, unknown>>;
+
+  // Banking endpoints (/v1/banking/*)
+  listBankAccounts(params?: { limit?: number; offset?: number }): Promise<PaginatedResponse<Record<string, unknown>>>;
+  getBankAccount(id: string): Promise<Record<string, unknown>>;
+  listTransactions(params?: { accountId?: string; from?: string; to?: string; status?: string; category?: string; limit?: number; offset?: number; after?: string }): Promise<PaginatedResponse<Record<string, unknown>>>;
+  categorizeTransaction(id: string, data: { category: string; notes?: string }): Promise<Record<string, unknown>>;
+  matchTransactionToDocument(transactionId: string, data: { documentId: string; documentType: "invoice" | "expense"; notes?: string }): Promise<Record<string, unknown>>;
+
+  // Fiscal endpoints (/v1/fiscal/*)
+  getFiscalModeloSummary(modeloCode: string, period?: string): Promise<Record<string, unknown>>;
+  getVerifactuStatus(invoiceId: string): Promise<Record<string, unknown>>;
+  resubmitVerifactu(invoiceId: string): Promise<Record<string, unknown>>;
+  getTicketbaiStatus(invoiceId: string): Promise<Record<string, unknown>>;
+
+  // Time tracking endpoints (/v1/time/*)
+  listTimeEntries(params?: { userId?: string; projectId?: string; from?: string; to?: string; billable?: boolean; limit?: number; offset?: number; after?: string }): Promise<PaginatedResponse<Record<string, unknown>>>;
+  createTimeEntry(data: Record<string, unknown>): Promise<Record<string, unknown>>;
+  updateTimeEntry(id: string, data: Record<string, unknown>): Promise<Record<string, unknown>>;
+  deleteTimeEntry(id: string): Promise<void>;
+
+  // Recurring invoice endpoints (/v1/recurring/*)
+  listRecurringInvoices(params?: { status?: string; limit?: number; offset?: number }): Promise<PaginatedResponse<Record<string, unknown>>>;
+  runRecurringNow(templateId: string, options?: { draftOnly?: boolean }): Promise<Record<string, unknown>>;
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -736,4 +736,125 @@ export class FrihetClient {
       quarter,
     });
   }
+
+  // ---------------------------------------------------------------- Banking
+  // NOTE: /v1/banking/* endpoints are planned — 404 propagates until backend ships.
+
+  async listBankAccounts(
+    params?: { limit?: number; offset?: number },
+  ): Promise<PaginatedResponse<Record<string, unknown>>> {
+    return this.requestPaginated("GET", "/banking/accounts", undefined, {
+      limit: params?.limit,
+      offset: params?.offset,
+    });
+  }
+
+  async getBankAccount(id: string): Promise<Record<string, unknown>> {
+    return this.request("GET", `/banking/accounts/${encodeURIComponent(id)}`);
+  }
+
+  async listTransactions(
+    params?: { accountId?: string; from?: string; to?: string; status?: string; category?: string; limit?: number; offset?: number; after?: string },
+  ): Promise<PaginatedResponse<Record<string, unknown>>> {
+    return this.requestPaginated("GET", "/banking/transactions", undefined, {
+      accountId: params?.accountId,
+      from: params?.from,
+      to: params?.to,
+      status: params?.status,
+      category: params?.category,
+      limit: params?.limit,
+      offset: params?.offset,
+      after: params?.after,
+    });
+  }
+
+  async categorizeTransaction(
+    id: string,
+    data: { category: string; notes?: string },
+  ): Promise<Record<string, unknown>> {
+    return this.request("PATCH", `/banking/transactions/${encodeURIComponent(id)}/categorize`, data);
+  }
+
+  async matchTransactionToDocument(
+    transactionId: string,
+    data: { documentId: string; documentType: "invoice" | "expense"; notes?: string },
+  ): Promise<Record<string, unknown>> {
+    return this.request("POST", `/banking/transactions/${encodeURIComponent(transactionId)}/match`, data);
+  }
+
+  // ---------------------------------------------------------------- Fiscal
+  // NOTE: /v1/fiscal/* endpoints are planned — 404 propagates until backend ships.
+
+  async getFiscalModeloSummary(
+    modeloCode: string,
+    period?: string,
+  ): Promise<Record<string, unknown>> {
+    return this.request("GET", `/fiscal/modelo/${encodeURIComponent(modeloCode)}`, undefined, {
+      period,
+    });
+  }
+
+  async getVerifactuStatus(invoiceId: string): Promise<Record<string, unknown>> {
+    return this.request("GET", `/fiscal/verifactu/${encodeURIComponent(invoiceId)}/status`);
+  }
+
+  async resubmitVerifactu(invoiceId: string): Promise<Record<string, unknown>> {
+    return this.request("POST", `/fiscal/verifactu/${encodeURIComponent(invoiceId)}/resubmit`, {});
+  }
+
+  async getTicketbaiStatus(invoiceId: string): Promise<Record<string, unknown>> {
+    return this.request("GET", `/fiscal/ticketbai/${encodeURIComponent(invoiceId)}/status`);
+  }
+
+  // ---------------------------------------------------------------- Time Tracking
+  // NOTE: /v1/time/* endpoints are planned — 404 propagates until backend ships.
+
+  async listTimeEntries(
+    params?: { userId?: string; projectId?: string; from?: string; to?: string; billable?: boolean; limit?: number; offset?: number; after?: string },
+  ): Promise<PaginatedResponse<Record<string, unknown>>> {
+    return this.requestPaginated("GET", "/time/entries", undefined, {
+      userId: params?.userId,
+      projectId: params?.projectId,
+      from: params?.from,
+      to: params?.to,
+      billable: params?.billable !== undefined ? (params.billable ? 1 : 0) : undefined,
+      limit: params?.limit,
+      offset: params?.offset,
+      after: params?.after,
+    });
+  }
+
+  async createTimeEntry(data: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return this.request("POST", "/time/entries", data);
+  }
+
+  async updateTimeEntry(id: string, data: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return this.request("PATCH", `/time/entries/${encodeURIComponent(id)}`, data);
+  }
+
+  async deleteTimeEntry(id: string): Promise<void> {
+    return this.request("DELETE", `/time/entries/${encodeURIComponent(id)}`);
+  }
+
+  // ---------------------------------------------------------------- Recurring Invoices
+  // NOTE: /v1/recurring/* endpoints are planned — 404 propagates until backend ships.
+
+  async listRecurringInvoices(
+    params?: { status?: string; limit?: number; offset?: number },
+  ): Promise<PaginatedResponse<Record<string, unknown>>> {
+    return this.requestPaginated("GET", "/recurring/invoices", undefined, {
+      status: params?.status,
+      limit: params?.limit,
+      offset: params?.offset,
+    });
+  }
+
+  async runRecurringNow(
+    templateId: string,
+    options?: { draftOnly?: boolean },
+  ): Promise<Record<string, unknown>> {
+    return this.request("POST", `/recurring/invoices/${encodeURIComponent(templateId)}/run`, {
+      draftOnly: options?.draftOnly ?? true,
+    });
+  }
 }

--- a/src/tools/banking.ts
+++ b/src/tools/banking.ts
@@ -1,0 +1,206 @@
+/**
+ * Banking tools for the Frihet MCP server — Wave 6 (5 tools).
+ *
+ * Tools:
+ *   1. list_bank_accounts  — list connected bank accounts per workspace
+ *   2. get_bank_account    — get single account with balance + last sync
+ *   3. list_transactions   — list bank transactions (filter: account, dateRange, status, category)
+ *   4. categorize_transaction — apply category to a transaction (manual classification)
+ *   5. match_transaction_to_invoice — link transaction to invoice/expense (reconciliation)
+ *
+ * REST surface: /v1/banking/accounts, /v1/banking/transactions
+ *
+ * NOTE: ERP backend endpoints /v1/banking/* are planned. Tools are wired
+ * and will surface 404 errors until the backend ships (documented: pending).
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod/v4";
+import type { IFrihetClient } from "../client-interface.js";
+import {
+  withToolLogging,
+  formatPaginatedResponse,
+  formatRecord,
+  listContent,
+  getContent,
+  mutateContent,
+  READ_ONLY_ANNOTATIONS,
+  UPDATE_ANNOTATIONS,
+  paginatedOutput,
+  bankAccountItemOutput,
+  bankTransactionItemOutput,
+} from "./shared.js";
+
+export function registerBankingTools(server: McpServer, client: IFrihetClient): void {
+  // -- list_bank_accounts --
+
+  server.registerTool(
+    "list_bank_accounts",
+    {
+      title: "List Bank Accounts",
+      description:
+        "List all connected bank accounts for the workspace. " +
+        "Returns alias, IBAN (last 4 digits only for security), currency, balance, and last sync timestamp. " +
+        "/ Lista todas las cuentas bancarias conectadas al espacio de trabajo. " +
+        "Devuelve alias, IBAN (solo ultimos 4 digitos por seguridad), divisa, saldo y ultima sincronizacion.",
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        limit: z.number().int().min(1).max(100).optional().describe("Max results (1-100) / Resultados maximos"),
+        offset: z.number().int().min(0).optional().describe("Offset / Desplazamiento"),
+      },
+      outputSchema: paginatedOutput(bankAccountItemOutput),
+    },
+    async ({ limit, offset }) => withToolLogging("list_bank_accounts", async () => {
+      const result = await client.listBankAccounts({ limit, offset });
+      return {
+        content: [listContent(formatPaginatedResponse("bank_accounts", result))],
+        structuredContent: result as unknown as Record<string, unknown>,
+      };
+    }),
+  );
+
+  // -- get_bank_account --
+
+  server.registerTool(
+    "get_bank_account",
+    {
+      title: "Get Bank Account",
+      description:
+        "Get a single connected bank account by ID. " +
+        "Returns alias, IBAN (last 4 digits), currency, current balance, and last sync timestamp. " +
+        "/ Obtiene una cuenta bancaria conectada por su ID. " +
+        "Devuelve alias, IBAN (ultimos 4 digitos), divisa, saldo actual y ultima sincronizacion.",
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        id: z.string().describe("Bank account ID / ID de la cuenta bancaria"),
+      },
+      outputSchema: bankAccountItemOutput,
+    },
+    async ({ id }) => withToolLogging("get_bank_account", async () => {
+      const result = await client.getBankAccount(id);
+      return {
+        content: [getContent(formatRecord("Bank Account", result))],
+        structuredContent: result as unknown as Record<string, unknown>,
+      };
+    }),
+  );
+
+  // -- list_transactions --
+
+  server.registerTool(
+    "list_transactions",
+    {
+      title: "List Bank Transactions",
+      description:
+        "List bank transactions with optional filters. " +
+        "Filter by account, date range, status (pending/posted/excluded), or category. " +
+        "Useful for reconciliation, expense matching, and cash flow analysis. " +
+        "/ Lista movimientos bancarios con filtros opcionales. " +
+        "Filtra por cuenta, rango de fechas, estado (pendiente/contabilizado/excluido) o categoria. " +
+        "Util para conciliacion, asignacion de gastos y analisis de flujo de caja.",
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        accountId: z.string().optional().describe("Filter by bank account ID / Filtrar por ID de cuenta"),
+        from: z.string().optional().describe("Start date ISO 8601 (YYYY-MM-DD) / Fecha inicio"),
+        to: z.string().optional().describe("End date ISO 8601 (YYYY-MM-DD) / Fecha fin"),
+        status: z
+          .enum(["pending", "posted", "excluded"])
+          .optional()
+          .describe("Filter by transaction status / Filtrar por estado"),
+        category: z.string().optional().describe("Filter by category slug / Filtrar por categoria"),
+        limit: z.number().int().min(1).max(100).optional().describe("Max results (1-100) / Resultados maximos"),
+        offset: z.number().int().min(0).optional().describe("Offset / Desplazamiento"),
+        after: z.string().optional().describe("Cursor for cursor-based pagination / Cursor para paginacion"),
+      },
+      outputSchema: paginatedOutput(bankTransactionItemOutput),
+    },
+    async ({ accountId, from, to, status, category, limit, offset, after }) =>
+      withToolLogging("list_transactions", async () => {
+        const result = await client.listTransactions({ accountId, from, to, status, category, limit, offset, after });
+        return {
+          content: [listContent(formatPaginatedResponse("transactions", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+  );
+
+  // -- categorize_transaction --
+
+  server.registerTool(
+    "categorize_transaction",
+    {
+      title: "Categorize Transaction",
+      description:
+        "Apply a category to a bank transaction for manual classification. " +
+        "Categories map to expense categories for tax deduction tracking. " +
+        "Example: id='tx_abc', category='supplies', notes='Office paper Q1' " +
+        "/ Asigna una categoria a un movimiento bancario. " +
+        "Las categorias se mapean a categorias de gastos para el control de deducciones fiscales.",
+      annotations: UPDATE_ANNOTATIONS,
+      inputSchema: {
+        id: z.string().describe("Transaction ID / ID del movimiento"),
+        category: z.string().describe("Category slug (e.g. 'supplies', 'travel', 'software') / Categoria"),
+        notes: z.string().optional().describe("Optional notes for this classification / Notas opcionales"),
+      },
+      outputSchema: bankTransactionItemOutput,
+    },
+    async ({ id, category, notes }) => withToolLogging("categorize_transaction", async () => {
+      const result = await client.categorizeTransaction(id, { category, notes });
+      return {
+        content: [mutateContent(formatRecord("Transaction categorized", result))],
+        structuredContent: result as unknown as Record<string, unknown>,
+      };
+    }),
+  );
+
+  // -- match_transaction_to_invoice --
+
+  server.registerTool(
+    "match_transaction_to_invoice",
+    {
+      title: "Match Transaction to Invoice",
+      description:
+        "TRUST AREA — RECONCILIATION. Link a bank transaction to an invoice or expense document. " +
+        "This affects fiscal reconciliation records. Requires confirm=true to proceed. " +
+        "Idempotent: re-matching to same document is a no-op. " +
+        "Example: transactionId='tx_abc', documentId='inv_xyz', documentType='invoice', confirm=true " +
+        "/ AREA DE CONFIANZA — CONCILIACION. Vincula un movimiento bancario a una factura o gasto. " +
+        "Afecta registros de conciliacion fiscal. Requiere confirm=true para ejecutar.",
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+      inputSchema: {
+        transactionId: z.string().describe("Bank transaction ID / ID del movimiento bancario"),
+        documentId: z.string().describe("Invoice or expense ID to link / ID de la factura o gasto a vincular"),
+        documentType: z
+          .enum(["invoice", "expense"])
+          .describe("Type of document being matched / Tipo de documento"),
+        confirm: z
+          .boolean()
+          .describe("Must be true to confirm fiscal reconciliation / Debe ser true para confirmar conciliacion fiscal"),
+        notes: z.string().optional().describe("Optional reconciliation notes / Notas de conciliacion opcionales"),
+      },
+      outputSchema: bankTransactionItemOutput,
+    },
+    async ({ transactionId, documentId, documentType, confirm, notes }) =>
+      withToolLogging("match_transaction_to_invoice", async () => {
+        if (!confirm) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: "Error: confirm=true is required to perform fiscal reconciliation. " +
+                  "This action links a bank transaction to a fiscal document and cannot be undone easily. " +
+                  "Set confirm=true when you are certain about the match. / " +
+                  "Se requiere confirm=true para realizar la conciliacion fiscal.",
+              },
+            ],
+            isError: true,
+          };
+        }
+        const result = await client.matchTransactionToDocument(transactionId, { documentId, documentType, notes });
+        return {
+          content: [mutateContent(formatRecord("Transaction matched", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+  );
+}

--- a/src/tools/fiscal.ts
+++ b/src/tools/fiscal.ts
@@ -1,0 +1,282 @@
+/**
+ * Fiscal tools for the Frihet MCP server — Wave 6 (8 tools).
+ *
+ * Tools:
+ *   1. get_modelo_303_summary   — IVA quarterly Spain
+ *   2. get_modelo_130_summary   — IRPF estimated payment Spain
+ *   3. get_modelo_390_summary   — IVA annual recap Spain
+ *   4. get_modelo_180_summary   — IRPF rentals annual Spain
+ *   5. get_modelo_347_summary   — Operations >€3005 annual third-party recap
+ *   6. verifactu_status         — VeriFactu submission status for an invoice
+ *   7. verifactu_resubmit       — Re-submit a failed VeriFactu submission (TRUST AREA)
+ *   8. ticketbai_status         — Basque Country e-invoicing status
+ *
+ * REST surface: /v1/fiscal/* (documented: pending — backend ships separately)
+ *
+ * NOTE: ERP backend endpoints /v1/fiscal/* are planned. Tools are wired
+ * and will surface 404 errors until the backend ships.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod/v4";
+import type { IFrihetClient } from "../client-interface.js";
+import {
+  withToolLogging,
+  formatRecord,
+  getContent,
+  mutateContent,
+  READ_ONLY_ANNOTATIONS,
+  fiscalModeloSummaryOutput,
+  verifactuStatusOutput,
+  ticketbaiStatusOutput,
+} from "./shared.js";
+
+export function registerFiscalTools(server: McpServer, client: IFrihetClient): void {
+  // -- get_modelo_303_summary --
+
+  server.registerTool(
+    "get_modelo_303_summary",
+    {
+      title: "Get Modelo 303 Summary (IVA Quarterly)",
+      description:
+        "Get IVA (VAT) quarterly summary for Modelo 303 filing in Spain. " +
+        "Returns aggregated totals by tax rate, deductible IVA, net amount due, and filing deadline. " +
+        "Example: period='2026-Q1' / " +
+        "Obtiene el resumen trimestral del IVA para el Modelo 303 en Espana. " +
+        "Devuelve totales por tipo impositivo, IVA deducible, cuota a ingresar y plazo.",
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        period: z
+          .string()
+          .optional()
+          .describe("Period in format YYYY-QN (e.g. '2026-Q1') or YYYY for annual / Periodo en formato YYYY-QN o YYYY"),
+      },
+      outputSchema: fiscalModeloSummaryOutput,
+    },
+    async ({ period }) => withToolLogging("get_modelo_303_summary", async () => {
+      const result = await client.getFiscalModeloSummary("303", period);
+      return {
+        content: [getContent(formatRecord("Modelo 303 Summary", result))],
+        structuredContent: result as unknown as Record<string, unknown>,
+      };
+    }),
+  );
+
+  // -- get_modelo_130_summary --
+
+  server.registerTool(
+    "get_modelo_130_summary",
+    {
+      title: "Get Modelo 130 Summary (IRPF Estimated Payment)",
+      description:
+        "Get IRPF estimated payment summary for Modelo 130 filing (freelancers/self-employed in Spain). " +
+        "Returns quarterly net income, deductible expenses, previous payments, and amount due. " +
+        "Example: period='2026-Q1' / " +
+        "Obtiene el resumen del pago fraccionado IRPF para el Modelo 130 (autonomos). " +
+        "Devuelve rendimiento neto, gastos deducibles, pagos previos y cuota a ingresar.",
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        period: z
+          .string()
+          .optional()
+          .describe("Period in format YYYY-QN (e.g. '2026-Q1') / Periodo en formato YYYY-QN"),
+      },
+      outputSchema: fiscalModeloSummaryOutput,
+    },
+    async ({ period }) => withToolLogging("get_modelo_130_summary", async () => {
+      const result = await client.getFiscalModeloSummary("130", period);
+      return {
+        content: [getContent(formatRecord("Modelo 130 Summary", result))],
+        structuredContent: result as unknown as Record<string, unknown>,
+      };
+    }),
+  );
+
+  // -- get_modelo_390_summary --
+
+  server.registerTool(
+    "get_modelo_390_summary",
+    {
+      title: "Get Modelo 390 Summary (IVA Annual Recap)",
+      description:
+        "Get IVA annual summary for Modelo 390 filing in Spain. " +
+        "Returns full-year totals by rate, total deductible IVA, and annual balance. " +
+        "Example: period='2025' / " +
+        "Obtiene el resumen anual del IVA para el Modelo 390. " +
+        "Devuelve totales anuales por tipo, IVA deducible total y resultado anual.",
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        period: z
+          .string()
+          .optional()
+          .describe("Year in format YYYY (e.g. '2025') / Ejercicio en formato YYYY"),
+      },
+      outputSchema: fiscalModeloSummaryOutput,
+    },
+    async ({ period }) => withToolLogging("get_modelo_390_summary", async () => {
+      const result = await client.getFiscalModeloSummary("390", period);
+      return {
+        content: [getContent(formatRecord("Modelo 390 Summary", result))],
+        structuredContent: result as unknown as Record<string, unknown>,
+      };
+    }),
+  );
+
+  // -- get_modelo_180_summary --
+
+  server.registerTool(
+    "get_modelo_180_summary",
+    {
+      title: "Get Modelo 180 Summary (IRPF Rentals Annual)",
+      description:
+        "Get IRPF annual informative summary for rental income withholdings (Modelo 180, Spain). " +
+        "Returns total retentions per tenant, property, and annual aggregate. " +
+        "Example: period='2025' / " +
+        "Obtiene el resumen anual de retenciones sobre alquileres para el Modelo 180. " +
+        "Devuelve retenciones totales por inquilino, inmueble y agregado anual.",
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        period: z
+          .string()
+          .optional()
+          .describe("Year in format YYYY (e.g. '2025') / Ejercicio en formato YYYY"),
+      },
+      outputSchema: fiscalModeloSummaryOutput,
+    },
+    async ({ period }) => withToolLogging("get_modelo_180_summary", async () => {
+      const result = await client.getFiscalModeloSummary("180", period);
+      return {
+        content: [getContent(formatRecord("Modelo 180 Summary", result))],
+        structuredContent: result as unknown as Record<string, unknown>,
+      };
+    }),
+  );
+
+  // -- get_modelo_347_summary --
+
+  server.registerTool(
+    "get_modelo_347_summary",
+    {
+      title: "Get Modelo 347 Summary (Operations >€3,005 Annual Recap)",
+      description:
+        "Get annual informative summary of operations exceeding €3,005 per counterparty (Modelo 347, Spain). " +
+        "Returns per-party totals for clients and vendors above the threshold. " +
+        "Example: period='2025' / " +
+        "Obtiene el resumen anual de operaciones con terceros superiores a 3.005€ (Modelo 347). " +
+        "Devuelve totales por cliente/proveedor que superen el umbral.",
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        period: z
+          .string()
+          .optional()
+          .describe("Year in format YYYY (e.g. '2025') / Ejercicio en formato YYYY"),
+      },
+      outputSchema: fiscalModeloSummaryOutput,
+    },
+    async ({ period }) => withToolLogging("get_modelo_347_summary", async () => {
+      const result = await client.getFiscalModeloSummary("347", period);
+      return {
+        content: [getContent(formatRecord("Modelo 347 Summary", result))],
+        structuredContent: result as unknown as Record<string, unknown>,
+      };
+    }),
+  );
+
+  // -- verifactu_status --
+
+  server.registerTool(
+    "verifactu_status",
+    {
+      title: "Get VeriFactu Submission Status",
+      description:
+        "Get the VeriFactu (AEAT Spanish e-invoice chain) submission status for a specific invoice. " +
+        "Returns last submission timestamp, hash, AEAT response code, and QR verification URL. " +
+        "/ Obtiene el estado de envio VeriFactu (AEAT) para una factura especifica. " +
+        "Devuelve timestamp del ultimo envio, hash, respuesta AEAT y URL del codigo QR.",
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        invoiceId: z.string().describe("Invoice ID / ID de la factura"),
+      },
+      outputSchema: verifactuStatusOutput,
+    },
+    async ({ invoiceId }) => withToolLogging("verifactu_status", async () => {
+      const result = await client.getVerifactuStatus(invoiceId);
+      return {
+        content: [getContent(formatRecord("VeriFactu Status", result))],
+        structuredContent: result as unknown as Record<string, unknown>,
+      };
+    }),
+  );
+
+  // -- verifactu_resubmit --
+
+  server.registerTool(
+    "verifactu_resubmit",
+    {
+      title: "Re-submit VeriFactu Submission",
+      description:
+        "TRUST AREA — COMPLIANCE. Re-submit a failed or rejected VeriFactu submission to AEAT. " +
+        "Idempotent: uses the same hash chain; AEAT deduplicates by hash. " +
+        "Creates an audit trail entry for every resubmission attempt. " +
+        "Requires confirm=true. Only use on invoices with status='failed'. " +
+        "/ AREA DE CONFIANZA — COMPLIANCE. Reenvio de una factura VeriFactu fallida a AEAT. " +
+        "Idempotente: misma cadena hash. Registra entrada de auditoria en cada intento. " +
+        "Requiere confirm=true. Solo para facturas con status='failed'.",
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+      inputSchema: {
+        invoiceId: z.string().describe("Invoice ID to resubmit / ID de la factura a reenviar"),
+        confirm: z
+          .boolean()
+          .describe("Must be true to confirm VeriFactu resubmission / Debe ser true para confirmar el reenvio"),
+      },
+      outputSchema: verifactuStatusOutput,
+    },
+    async ({ invoiceId, confirm }) => withToolLogging("verifactu_resubmit", async () => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Error: confirm=true is required for VeriFactu resubmission. " +
+                "This is a COMPLIANCE action that submits fiscal data to AEAT. " +
+                "Verify the invoice data is correct before setting confirm=true. / " +
+                "Se requiere confirm=true para el reenvio VeriFactu. Accion de COMPLIANCE que envia datos fiscales a AEAT.",
+            },
+          ],
+          isError: true,
+        };
+      }
+      const result = await client.resubmitVerifactu(invoiceId);
+      return {
+        content: [mutateContent(formatRecord("VeriFactu Resubmitted", result))],
+        structuredContent: result as unknown as Record<string, unknown>,
+      };
+    }),
+  );
+
+  // -- ticketbai_status --
+
+  server.registerTool(
+    "ticketbai_status",
+    {
+      title: "Get TicketBAI Status (Basque Country)",
+      description:
+        "Get the TicketBAI e-invoicing status for an invoice (Basque Country fiscal territories: Araba, Bizkaia, Gipuzkoa). " +
+        "Returns submission status, hash, territory province, and AEAT-PV/Bizkaia/Gipuzkoa response. " +
+        "/ Obtiene el estado TicketBAI de una factura (territorios forales vascos: Araba, Bizkaia, Gipuzkoa). " +
+        "Devuelve estado de envio, hash, provincia y respuesta de la hacienda foral.",
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        invoiceId: z.string().describe("Invoice ID / ID de la factura"),
+      },
+      outputSchema: ticketbaiStatusOutput,
+    },
+    async ({ invoiceId }) => withToolLogging("ticketbai_status", async () => {
+      const result = await client.getTicketbaiStatus(invoiceId);
+      return {
+        content: [getContent(formatRecord("TicketBAI Status", result))],
+        structuredContent: result as unknown as Record<string, unknown>,
+      };
+    }),
+  );
+}

--- a/src/tools/recurring.ts
+++ b/src/tools/recurring.ts
@@ -1,0 +1,93 @@
+/**
+ * Recurring invoice tools for the Frihet MCP server — Wave 6 (2 tools).
+ *
+ * Tools:
+ *   1. list_recurring_invoices — list recurring invoice templates
+ *   2. run_recurring_now       — manually trigger generation of next instance from template
+ *
+ * REST surface: /v1/recurring/invoices
+ *
+ * NOTE: ERP backend endpoints /v1/recurring/* are planned. Tools are wired
+ * and will surface 404 errors until the backend ships.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod/v4";
+import type { IFrihetClient } from "../client-interface.js";
+import {
+  withToolLogging,
+  formatPaginatedResponse,
+  formatRecord,
+  listContent,
+  mutateContent,
+  READ_ONLY_ANNOTATIONS,
+  paginatedOutput,
+  actionResultOutput,
+  recurringInvoiceItemOutput,
+} from "./shared.js";
+
+export function registerRecurringTools(server: McpServer, client: IFrihetClient): void {
+  // -- list_recurring_invoices --
+
+  server.registerTool(
+    "list_recurring_invoices",
+    {
+      title: "List Recurring Invoices",
+      description:
+        "List all recurring invoice templates. " +
+        "Returns template name, frequency, next scheduled run date, recipient, line items, and active/paused status. " +
+        "/ Lista todas las plantillas de facturas recurrentes. " +
+        "Devuelve nombre de la plantilla, frecuencia, proxima fecha de ejecucion, destinatario, lineas y estado.",
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        status: z
+          .enum(["active", "paused"])
+          .optional()
+          .describe("Filter by status / Filtrar por estado"),
+        limit: z.number().int().min(1).max(100).optional().describe("Max results (1-100) / Resultados maximos"),
+        offset: z.number().int().min(0).optional().describe("Offset / Desplazamiento"),
+      },
+      outputSchema: paginatedOutput(recurringInvoiceItemOutput),
+    },
+    async ({ status, limit, offset }) => withToolLogging("list_recurring_invoices", async () => {
+      const result = await client.listRecurringInvoices({ status, limit, offset });
+      return {
+        content: [listContent(formatPaginatedResponse("recurring_invoices", result))],
+        structuredContent: result as unknown as Record<string, unknown>,
+      };
+    }),
+  );
+
+  // -- run_recurring_now --
+
+  server.registerTool(
+    "run_recurring_now",
+    {
+      title: "Run Recurring Invoice Now",
+      description:
+        "Manually trigger immediate generation of the next invoice instance from a recurring template. " +
+        "Useful for billing ahead of schedule or recovering from a missed automated run. " +
+        "The generated invoice is created as a draft; review and send separately. " +
+        "Example: templateId='rec_abc123' " +
+        "/ Genera manualmente la siguiente instancia de una factura recurrente. " +
+        "Util para facturar antes de lo programado o recuperar un ciclo perdido. " +
+        "La factura generada se crea como borrador; revisar y enviar por separado.",
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+      inputSchema: {
+        templateId: z.string().describe("Recurring invoice template ID / ID de la plantilla de factura recurrente"),
+        draftOnly: z
+          .boolean()
+          .optional()
+          .describe("If true, create as draft only (default true). Set false to create and mark as sent immediately. / Si true, crea como borrador. Set false para crear y marcar como enviada."),
+      },
+      outputSchema: actionResultOutput,
+    },
+    async ({ templateId, draftOnly }) => withToolLogging("run_recurring_now", async () => {
+      const result = await client.runRecurringNow(templateId, { draftOnly: draftOnly ?? true });
+      return {
+        content: [mutateContent(formatRecord("Recurring invoice triggered", result))],
+        structuredContent: result as unknown as Record<string, unknown>,
+      };
+    }),
+  );
+}

--- a/src/tools/register-all.ts
+++ b/src/tools/register-all.ts
@@ -1,12 +1,12 @@
 /**
- * Barrel module that registers all 75 Frihet ERP tools on an McpServer.
+ * Barrel module that registers all 94 Frihet ERP tools on an McpServer.
  *
  * Used by both the local (stdio) and remote (Cloudflare Workers) servers
  * so tool definitions stay in sync — one source of truth.
  *
  * Langfuse observability is injected by patching server.registerTool once
  * before any tool registration. This wraps every tool callback with
- * traceMCPTool so all 75 tools are instrumented at zero per-tool cost.
+ * traceMCPTool so all 94 tools are instrumented at zero per-tool cost.
  */
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -25,6 +25,10 @@ import { registerDepositTools } from "./deposits.js";
 import { registerEInvoiceTools } from "./einvoice.js";
 import { registerStayTools } from "./stay.js";
 import { registerPosTools } from "./pos.js";
+import { registerBankingTools } from "./banking.js";
+import { registerFiscalTools } from "./fiscal.js";
+import { registerTimeTools } from "./time.js";
+import { registerRecurringTools } from "./recurring.js";
 
 /**
  * Patches server.registerTool to wrap every tool callback with Langfuse tracing.
@@ -72,4 +76,8 @@ export function registerAllTools(server: McpServer, client: IFrihetClient): void
   registerEInvoiceTools(server, client);
   registerStayTools(server, client);
   registerPosTools(server, client);
+  registerBankingTools(server, client);
+  registerFiscalTools(server, client);
+  registerTimeTools(server, client);
+  registerRecurringTools(server, client);
 }

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -559,6 +559,96 @@ export const actionResultOutput = z.object({
   message: z.string().optional(),
 }).passthrough();
 
+/* --- Banking item schemas -------------------------------------------------- */
+
+export const bankAccountItemOutput = z.object({
+  id: z.string(),
+  alias: z.string().optional(),
+  ibanLast4: z.string().optional().describe("Last 4 digits of IBAN (security masked)"),
+  currency: z.string().optional(),
+  balance: z.number().optional(),
+  lastSyncedAt: z.string().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+}).passthrough();
+
+export const bankTransactionItemOutput = z.object({
+  id: z.string(),
+  accountId: z.string().optional(),
+  amount: z.number(),
+  currency: z.string().optional(),
+  description: z.string().optional(),
+  postedAt: z.string().optional(),
+  category: z.string().optional(),
+  status: z.enum(["pending", "posted", "excluded"]).optional(),
+  matchedDocId: z.string().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+}).passthrough();
+
+/* --- Fiscal item schemas --------------------------------------------------- */
+
+export const fiscalModeloSummaryOutput = z.object({
+  modeloCode: z.string(),
+  period: z.string().optional(),
+  totalsByRate: z.record(z.string(), z.number()).optional(),
+  totalDeductible: z.number().optional(),
+  totalDue: z.number().optional(),
+  deadline: z.string().optional(),
+}).passthrough();
+
+export const verifactuStatusOutput = z.object({
+  invoiceId: z.string(),
+  lastSubmissionAt: z.string().optional(),
+  hash: z.string().optional(),
+  status: z.enum(["success", "pending", "failed"]).optional(),
+  aeatResponse: z.string().optional(),
+  qrUrl: z.string().optional(),
+}).passthrough();
+
+export const ticketbaiStatusOutput = z.object({
+  invoiceId: z.string(),
+  lastSubmissionAt: z.string().optional(),
+  hash: z.string().optional(),
+  status: z.enum(["success", "pending", "failed"]).optional(),
+  aeatResponse: z.string().optional(),
+  qrUrl: z.string().optional(),
+  province: z.enum(["araba", "bizkaia", "gipuzkoa"]).optional(),
+}).passthrough();
+
+/* --- Time entry item schemas ----------------------------------------------- */
+
+export const timeEntryItemOutput = z.object({
+  id: z.string(),
+  userId: z.string().optional(),
+  projectId: z.string().optional(),
+  hours: z.number(),
+  description: z.string().optional(),
+  billable: z.boolean().optional(),
+  date: z.string().optional(),
+  status: z.string().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+}).passthrough();
+
+/* --- Recurring invoice item schemas ---------------------------------------- */
+
+export const recurringInvoiceItemOutput = z.object({
+  id: z.string(),
+  templateName: z.string().optional(),
+  frequency: z.string().optional(),
+  nextRun: z.string().optional(),
+  recipient: z.string().optional(),
+  lineItems: z.array(z.object({
+    description: z.string(),
+    quantity: z.number(),
+    unitPrice: z.number(),
+  })).optional(),
+  status: z.enum(["active", "paused"]).optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+}).passthrough();
+
 /** Schema for PDF results */
 export const pdfResultOutput = z.object({
   id: z.string(),

--- a/src/tools/time.ts
+++ b/src/tools/time.ts
@@ -1,0 +1,179 @@
+/**
+ * Time tracking tools for the Frihet MCP server — Wave 6 (4 tools).
+ *
+ * Tools:
+ *   1. list_time_entries  — list timesheets (filter: user, project, date range)
+ *   2. create_time_entry  — log time (project, hours, description, billable flag)
+ *   3. update_time_entry  — modify existing time entry
+ *   4. delete_time_entry  — soft delete (Trust Area: requires confirm)
+ *
+ * REST surface: /v1/time/entries
+ *
+ * NOTE: ERP backend endpoints /v1/time/* are planned. Tools are wired
+ * and will surface 404 errors until the backend ships.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod/v4";
+import type { IFrihetClient } from "../client-interface.js";
+import {
+  withToolLogging,
+  formatPaginatedResponse,
+  formatRecord,
+  listContent,
+  getContent,
+  mutateContent,
+  READ_ONLY_ANNOTATIONS,
+  CREATE_ANNOTATIONS,
+  UPDATE_ANNOTATIONS,
+  paginatedOutput,
+  deleteResultOutput,
+  timeEntryItemOutput,
+} from "./shared.js";
+
+export function registerTimeTools(server: McpServer, client: IFrihetClient): void {
+  // -- list_time_entries --
+
+  server.registerTool(
+    "list_time_entries",
+    {
+      title: "List Time Entries",
+      description:
+        "List time tracking entries with optional filters. " +
+        "Filter by user, project, date range, or billable status. " +
+        "Useful for generating timesheets, billing reports, and project cost analysis. " +
+        "/ Lista entradas de tiempo con filtros opcionales. " +
+        "Filtra por usuario, proyecto, rango de fechas o facturabilidad. " +
+        "Util para partes de trabajo, informes de facturacion y analisis de costes por proyecto.",
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        userId: z.string().optional().describe("Filter by user ID / Filtrar por ID de usuario"),
+        projectId: z.string().optional().describe("Filter by project ID / Filtrar por ID de proyecto"),
+        from: z.string().optional().describe("Start date ISO 8601 (YYYY-MM-DD) / Fecha inicio"),
+        to: z.string().optional().describe("End date ISO 8601 (YYYY-MM-DD) / Fecha fin"),
+        billable: z.boolean().optional().describe("Filter by billable flag / Filtrar por facturabilidad"),
+        limit: z.number().int().min(1).max(100).optional().describe("Max results (1-100) / Resultados maximos"),
+        offset: z.number().int().min(0).optional().describe("Offset / Desplazamiento"),
+        after: z.string().optional().describe("Cursor for cursor-based pagination / Cursor para paginacion"),
+      },
+      outputSchema: paginatedOutput(timeEntryItemOutput),
+    },
+    async ({ userId, projectId, from, to, billable, limit, offset, after }) =>
+      withToolLogging("list_time_entries", async () => {
+        const result = await client.listTimeEntries({ userId, projectId, from, to, billable, limit, offset, after });
+        return {
+          content: [listContent(formatPaginatedResponse("time_entries", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+  );
+
+  // -- create_time_entry --
+
+  server.registerTool(
+    "create_time_entry",
+    {
+      title: "Create Time Entry",
+      description:
+        "Log a time entry for a project. " +
+        "Requires projectId, hours (decimal), and date. " +
+        "Mark as billable=true to include in client invoicing. " +
+        "Example: projectId='proj_abc', hours=2.5, description='Frontend review', billable=true, date='2026-05-10' " +
+        "/ Registra una entrada de tiempo para un proyecto. " +
+        "Requiere projectId, horas (decimal) y fecha. " +
+        "Marca billable=true para incluirlo en la facturacion al cliente.",
+      annotations: CREATE_ANNOTATIONS,
+      inputSchema: {
+        projectId: z.string().describe("Project ID / ID del proyecto"),
+        hours: z.number().min(0.01).describe("Hours worked (decimal, e.g. 1.5) / Horas trabajadas (decimal)"),
+        date: z.string().describe("Work date ISO 8601 (YYYY-MM-DD) / Fecha del trabajo"),
+        description: z.string().optional().describe("Description of work done / Descripcion del trabajo realizado"),
+        billable: z.boolean().optional().describe("Whether hours are billable to client (default true) / Si las horas son facturables"),
+        userId: z.string().optional().describe("User ID (defaults to API key owner) / ID del usuario (por defecto el propietario de la API key)"),
+      },
+      outputSchema: timeEntryItemOutput,
+    },
+    async ({ projectId, hours, date, description, billable, userId }) =>
+      withToolLogging("create_time_entry", async () => {
+        const result = await client.createTimeEntry({ projectId, hours, date, description, billable, userId });
+        return {
+          content: [mutateContent(formatRecord("Time entry created", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+  );
+
+  // -- update_time_entry --
+
+  server.registerTool(
+    "update_time_entry",
+    {
+      title: "Update Time Entry",
+      description:
+        "Update an existing time entry using PATCH semantics. Only provided fields are changed. " +
+        "Example: id='te_abc123', hours=3.0, description='Frontend review + testing' " +
+        "/ Actualiza una entrada de tiempo existente. Solo se modifican los campos proporcionados.",
+      annotations: UPDATE_ANNOTATIONS,
+      inputSchema: {
+        id: z.string().describe("Time entry ID / ID de la entrada de tiempo"),
+        hours: z.number().min(0.01).optional().describe("Updated hours / Horas actualizadas"),
+        date: z.string().optional().describe("Updated date ISO 8601 / Fecha actualizada"),
+        description: z.string().optional().describe("Updated description / Descripcion actualizada"),
+        billable: z.boolean().optional().describe("Updated billable flag / Facturabilidad actualizada"),
+        projectId: z.string().optional().describe("Reassign to different project / Reasignar a otro proyecto"),
+      },
+      outputSchema: timeEntryItemOutput,
+    },
+    async ({ id, ...data }) => withToolLogging("update_time_entry", async () => {
+      const result = await client.updateTimeEntry(id, data);
+      return {
+        content: [mutateContent(formatRecord("Time entry updated", result))],
+        structuredContent: result as unknown as Record<string, unknown>,
+      };
+    }),
+  );
+
+  // -- delete_time_entry --
+
+  server.registerTool(
+    "delete_time_entry",
+    {
+      title: "Delete Time Entry",
+      description:
+        "Soft-delete a time entry by ID. " +
+        "Requires confirm=true to prevent accidental deletion. " +
+        "Deleted entries are excluded from billing reports but retained for audit. " +
+        "/ Elimina (soft-delete) una entrada de tiempo por su ID. " +
+        "Requiere confirm=true para evitar eliminaciones accidentales. " +
+        "Las entradas eliminadas se excluyen de informes de facturacion pero se retienen en auditoria.",
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },
+      inputSchema: {
+        id: z.string().describe("Time entry ID / ID de la entrada de tiempo"),
+        confirm: z
+          .boolean()
+          .describe("Must be true to confirm deletion / Debe ser true para confirmar la eliminacion"),
+      },
+      outputSchema: deleteResultOutput,
+    },
+    async ({ id, confirm }) => withToolLogging("delete_time_entry", async () => {
+      if (!confirm) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Error: confirm=true is required to delete a time entry. " +
+                "Deleted entries affect billing reports. Set confirm=true to proceed. / " +
+                "Se requiere confirm=true para eliminar una entrada de tiempo.",
+            },
+          ],
+          isError: true,
+        };
+      }
+      await client.deleteTimeEntry(id);
+      return {
+        content: [mutateContent(`Time entry ${id} deleted (soft). / Entrada de tiempo ${id} eliminada.`)],
+        structuredContent: { success: true, id } as unknown as Record<string, unknown>,
+      };
+    }),
+  );
+}


### PR DESCRIPTION
## Summary

- **Banking (5 tools)**: `list_bank_accounts`, `get_bank_account`, `list_transactions`, `categorize_transaction`, `match_transaction_to_invoice` (Trust Area: fiscal reconciliation, `confirm=true` required)
- **Fiscal (8 tools)**: `get_modelo_303_summary`, `get_modelo_130_summary`, `get_modelo_390_summary`, `get_modelo_180_summary`, `get_modelo_347_summary`, `verifactu_status`, `verifactu_resubmit` (Trust Area: AEAT COMPLIANCE, `confirm=true` + audit trail), `ticketbai_status` (Basque Country, `province` field)
- **Time Tracking (4 tools)**: `list_time_entries`, `create_time_entry`, `update_time_entry`, `delete_time_entry` (soft-delete, Trust Area: `confirm=true`)
- **Recurring Invoices (2 tools)**: `list_recurring_invoices`, `run_recurring_now` (`draftOnly` flag, no confirm required)

**Total: 75 → 94 tools (+19). Version: 1.8.0-beta.1 → 1.9.0-beta.1.**

## Changes

- 4 new tool files: `banking.ts`, `fiscal.ts`, `time.ts`, `recurring.ts`
- 4 new test files: 136 total tests, 136 pass, 0 fail
- 7 new output schemas in `shared.ts`: `bankAccountItemOutput`, `bankTransactionItemOutput`, `fiscalModeloSummaryOutput`, `verifactuStatusOutput`, `ticketbaiStatusOutput`, `timeEntryItemOutput`, `recurringInvoiceItemOutput`
- 19 new methods in `IFrihetClient` interface + `FrihetClient` HTTP implementations
- `register-all.ts` wired with 4 new family imports
- `package.json` version bump + test script extended
- `README.md` badge updated (75→94), `CHANGELOG.md` Wave 6 entry added

## ERP Backend Dependency

REST endpoints `/v1/banking/*`, `/v1/fiscal/*`, `/v1/time/*`, `/v1/recurring/*` are planned for Frihet-ERP backend. MCP tools are fully wired and will return 404 (via `FrihetApiError`) until the backend ships — same pattern as Stay + POS (Wave 4+5) which landed before their backend.

## Trust Area Review

Three tools have `confirm=true` gates with fail-open error messages:
- `match_transaction_to_invoice` — fiscal reconciliation (idempotent, mutates matched doc state)
- `verifactu_resubmit` — AEAT COMPLIANCE (idempotent by hash chain, creates audit trail row)
- `delete_time_entry` — soft delete (excluded from billing reports, retained for audit)

## Test plan

- [x] `npm run build` — TS clean (0 errors)
- [x] `npm test` — 136/136 pass across 7 test files (einvoice + stay + pos + banking + fiscal + time + recurring)
- [x] All existing tests (einvoice, stay, pos) unaffected — no regressions
- [x] Trust Area gates: `confirm=false` returns `isError: true` without calling client
- [x] 404 error propagation tested for all new families
- [ ] Backend integration smoke — deferred until `/v1/banking|fiscal|time|recurring` endpoints land in Frihet-ERP

🤖 Generated with [Claude Code](https://claude.com/claude-code)