### PR TITLE
fix(mcp): shorten server.json description to ≤100 chars

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.frihet/erp",
   "title": "Frihet ERP",
-  "description": "AI-native business management — 94 tools for invoicing, CRM, accounting, tax, banking, fiscal compliance, POS, vacation rentals, time tracking & recurring.",
+  "description": "AI-native ERP — 94 tools: invoicing, CRM, accounting, tax, banking, POS, fiscal & more.",
   "repository": {
     "url": "https://github.com/Frihet-io/frihet-mcp",
     "source": "github"


### PR DESCRIPTION
Anthropic MCP registry rejects description >100 chars (422 validation). Shorten 155→87 chars to unblock `mcp-publisher publish`.