### PR TITLE
fix(mcp): shorten server.json description to ≤100 chars (registry constraint)

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.frihet/erp",
   "title": "Frihet ERP",
-  "description": "AI-native business management — 94 tools for invoicing, CRM, accounting, tax, banking, fiscal compliance, POS, vacation rentals, time tracking & recurring.",
+  "description": "AI-native ERP — 94 tools: invoicing, CRM, accounting, tax, banking, POS, fiscal & more.",
   "repository": {
     "url": "https://github.com/Frihet-io/frihet-mcp",
     "source": "github"


### PR DESCRIPTION
## Summary

- MCP registry validation rejects `server.json` where `description.length > 100` with HTTP 422 Unprocessable Entity
- Previous description (from PR #16) was 155 chars → submission would fail
- Shortened to 87 chars: `"AI-native ERP — 94 tools: invoicing, CRM, accounting, tax, banking, POS, fiscal & more."`

## Why this matters

Any `mcp-publisher publish` or registry re-submission (e.g. version bump on v2.0.0) would be rejected without this fix. Merge before submitting to Anthropic MCP Registry, Cursor, or OpenAI marketplaces.

## Wave Mature 3

Part of the Wave Mature 3 marketplace preparation sprint. Companion PR: `feat/wave-mature-3-marketplace-packages` adds the full marketplace submission packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)