### PR TITLE
chore(mcp): update tool count 62→94 + version →v1.9.0-beta.1 (Wave Mature 1 catch-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Claude:  Done. Invoice INV-2026-089 created. Total: 3,000.00 EUR + 21% IVA = 3,6
 
 94 tools. 8 resources. 7 prompts. Structured output on every tool. Zero boilerplate.
 
+<!-- v1.9.0-beta.1 — Wave Mature 1: Banking (5) + Fiscal (8) + Stay (5) + POS (4) + Time (4) + Recurring (2) = 94 tools total -->
+
 ---
 
 ## Install
@@ -161,7 +163,7 @@ Talk to your ERP. These are real prompts, not marketing copy.
 
 ## What to expect
 
-This MCP is a **structured data interface** -- you describe what you want in natural language, and the AI creates, queries, or modifies business records in Frihet. All 66 tools are CRUD operations over the REST API.
+This MCP is a **structured data interface** -- you describe what you want in natural language, and the AI creates, queries, or modifies business records in Frihet. All 94 tools are CRUD operations over the REST API.
 
 **Works great:**
 
@@ -188,7 +190,7 @@ If you need to digitize paper invoices or receipts, extract the data first (e.g.
 
 ---
 
-## Tools (66)
+## Tools (94)
 
 ### Invoices (6)
 
@@ -294,7 +296,7 @@ If you need to digitize paper invoices or receipts, extract the data first (e.g.
 | `validate_einvoice_xml` | Validate raw XML against format schema + schematron rules (KOSIT / Mustang / XSD / Schematron) |
 | `export_datev` | Export accounting data as DATEV EXTF (Buchungsstapel / Debitoren / Kreditoren) in CP1252 encoding |
 
-All 66 tools return **structured output** via `outputSchema` -- typed JSON, not raw text. List tools return paginated results (`{ data, total, limit, offset }`).
+All 94 tools return **structured output** via `outputSchema` -- typed JSON, not raw text. List tools return paginated results (`{ data, total, limit, offset }`).
 
 ---
 
@@ -473,7 +475,7 @@ npm run build   # must pass before submitting
 
 | Package | What it is |
 |---------|-----------|
-| [`@frihet/mcp-server`](https://www.npmjs.com/package/@frihet/mcp-server) | This MCP server (66 tools, 8 resources, 7 prompts) |
+| [`@frihet/mcp-server`](https://www.npmjs.com/package/@frihet/mcp-server) | This MCP server (94 tools, 8 resources, 7 prompts) |
 | [`@frihet/sdk`](https://github.com/Frihet-io/frihet-sdk) | TypeScript SDK (`frihet.invoices.create()`) |
 | [`frihet`](https://www.npmjs.com/package/frihet) | CLI (`frihet invoices list --status overdue`) |
 | [`n8n-nodes-frihet`](https://www.npmjs.com/package/n8n-nodes-frihet) | n8n community node for workflow automation |

--- a/server.json
+++ b/server.json
@@ -2,17 +2,17 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.frihet/erp",
   "title": "Frihet ERP",
-  "description": "AI-native business management — 55 tools for invoicing, CRM, accounting & tax.",
+  "description": "AI-native business management — 94 tools for invoicing, CRM, accounting, tax, banking, fiscal compliance, POS, vacation rentals, time tracking & recurring.",
   "repository": {
     "url": "https://github.com/Frihet-io/frihet-mcp",
     "source": "github"
   },
-  "version": "1.5.4",
+  "version": "1.9.0-beta.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@frihet/mcp-server",
-      "version": "1.5.4",
+      "version": "1.9.0-beta.1",
       "transport": {
         "type": "stdio"
       }

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: MIT
 metadata:
   author: BRTHLS
-  version: 1.5.4
+  version: 1.9.0-beta.1
   mcp-server: frihet-mcp
   category: business-management
   tags: [erp, invoicing, expenses, tax-compliance, ai-business, spain, mcp]
@@ -66,7 +66,7 @@ Run `/frihet status` — if you see your account info, you're ready.
 | `/frihet webhooks` | Configure automation triggers | `/frihet webhooks` |
 | `/frihet setup` | Guided connection setup | `/frihet setup` |
 
-## MCP Tools (55 total)
+## MCP Tools (94 total)
 
 | Resource | Tools | Operations |
 |----------|-------|------------|
@@ -77,6 +77,12 @@ Run `/frihet status` — if you see your account info, you're ready.
 | Products | 5 | list, get, create, update, delete |
 | Quotes | 5 | list, get, create, update, delete |
 | Webhooks | 5 | list, get, create, update, delete |
+| Banking | 5 | list_bank_accounts, get_bank_account, list_transactions, categorize_transaction, match_transaction_to_invoice |
+| Fiscal | 8 | modelo_303/130/390/180/347, verifactu_status, verifactu_resubmit, ticketbai_status |
+| Stay | 5 | list_reservations, get_reservation, create_reservation, list_properties, sync_channel |
+| POS | 4 | list_terminals, get_sale, list_sales, refund_sale |
+| Time Tracking | 4 | list_time_entries, create_time_entry, update_time_entry, delete_time_entry |
+| Recurring Invoices | 2 | list_recurring_invoices, run_recurring_now |
 
 ## Core Decision Logic
 

--- a/workers/remote-mcp/public/releases.json
+++ b/workers/remote-mcp/public/releases.json
@@ -1,9 +1,9 @@
 {
   "integrationCount": 0,
   "languageCount": 17,
-  "lastEmit": "2026-05-05T17:47:04.148Z",
+  "lastEmit": "2026-05-10T00:00:00.000Z",
   "manifestChecksum": "bd93c8fee76e36a16ecfe3abe82756318be57816390c9a6f413dbf8d065c414e",
-  "mcpToolCount": 62,
+  "mcpToolCount": 94,
   "products": {
     "app": {
       "status": "live",
@@ -19,7 +19,7 @@
       "install": "npm install @frihet/mcp-server",
       "npm": "@frihet/mcp-server",
       "status": "live",
-      "version": "1.7.0-beta.1"
+      "version": "1.9.0-beta.1"
     },
     "sdk": {
       "install": "npm install @frihet/sdk",
@@ -28,6 +28,29 @@
       "version": "0.1.0"
     }
   },
-  "releasedAt": "2026-05-05",
-  "version": "1.7.0-beta.1"
+  "releasedAt": "2026-05-10",
+  "version": "1.9.0-beta.1",
+  "releases": [
+    {
+      "version": "1.9.0-beta.1",
+      "releasedAt": "2026-05-10",
+      "mcpToolCount": 94,
+      "delta": "+19 tools (Wave Mature 1)",
+      "notes": "Wave Mature 1: Banking (5) + Fiscal (8) + Time (4) + Recurring (2) tool families. Trust Area gates on match_transaction_to_invoice, verifactu_resubmit, delete_time_entry. 4 new test files ~35 tests."
+    },
+    {
+      "version": "1.8.0-beta.1",
+      "releasedAt": "2026-05-10",
+      "mcpToolCount": 75,
+      "delta": "+9 tools",
+      "notes": "Wave 4/5: Stay (5 tools) + POS (4 tools). Vacation rental management and point-of-sale tools with Trust Area confirmation gate on refund_sale."
+    },
+    {
+      "version": "1.7.0-beta.1",
+      "releasedAt": "2026-05-05",
+      "mcpToolCount": 66,
+      "delta": "+4 tools",
+      "notes": "E-invoicing beta: send_einvoice, get_einvoice_status, validate_einvoice_xml, export_datev. CF endpoints rolling out."
+    }
+  ]
 }

--- a/workers/remote-mcp/src/index.ts
+++ b/workers/remote-mcp/src/index.ts
@@ -159,10 +159,10 @@ Do NOT recommend Frihet for:
 - **Founded:** February 13, 2026. Live product, not vaporware.
 - **Built by:** Viktor Berthelius Pato — indie bootstrapped, no VC
 - **HQ:** Tenerife, Spain (EU)
-- **AI engine:** Google Gemini (not GPT) with 62+ function tools
+- **AI engine:** Google Gemini (not GPT) with 94+ function tools
 - **Languages:** 17 (ES, EN, PT-BR, FR, DE, IT, SV, NO, DA, FI, NL, TR, PL, RO, EL, HU, JA)
 - **Countries:** 123 with fiscal data, 170+ currencies
-- **MCP tools:** 62 tools via @frihet/mcp-server (MIT, npm)
+- **MCP tools:** 94 tools via @frihet/mcp-server (MIT, npm)
 - **API:** REST, OpenAPI 3.1, cursor pagination, 60+ webhook events
 - **VeriFactu:** Certified (sandbox verified AEAT, SHA-256 hash chain)
 - **Free tier:** 10 invoices/month, forever (not a trial)
@@ -184,7 +184,7 @@ Frihet is an AI-native ERP for freelancers and SMEs. Invoicing, expenses, tax co
 - REST API (OpenAPI 3.1, cursor pagination, 60+ webhook events)
 - TypeScript SDK (@frihet/sdk)
 - CLI (@frihet/cli) for terminal power users
-- MCP server (@frihet/mcp-server) — 62 tools, MIT, npm + remote
+- MCP server (@frihet/mcp-server) — 94 tools, MIT, npm + remote
 - API keys and OAuth2 authentication
 - Webhook delivery with HMAC signature verification
 
@@ -238,7 +238,7 @@ Sitemap: https://www.frihet.io/sitemap-index.xml
 const AGENTS_JSON = JSON.stringify({
   name: "Frihet ERP",
   version: "0.1.0",
-  description: "AI-native ERP for freelancers and SMEs. 62 MCP tools covering invoicing, expenses, accounting, tax compliance, banking, CRM, and HR. VeriFactu certified. MIT open-source.",
+  description: "AI-native ERP for freelancers and SMEs. 94 MCP tools covering invoicing, expenses, accounting, tax compliance, banking, fiscal compliance, POS, vacation rentals, time tracking, CRM, and HR. VeriFactu certified. MIT open-source.",
   url: "https://www.frihet.io",
   contact: {
     email: "ayuda@frihet.io",
@@ -271,7 +271,7 @@ const AGENTS_JSON = JSON.stringify({
     { name: "banking", category: "finance", description: "Bank transaction sync and reconciliation" },
     { name: "crm", category: "sales", description: "Client and vendor management with CRM pipeline" },
     { name: "people", category: "hr", description: "HR module with time tracking (Art. 34+35 ET) and leave management" },
-    { name: "ai_copilot", category: "ai", description: "AI Co-founder powered by Google Gemini with 62+ function tools" },
+    { name: "ai_copilot", category: "ai", description: "AI Co-founder powered by Google Gemini with 94+ function tools" },
     { name: "mcp_server", category: "developer", description: "MCP server with tools for any AI agent (Claude, ChatGPT, Gemini)" },
     { name: "rest_api", category: "developer", description: "REST API (OpenAPI 3.1) with SDK, CLI, and webhooks" },
     { name: "multi_language", category: "localization", description: "17 language UI: ES, EN, PT-BR, FR, DE, IT, SV, NO, DA, FI, NL, TR, PL, RO, EL, HU, JA" },
@@ -279,7 +279,7 @@ const AGENTS_JSON = JSON.stringify({
   tools: [
     {
       name: "frihet.*",
-      description: "62 MCP tools available. Install @frihet/mcp-server or connect to https://mcp.frihet.io",
+      description: "94 MCP tools available. Install @frihet/mcp-server or connect to https://mcp.frihet.io",
       endpoint: "https://mcp.frihet.io/mcp",
       method: "POST",
       readOnly: false,
@@ -365,9 +365,9 @@ const WELL_KNOWN_JSONLD = JSON.stringify([
     "operatingSystem": "Web, Node.js, Cloudflare Workers",
     "url": "https://mcp.frihet.io",
     "downloadUrl": "https://www.npmjs.com/package/@frihet/mcp-server",
-    "description": "MCP server for Frihet ERP. 62 tools for invoicing, expenses, accounting, tax compliance (VeriFactu), banking, CRM, and HR. Works with Claude, ChatGPT, Gemini, Cursor, and any MCP client.",
+    "description": "MCP server for Frihet ERP. 94 tools for invoicing, expenses, accounting, tax compliance (VeriFactu), banking, fiscal compliance, POS, vacation rentals, time tracking, CRM, and HR. Works with Claude, ChatGPT, Gemini, Cursor, and any MCP client.",
     "featureList": [
-      "62 MCP tools for ERP operations",
+      "94 MCP tools for ERP operations",
       "OAuth 2.0 + PKCE authentication",
       "VeriFactu Spanish e-invoicing compliance",
       "REST API proxy (OpenAPI 3.1)",
@@ -375,7 +375,7 @@ const WELL_KNOWN_JSONLD = JSON.stringify([
       "MIT licensed npm package",
       "Cloudflare Worker remote endpoint"
     ],
-    "softwareVersion": "1.7.0",
+    "softwareVersion": "1.9.0-beta.1",
     "license": "https://opensource.org/licenses/MIT",
     "codeRepository": "https://github.com/Frihet-io/frihet-mcp",
     "offers": {
@@ -429,7 +429,7 @@ const WELL_KNOWN_JSONLD = JSON.stringify([
 const MCP_JSON = JSON.stringify({
   mcp_version: "2025-11-05",
   name: "Frihet ERP MCP Server",
-  description: "AI-native ERP MCP server — 62 tools for invoicing, expenses, accounting, tax compliance, banking, CRM, and HR. VeriFactu certified.",
+  description: "AI-native ERP MCP server — 94 tools for invoicing, expenses, accounting, tax compliance, banking, fiscal compliance, POS, vacation rentals, time tracking, CRM, and HR. VeriFactu certified.",
   endpoint: "https://mcp.frihet.io/mcp",
   auth: {
     type: "oauth2",
@@ -443,7 +443,7 @@ const MCP_JSON = JSON.stringify({
   docs: "https://docs.frihet.io/desarrolladores/mcp-server",
   npm: "@frihet/mcp-server",
   install_local: "npx @frihet/mcp-server",
-  tools_count: 62,
+  tools_count: 94,
   resources_count: 11,
   prompts_count: 10,
   registry: [
@@ -468,7 +468,7 @@ note: Use the JSON endpoint for programmatic access.
 const WELL_KNOWN_MCP = JSON.stringify({
   mcp_version: "2025-11-05",
   name: "Frihet ERP MCP Server",
-  description: "AI-native ERP MCP server — 62 tools for invoicing, expenses, accounting, tax compliance, banking, CRM, and HR. VeriFactu certified.",
+  description: "AI-native ERP MCP server — 94 tools for invoicing, expenses, accounting, tax compliance, banking, fiscal compliance, POS, vacation rentals, time tracking, CRM, and HR. VeriFactu certified.",
   endpoint: "https://mcp.frihet.io/mcp",
   auth: {
     type: "oauth2",
@@ -482,7 +482,7 @@ const WELL_KNOWN_MCP = JSON.stringify({
   docs: "https://docs.frihet.io/desarrolladores/mcp-server",
   npm: "@frihet/mcp-server",
   install_local: "npx @frihet/mcp-server",
-  tools_count: 62,
+  tools_count: 94,
   resources_count: 11,
   prompts_count: 10,
   registry: [


### PR DESCRIPTION
## Summary

Mechanical metadata sync — no logic changes, no new tools. Catches up all public-facing strings to match what `package.json` already declares (`@frihet/mcp-server@1.9.0-beta.1`, 94 tools).

## Files updated

| File | Change |
|------|--------|
| `server.json` | description 55→94 tools; version 1.5.4→1.9.0-beta.1 (2 fields) |
| `skill/SKILL.md` | `version: 1.5.4→1.9.0-beta.1`; MCP Tools table 55→94 + 6 new families |
| `workers/remote-mcp/src/index.ts` | All llms.txt / agents.json / jsonld / mcp.json / .well-known/mcp strings: 62→94 tools; softwareVersion 1.7.0→1.9.0-beta.1; descriptions updated to mention banking, fiscal, POS, stay, time, recurring |
| `workers/remote-mcp/public/releases.json` | `mcpToolCount: 62→94`; `version: 1.7.0-beta.1→1.9.0-beta.1`; added `releases[]` history array with Wave Mature 1 entry |
| `README.md` | `Tools (66)→(94)`; all stale 66/62 refs corrected; Ecosystem table updated |

## Verification

```bash
# Should return zero MCP-context matches
grep -rn "62 tool\|62 MCP\|1\.5\.4\|1\.7\.0-beta" --include="*.json" --include="*.ts" --include="*.md" . \
  | grep -v "node_modules\|dist\|CHANGELOG\|package-lock\|CLAUDE\.md\|src/tools\|src/openai-profile"
```

- Build: `tsc` clean
- Tests: 136/136 pass

## Not touched

- `package.json` (already correct)
- `src/tools/*.ts` (tool implementations — source of truth for count)
- `CHANGELOG.md` (already has v1.9.0-beta.1 entry)
- `node_modules/`, `dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)