### PR TITLE
feat(marketplace): Wave Mature 3 — submission packages for Cursor, OpenAI, Anthropic

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@
 
 ---
 
+## Distribution
+
+| Channel | Status | Install |
+|---------|--------|---------|
+| **npm** | Live | `npx @frihet/mcp-server` |
+| **Remote endpoint** | Live | `https://mcp.frihet.io/mcp` (zero install, OAuth or API key) |
+| **Smithery** | Live | [smithery.ai/server/frihet/frihet-mcp](https://smithery.ai/server/frihet/frihet-mcp) |
+| **MCP Registry** | Live | [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io/?q=io.frihet) |
+| **Cursor Marketplace** | Coming soon | [cursor.com/marketplace](https://cursor.com/marketplace) |
+| **ChatGPT Apps** | Coming soon | [chatgpt.com](https://chatgpt.com) |
+| **Anthropic Claude Directory** | Coming soon | [claude.ai/settings/connectors](https://claude.ai/settings/connectors) |
+
+---
+
 ## What is this
 
 An MCP server that connects your AI assistant to [Frihet](https://frihet.io). Create invoices by talking. Query expenses in natural language. Manage your entire business from your IDE.

--- a/marketplace/README.md
+++ b/marketplace/README.md
@@ -1,0 +1,79 @@
+# Marketplace Submission Packages
+
+> **DO NOT SUBMIT anything here without Viktor's explicit OK.**
+> Each `SUBMISSION.md` file is a complete, copy-paste-ready package — not a trigger to submit.
+
+Wave Mature 3 — prepared May 2026.
+
+---
+
+## Status
+
+| Marketplace | Package | Status | Priority |
+|-------------|---------|--------|----------|
+| Cursor Marketplace | `cursor/SUBMISSION.md` | Ready — submit first | HIGH |
+| OpenAI ChatGPT Apps | `openai/SUBMISSION.md` | Ready — submit second | HIGH |
+| Anthropic Claude Directory | `anthropic/SUBMISSION.md` | Ready — submit last (~2wk review) | HIGH |
+
+---
+
+## Recommended Submission Order
+
+**1. Cursor (submit first)**
+- Fastest review cycle, community-driven
+- Lower technical bar (no OAuth domain verification required)
+- Use as messaging test run before higher-stakes submissions
+- URL: https://cursor.com/marketplace/publish
+- Also submit in parallel to cursor.directory/mcp and mcpcursor.com (community directories, instant)
+
+**2. OpenAI ChatGPT Apps (submit second)**
+- Requires domain verification token deployed to Worker BEFORE submitting
+- OAuth must include `code_challenge_methods_supported: ["S256"]`
+- Test full OAuth flow in Developer Mode first
+- URL: https://chatgpt.com → Settings → Developer Mode → "Create App"
+
+**3. Anthropic Claude Directory (submit last)**
+- ~2 week review cycle
+- Strictest requirements: production-ready, full OAuth, tool annotations, privacy policy live
+- Requires `-beta` version dropped OR explicitly noted
+- URL: https://claude.ai/settings/connectors
+- Submission form: https://claude.com/docs/connectors/building/submission
+
+---
+
+## Pre-Submission Checklist (all three)
+
+- [ ] `https://mcp.frihet.io/mcp` reachable with valid MCP response
+- [ ] `server.json` description ≤ 100 chars (PR #fix/server-json-desc-100chars merged)
+- [ ] All 94 tools have `readOnlyHint` correctly set
+- [ ] `https://frihet.io/legal/privacy` live
+- [ ] `https://frihet.io/legal/terms` live
+- [ ] `https://docs.frihet.io/desarrolladores/mcp-server` live and public
+- [ ] Test account created at app.frihet.io with sample data
+- [ ] App icon 512×512 PNG exported from favicon.svg
+- [ ] Min 2 screenshots per marketplace prepared
+- [ ] OAuth redirect URIs updated for each marketplace's callback URL
+
+---
+
+## Assets
+
+All visual assets are documented in `assets/ASSETS.md`.
+No binary files are stored in this repo — assets live in `Frihet-Saas-Website/public/`.
+
+---
+
+## Also Relevant (already live or separate submissions)
+
+| Platform | Status | Action needed |
+|----------|--------|---------------|
+| Anthropic MCP Registry (`registry.modelcontextprotocol.io`) | LIVE — `io.frihet/erp` | Keep `server.json` updated on releases |
+| Smithery | LIVE — `smithery.ai/server/frihet/frihet-mcp` | Track install rate weekly |
+| npm | LIVE — `@frihet/mcp-server` v1.9.0-beta.1 | Bump to stable on v2.0.0 |
+| Glama / mcpservers.org | Not verified | Submit separately (15min) |
+| PulseMCP | Not verified | Submit separately (15min) |
+| mcp.so | Not verified | Submit separately (15min) |
+| LobeHub MCP | Not verified | Submit separately (15min) |
+| Docker MCP Catalog | Not submitted | Wave 4 (requires Dockerfile) |
+
+Full distribution roadmap: `../DISTRIBUTION-ROADMAP.md`

--- a/marketplace/anthropic/SUBMISSION.md
+++ b/marketplace/anthropic/SUBMISSION.md
@@ -1,0 +1,157 @@
+# Anthropic Claude Connectors Directory — Submission Package
+
+> **DO NOT SUBMIT — awaiting Viktor final OK.**
+> Review this document fully, verify all checklist items, then submit manually at the URL below.
+
+---
+
+## Target Store
+
+**Submission form:** https://claude.ai/settings/connectors (Claude.ai → Settings → Connectors → "Submit your connector")
+**Directory listing (post-approval):** https://claude.ai/settings/connectors
+**Announcement page:** https://www.anthropic.com/news/integrations
+**Docs:** https://claude.com/docs/connectors/building/submission
+**FAQ:** https://support.claude.com/en/articles/11596036-anthropic-connectors-directory-faq
+**Review timeline:** ~2 weeks
+
+---
+
+## Form Fields (exact names + limits)
+
+### Section 1 — Server Basics
+
+| Field | Max | Value |
+|-------|-----|-------|
+| Server name | 80 chars | `Frihet ERP` |
+| Short description | 80 chars | `AI-native ERP — invoicing, CRM, tax, banking, POS for Spain & EU.` |
+| Long description | 1,000 chars | See below |
+| Server identifier (MCP name) | — | `io.frihet/erp` |
+| Server URL (remote endpoint) | — | `https://mcp.frihet.io/mcp` |
+| npm package | — | `@frihet/mcp-server` |
+| Version | — | `1.9.0-beta.1` |
+| License | — | `MIT` |
+| GitHub repository | — | `https://github.com/Frihet-io/frihet-mcp` |
+| Homepage / docs | — | `https://docs.frihet.io/desarrolladores/mcp-server` |
+
+**Long description (copy-paste ready, 618 chars):**
+
+```
+Frihet MCP Server connects your AI assistant to Frihet ERP — the AI-native business platform for freelancers and SMEs in Spain and the EU.
+
+94 tools across 17 domains: invoices, expenses, clients, CRM, quotes, products, deposits, webhooks, e-invoicing (XRechnung, Factur-X, FatturaPA, PEPPOL, Facturae), banking, fiscal (Modelo 303/130/390/180/347), VeriFactu compliance, TicketBAI, vacation rentals (Stay), point-of-sale, time tracking, and recurring invoices.
+
+Zero install: connect via the remote endpoint at mcp.frihet.io with OAuth 2.0 + PKCE or API key. Also available as npm @frihet/mcp-server for local stdio use.
+```
+
+---
+
+### Section 2 — Authentication
+
+| Field | Value |
+|-------|-------|
+| Auth type | OAuth 2.0 + PKCE (primary) + API key Bearer (fallback) |
+| OAuth authorization URL | `https://mcp.frihet.io/oauth/authorize` |
+| OAuth token URL | `https://mcp.frihet.io/oauth/token` |
+| OAuth scopes | `read write` |
+| Required redirect URIs to allowlist | `https://claude.ai/api/mcp/auth_callback` AND `https://claude.com/api/mcp/auth_callback` |
+| API key env var (stdio) | `FRIHET_API_KEY` (format: `fri_*`) |
+| Account creation URL | `https://app.frihet.io` |
+
+---
+
+### Section 3 — Tools & Resources
+
+**Tool count:** 94 tools, 8 resources, 7 prompts
+
+**Domains covered:**
+- Invoices (6), Expenses (5), Clients (5), CRM/Contacts (3), CRM/Activities (2), CRM/Notes (3)
+- Products (5), Quotes (5), Deposits (7), Vendors (5), Webhooks (5)
+- E-Invoicing (4), Intelligence (4)
+- Banking (5), Fiscal — Modelo 303/130/390/180/347 + VeriFactu + TicketBAI (8)
+- Stay / Vacation Rentals (5), POS / Point-of-Sale (4)
+- Time Tracking (4), Recurring Invoices (2)
+
+**Tool annotations (all tools comply):**
+- Read-only tools (`list_*`, `get_*`, `search_*`): `readOnlyHint: true`
+- Write tools (`create_*`, `update_*`, `delete_*`): `readOnlyHint: false`, `destructiveHint` set where applicable
+- All tools return `outputSchema` — typed structured JSON, not prose
+
+---
+
+### Section 4 — Compliance & Privacy
+
+| Field | Value |
+|-------|-------|
+| Privacy policy URL | `https://frihet.io/legal/privacy` |
+| Terms of service URL | `https://frihet.io/legal/terms` |
+| Data residency | EU (europe-west1, Frankfurt) |
+| GDPR compliant | Yes — see privacy policy |
+| Data stored | Tool inputs/outputs are not stored server-side beyond the API request lifecycle |
+| Support email | `hola@frihet.io` |
+
+---
+
+### Section 5 — Documentation & Support
+
+| Field | Value |
+|-------|-------|
+| Documentation URL | `https://docs.frihet.io/desarrolladores/mcp-server` |
+| Setup guide | `https://docs.frihet.io/desarrolladores/mcp-server#install` |
+| Changelog | `https://github.com/Frihet-io/frihet-mcp/blob/main/CHANGELOG.md` |
+| GitHub issues | `https://github.com/Frihet-io/frihet-mcp/issues` |
+| Support email | `hola@frihet.io` |
+
+---
+
+### Section 6 — Branding & Assets
+
+| Asset | Path | Notes |
+|-------|------|-------|
+| Logo SVG (dark bg) | `~/Documents/frihet-mcp/assets/banner.svg` | Full banner |
+| Logo SVG (light bg) | `~/Documents/frihet-mcp/assets/banner-light.svg` | Full banner |
+| Logo square (for icon) | `~/Documents/Frihet-Saas-Website/public/favicon.svg` | Use as app icon |
+| Favicon 32×32 | `~/Documents/Frihet-Saas-Website/public/favicon-32x32.png` | — |
+| Favicon 16×16 | `~/Documents/Frihet-Saas-Website/public/favicon-16x16.png` | — |
+| OG / promo image | `~/Documents/Frihet-Saas-Website/public/banners/frihet-banner-dev-github.png` | Use for marketplace banner |
+| Dev-focused banner | `~/Documents/Frihet-Saas-Website/public/banners/frihet-banner-dev-twitter.png` | Social-sized promo |
+
+**Screenshots to prepare (not yet created — Viktor action required):**
+1. Claude Desktop / Claude Code: natural language invoice creation
+2. Claude: quarterly tax prep (`quarterly-tax-prep` prompt)
+3. Claude: client CRM activity log
+4. Claude: banking transactions + categorization
+
+---
+
+### Section 7 — Test Credentials (required by Anthropic reviewers)
+
+Viktor must create a dedicated test account before submission:
+- Account: create at `https://app.frihet.io` (free plan is sufficient)
+- API key: generate under **Settings > API**, format `fri_test_*`
+- Populate with: 2–3 test clients, 3–5 draft invoices, 5 sample expenses
+- Include in submission form under "Test account credentials"
+
+---
+
+## Verification Checklist
+
+Before submitting:
+
+- [ ] Server is publicly reachable: `curl -s https://mcp.frihet.io/mcp` returns valid MCP response
+- [ ] OAuth redirect URIs include both `https://claude.ai/api/mcp/auth_callback` AND `https://claude.com/api/mcp/auth_callback`
+- [ ] All 94 tools have `readOnlyHint` set correctly (verify in `src/tools/*.ts`)
+- [ ] Privacy policy page is live at `https://frihet.io/legal/privacy`
+- [ ] Documentation page is live and public at `https://docs.frihet.io/desarrolladores/mcp-server`
+- [ ] Test account created and credentials ready
+- [ ] Logo/icon assets prepared at required sizes (see Section 6)
+- [ ] Screenshots prepared (see Section 6)
+- [ ] `server.json` description is ≤ 100 chars (verified: 87 chars on branch `fix/server-json-desc-100chars`)
+- [ ] Version is stable (not `-beta`) before submitting to production directory, OR note beta status clearly
+
+---
+
+## Submission Order Recommendation
+
+Submit Anthropic **last** among the three marketplaces. Reason: 2-week review cycle + production-readiness requirement. Ship Cursor and OpenAI first (faster turnaround), then submit Anthropic once version is stable.
+
+See `../README.md` for full submission sequencing.

--- a/marketplace/assets/ASSETS.md
+++ b/marketplace/assets/ASSETS.md
@@ -1,0 +1,94 @@
+# Marketplace Assets — Index
+
+This directory documents the visual assets required for each marketplace submission.
+No binary files are stored here — all assets live in their canonical locations.
+Export/convert as needed before submitting.
+
+---
+
+## Canonical Asset Locations
+
+### Frihet MCP Repo (`~/Documents/frihet-mcp/`)
+
+| File | Description | Use |
+|------|-------------|-----|
+| `assets/banner.svg` | Full-width banner, dark background | GitHub README hero, dark-mode |
+| `assets/banner-light.svg` | Full-width banner, light background | GitHub README hero, light-mode |
+
+### Frihet Saas Website (`~/Documents/Frihet-Saas-Website/public/`)
+
+| File | Description | Dimensions | Use |
+|------|-------------|------------|-----|
+| `favicon.svg` | Frihet icon, monochrome | Vector | App icon for all marketplaces |
+| `favicon-32x32.png` | Frihet icon, PNG | 32×32 | Favicon, small icon slots |
+| `favicon-16x16.png` | Frihet icon, PNG | 16×16 | Favicon |
+| `apple-touch-icon.png` | Apple touch icon | 180×180 | Mobile icon |
+| `apple-touch-icon.svg` | Apple touch icon SVG | Vector | Mobile icon |
+| `banners/frihet-banner-dev-github.png` | Dev-focused banner | 1280×640 approx | GitHub, Cursor marketplace |
+| `banners/frihet-banner-dev-twitter.png` | Dev banner Twitter/X size | 1500×500 approx | Social promo |
+| `banners/frihet-banner-dev-bluesky.png` | Dev banner Bluesky size | — | Social promo |
+| `banners/frihet-banner-business-og.png` | Business-focused OG image | 1200×630 | OpenAI hero, OG tags |
+| `banners/frihet-banner-business-linkedin.png` | Business banner LinkedIn | 1200×627 approx | Business-focused listings |
+| `banners/frihet-banner-business-youtube.png` | YouTube thumbnail size | 1280×720 | Demo video thumbnail |
+
+---
+
+## Required Exports (Viktor action required before each submission)
+
+### Anthropic Directory
+
+- [ ] App icon PNG 512×512 — export `favicon.svg` → PNG
+- [ ] 4× screenshots (1200×800 minimum) — see `anthropic/SUBMISSION.md` Section 6
+
+### Cursor Marketplace
+
+- [ ] Plugin icon PNG 128×128 — export `favicon.svg` → PNG at 128×128
+- [ ] 3× screenshots — see `cursor/SUBMISSION.md` branding section
+
+### OpenAI ChatGPT Apps
+
+- [ ] App icon PNG 512×512 — export `favicon.svg` → PNG
+- [ ] 4× screenshots (1200×800 minimum) — see `openai/SUBMISSION.md` Section 5
+
+---
+
+## SVG → PNG Export (macOS one-liner)
+
+Requires `rsvg-convert` (Homebrew: `brew install librsvg`):
+
+```bash
+# 512×512 app icon
+rsvg-convert -w 512 -h 512 ~/Documents/Frihet-Saas-Website/public/favicon.svg \
+  > ~/Documents/frihet-mcp/marketplace/assets/frihet-icon-512.png
+
+# 128×128 Cursor plugin icon
+rsvg-convert -w 128 -h 128 ~/Documents/Frihet-Saas-Website/public/favicon.svg \
+  > ~/Documents/frihet-mcp/marketplace/assets/frihet-icon-128.png
+```
+
+Or use Inkscape / Figma / any SVG viewer if rsvg-convert is not available.
+
+---
+
+## Screenshots — Capture Guide
+
+All screenshots should show:
+- Dark terminal or editor UI (consistent with Frihet brand: #171717 background)
+- Real natural language input → structured response
+- No personal NIF/IBAN/email in test data
+
+Recommended capture tool: macOS Screenshot (`⌘⇧4`) + crop to 1200×800 or 1280×720.
+
+---
+
+## Demo Video Placeholder
+
+A demo video (optional but recommended for all three marketplaces) showing:
+1. Claude / ChatGPT / Cursor — "Create an invoice for [client], [items]"
+2. Invoice created → structured response shown
+3. "Show me unpaid invoices" → list appears
+4. "Prepare my quarterly taxes Q1 2026" → Modelo 303 breakdown
+
+Record with QuickTime or OBS. Upload to YouTube (unlisted) and reference the URL in submission forms.
+
+**Status:** Not yet recorded. Viktor to record post-submission prep.

--- a/marketplace/cursor/SUBMISSION.md
+++ b/marketplace/cursor/SUBMISSION.md
@@ -1,0 +1,190 @@
+# Cursor Marketplace — Submission Package
+
+> **DO NOT SUBMIT — awaiting Viktor final OK.**
+> Review this document fully, verify checklist items, then submit via the paths listed below.
+
+---
+
+## Target Store
+
+**Primary submission URL:** https://cursor.com/marketplace/publish
+**Marketplace listing (post-approval):** https://cursor.com/marketplace
+**Cursor plugin spec (GitHub):** https://github.com/cursor/plugins
+**Plugin template:** https://github.com/cursor/plugin-template
+**Blog / announcement:** https://cursor.com/blog/marketplace
+**Docs:** https://cursor.com/docs/plugins
+
+**Contact for submission:** Submit via the publish form, or email `kniparko@anysphere.com` with repo link and description.
+
+---
+
+## Context: Cursor Plugin Architecture
+
+Cursor plugins bundle primitives that agents use:
+- **MCP servers** — connect to external tools and APIs
+- **Skills** — domain-specific prompts and instructions
+- **Rules** — system-level instructions
+- **Subagents** — specialized parallel agents
+- **Hooks** — custom scripts for observing agent behavior
+
+A Frihet submission is primarily an **MCP server plugin** with an optional **Skill** bundled.
+
+---
+
+## Form Fields (cursor.com/marketplace/publish)
+
+| Field | Max | Value |
+|-------|-----|-------|
+| Plugin name | 60 chars | `Frihet ERP` |
+| Tagline / short description | 100 chars | `AI-native ERP — 94 tools for invoicing, CRM, tax & banking via natural language.` |
+| Long description | 2,000 chars | See below |
+| Category | — | `Finance & Accounting` (primary) / `Business Tools` (secondary) |
+| GitHub repository | — | `https://github.com/Frihet-io/frihet-mcp` |
+| Homepage | — | `https://frihet.io` |
+| Documentation URL | — | `https://docs.frihet.io/desarrolladores/mcp-server` |
+| npm package | — | `@frihet/mcp-server` |
+| Remote MCP URL | — | `https://mcp.frihet.io/mcp` |
+| License | — | `MIT` |
+| Contact email | — | `hola@frihet.io` |
+
+**Long description (copy-paste ready, 721 chars):**
+
+```
+Frihet MCP Server connects Cursor directly to your Frihet ERP account.
+
+Talk to your business in natural language from inside Cursor. Create invoices, log expenses, manage clients, check cash flow, prepare quarterly taxes — all without leaving the editor.
+
+94 tools across invoicing, CRM, products, quotes, expenses, banking, fiscal compliance (Modelo 303/130, VeriFactu, TicketBAI), e-invoicing (PEPPOL, XRechnung, FatturaPA), vacation rental management, point-of-sale, time tracking, and recurring invoices.
+
+Zero install — connect via the remote endpoint at mcp.frihet.io with OAuth or API key. Also available as npx @frihet/mcp-server for local stdio transport.
+
+Works with the free Frihet plan. Get an API key at app.frihet.io.
+```
+
+---
+
+## Cursor MCP Configuration (for .cursor/mcp.json)
+
+**Option A — Remote (zero install, recommended):**
+
+```json
+{
+  "mcpServers": {
+    "frihet": {
+      "type": "streamable-http",
+      "url": "https://mcp.frihet.io/mcp",
+      "headers": {
+        "Authorization": "Bearer fri_your_key_here"
+      }
+    }
+  }
+}
+```
+
+**Option B — Local stdio:**
+
+```json
+{
+  "mcpServers": {
+    "frihet": {
+      "command": "npx",
+      "args": ["-y", "@frihet/mcp-server"],
+      "env": {
+        "FRIHET_API_KEY": "fri_your_key_here"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Plugin Manifest (plugin.json — required for Cursor marketplace bundles)
+
+```json
+{
+  "name": "frihet-erp",
+  "version": "1.9.0-beta.1",
+  "displayName": "Frihet ERP",
+  "description": "AI-native ERP — 94 tools for invoicing, CRM, tax & banking via natural language.",
+  "icon": "https://frihet.io/favicon.svg",
+  "homepage": "https://frihet.io",
+  "repository": "https://github.com/Frihet-io/frihet-mcp",
+  "license": "MIT",
+  "categories": ["Finance & Accounting", "Business Tools"],
+  "mcp": {
+    "servers": [
+      {
+        "name": "frihet",
+        "transport": "streamable-http",
+        "url": "https://mcp.frihet.io/mcp",
+        "auth": {
+          "type": "bearer",
+          "env": "FRIHET_API_KEY"
+        }
+      }
+    ]
+  },
+  "skills": [
+    {
+      "name": "frihet",
+      "path": "./skill"
+    }
+  ]
+}
+```
+
+> Note: The `skill/` directory already exists in the repo at `~/Documents/frihet-mcp/skill/`. Bundle it with the plugin manifest.
+
+---
+
+## Branding & Assets
+
+| Asset | Path | Notes |
+|-------|------|-------|
+| Plugin icon (SVG) | `~/Documents/Frihet-Saas-Website/public/favicon.svg` | Monochrome preferred |
+| Plugin icon (PNG 128×128) | `~/Documents/Frihet-Saas-Website/public/favicon-32x32.png` | Upscale to 128×128 for submission |
+| Banner image | `~/Documents/Frihet-Saas-Website/public/banners/frihet-banner-dev-github.png` | 1280×640 dev-focused |
+| Dev banner (Twitter/X size) | `~/Documents/Frihet-Saas-Website/public/banners/frihet-banner-dev-twitter.png` | 1500×500 |
+| Bluesky banner | `~/Documents/Frihet-Saas-Website/public/banners/frihet-banner-dev-bluesky.png` | — |
+
+**Screenshots to prepare (Viktor action required):**
+1. Cursor agent: `"Create an invoice for Acme SL, 10h consulting at 95/h"` → invoice created response
+2. Cursor agent: `"Show me all overdue invoices"` → structured list
+3. Cursor agent: `"What's my quarterly tax liability for Q1 2026?"` → Modelo 303 breakdown
+
+---
+
+## Alternative: cursor.directory Listing
+
+In addition to the official Cursor Marketplace, also submit to:
+- **cursor.directory/mcp**: Community-curated MCP server directory for Cursor users
+  - URL: https://cursor.directory/mcp
+  - Process: Submit via the site's "Add server" form
+- **MCPCursor**: https://mcpcursor.com — submit via website
+
+These are independent community directories and can be submitted **before** the official marketplace.
+
+---
+
+## Verification Checklist
+
+Before submitting:
+
+- [ ] `https://mcp.frihet.io/mcp` is reachable (returns MCP protocol response)
+- [ ] `plugin.json` created in repo root or `marketplace/cursor/plugin.json` (copy template above)
+- [ ] Skill directory (`skill/`) is present and functional: `ls ~/Documents/frihet-mcp/skill/`
+- [ ] npm package `@frihet/mcp-server` is latest published version
+- [ ] Icon at `https://frihet.io/favicon.svg` returns valid SVG
+- [ ] Screenshots prepared (min 2, max 5)
+- [ ] No beta version in plugin.json displayName unless explicitly noted
+- [ ] Email `hola@frihet.io` is monitored for Cursor review communications
+- [ ] README includes Cursor-specific install badge and `.cursor/mcp.json` config snippet (already in main README)
+
+---
+
+## Submission Order Recommendation
+
+Submit Cursor **first** — fastest review cycle, community-driven, lower bar than Anthropic. Use as a test run for messaging before Anthropic review.
+
+See `../README.md` for full submission sequencing.

--- a/marketplace/openai/SUBMISSION.md
+++ b/marketplace/openai/SUBMISSION.md
@@ -1,0 +1,190 @@
+# OpenAI ChatGPT Apps Marketplace — Submission Package
+
+> **DO NOT SUBMIT — awaiting Viktor final OK.**
+> Review this document fully, verify all checklist items (especially domain verification), then submit manually via ChatGPT Developer Mode.
+
+---
+
+## Target Store
+
+**Developer Mode (build & test):** https://chatgpt.com (Settings → Developer Mode → "Create App")
+**Submission flow:** https://developers.openai.com/apps-sdk/deploy/submission
+**MCP docs:** https://developers.openai.com/api/docs/mcp
+**Auth docs:** https://developers.openai.com/apps-sdk/build/auth
+**Help Center:** https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt-beta
+
+**Note:** As of December 17, 2025, OpenAI renamed "connectors" to "apps". Existing functionality unchanged.
+
+---
+
+## Form Fields
+
+### Section 1 — App Basics
+
+| Field | Max | Value |
+|-------|-----|-------|
+| App name | 60 chars | `Frihet ERP` |
+| Short description (tagline) | 120 chars | `Create invoices, manage clients, and handle Spanish tax compliance through ChatGPT — 94 tools, zero install.` |
+| Long description | 2,000 chars | See below |
+| Category | — | `Finance & Accounting` |
+| App icon URL | — | `https://frihet.io/favicon.svg` |
+| Homepage | — | `https://frihet.io` |
+| Developer name | — | `BRTHLS / Viktor` |
+| Developer email | — | `hola@frihet.io` |
+| Privacy policy URL | — | `https://frihet.io/legal/privacy` |
+| Terms of service URL | — | `https://frihet.io/legal/terms` |
+| Support URL | — | `https://docs.frihet.io/desarrolladores/mcp-server` |
+
+**Long description (copy-paste ready, 814 chars):**
+
+```
+Frihet ERP connects ChatGPT directly to your business data.
+
+Create invoices by describing what you sold. Log expenses in plain language. Check your cash position. Prepare quarterly tax filings. All from inside ChatGPT — no forms, no dashboards, just conversation.
+
+94 tools across every business domain: invoices, expenses, clients, CRM, products, quotes, deposits, banking (accounts + transactions + reconciliation), fiscal compliance for Spain (Modelo 303, 130, 390, 180, 347), VeriFactu real-time invoice signing, TicketBAI, e-invoicing in 7 formats (PEPPOL, XRechnung, FatturaPA, Factur-X, Facturae, UBL, CII), vacation rental management, point-of-sale, time tracking, and recurring invoices.
+
+Connect via OAuth 2.0 in seconds — no API key required. Get a free Frihet account at app.frihet.io.
+
+First official AI-native MCP server for a Spanish ERP.
+```
+
+---
+
+### Section 2 — MCP Server Configuration
+
+| Field | Value |
+|-------|-------|
+| MCP server URL | `https://mcp.frihet.io/mcp` |
+| Transport type | `streamable-http` |
+| Authentication type | OAuth 2.0 + PKCE |
+| Authorization endpoint | `https://mcp.frihet.io/oauth/authorize` |
+| Token endpoint | `https://mcp.frihet.io/oauth/token` |
+| Scopes | `read write` |
+
+**Required: Add OpenAI's redirect URI to your OAuth config before submitting.**
+OpenAI's callback URL (exact value provided during submission — add it alongside existing claude.ai callbacks).
+
+---
+
+### Section 3 — Domain Verification
+
+OpenAI verifies domain ownership before publishing. The verification flow:
+
+1. OpenAI provides a token (e.g., `abc123xyz789`) during submission
+2. You must serve it at: `GET https://mcp.frihet.io/.well-known/openai-apps-challenge`
+3. Response must be **plain text** (not JSON, not HTML) — just the token string
+4. OpenAI pings immediately on form submission — deploy the file BEFORE clicking submit
+
+**Current `.well-known` routes on `mcp.frihet.io` Worker:**
+
+The Worker already serves `.well-known/mcp`, `.well-known/ai.txt`. Add `openai-apps-challenge` route BEFORE submitting:
+
+```typescript
+// In the Cloudflare Worker (wrangler.toml / src/index.ts), add:
+if (url.pathname === '/.well-known/openai-apps-challenge') {
+  return new Response('OPENAI_TOKEN_GOES_HERE', {
+    headers: { 'Content-Type': 'text/plain' }
+  });
+}
+```
+
+Replace `OPENAI_TOKEN_GOES_HERE` with the actual token OpenAI provides during submission. Deploy to Cloudflare before clicking submit.
+
+**Alternative:** If `mcp.frihet.io` serves from a subpath (e.g., `/mcp`), OpenAI's domain verification may require the challenge at the root domain. Note: OpenAI has a known limitation with subpath-hosted servers — file a support request if domain verification fails.
+Reference: https://community.openai.com/t/chatgpt-app-submissions-domain-verification-step-does-not-support-subpath-hosted-mcp-servers/1379021
+
+---
+
+### Section 4 — OAuth Technical Requirements
+
+OpenAI enforces strict OAuth 2.1 compliance. Verify before submitting:
+
+**Required in authorization server metadata (`/.well-known/oauth-authorization-server`):**
+```json
+{
+  "code_challenge_methods_supported": ["S256"],
+  "response_types_supported": ["code"],
+  "grant_types_supported": ["authorization_code"],
+  "token_endpoint_auth_methods_supported": ["none"]
+}
+```
+
+**Critical:** If `code_challenge_methods_supported` is missing or doesn't include `S256`, ChatGPT will reject the OAuth flow with "unsupported OAuth config type". This is a hard block.
+
+**OpenAI's OAuth state parameter** is 400+ chars of base64-encoded JSON. Ensure the OAuth state handler on `mcp.frihet.io` accepts long state values (no length truncation).
+
+---
+
+### Section 5 — Branding & Assets
+
+| Asset | Path | Notes |
+|-------|------|-------|
+| App icon (512×512 PNG) | `~/Documents/Frihet-Saas-Website/public/favicon.svg` | Export to PNG 512×512 |
+| Hero image (1280×720) | `~/Documents/Frihet-Saas-Website/public/banners/frihet-banner-business-og.png` | Business-focused |
+| LinkedIn banner | `~/Documents/Frihet-Saas-Website/public/banners/frihet-banner-business-linkedin.png` | Business audience |
+
+**Screenshots to prepare (Viktor action required):**
+1. ChatGPT: `"Show me all unpaid invoices"` → structured table response
+2. ChatGPT: `"Create an invoice for Acme SL, 5 hours consulting at 100/h"` → invoice created
+3. ChatGPT: `"What's my tax liability for Q1 2026 — Modelo 303?"` → fiscal breakdown
+4. ChatGPT: `"Log a 89 EUR expense for Adobe CC, category software"` → expense logged
+
+---
+
+### Section 6 — Compliance & Privacy
+
+| Field | Value |
+|-------|-------|
+| Data storage | Per-request only — no persistent storage of user data server-side |
+| Data residency | EU (europe-west1) |
+| GDPR | Yes — see `https://frihet.io/legal/privacy` |
+| PII handling | API key / Bearer token transmitted in headers only. No PII logged. |
+| EU users | Yes — primary market (Spain + EU) |
+
+---
+
+## Test Account (required for OpenAI review)
+
+OpenAI reviewers will test the app end-to-end using OAuth flow:
+- Create a test account at `https://app.frihet.io`
+- Ensure it has: 2–3 clients, 3–5 invoices (mix of paid/unpaid/overdue), 5 expenses
+- Include credentials in the submission form under "Test account"
+
+---
+
+## Verification Checklist
+
+Before submitting:
+
+- [ ] `https://mcp.frihet.io/mcp` is reachable with valid MCP response
+- [ ] OAuth metadata at `https://mcp.frihet.io/.well-known/oauth-authorization-server` includes `code_challenge_methods_supported: ["S256"]`
+- [ ] `/.well-known/openai-apps-challenge` route added to Worker (deploy BEFORE submitting)
+- [ ] OpenAI redirect URI added to OAuth allowlist (exact URI provided by OpenAI during submission)
+- [ ] OAuth state parameter handler accepts strings of 400+ chars (no truncation)
+- [ ] Privacy policy live at `https://frihet.io/legal/privacy`
+- [ ] Terms of service live at `https://frihet.io/legal/terms`
+- [ ] App icon (512×512 PNG) prepared from `favicon.svg`
+- [ ] Screenshots prepared (min 2)
+- [ ] Test account created and credentials ready
+- [ ] Worker deployed with domain verification token BEFORE clicking submit
+
+---
+
+## Pre-Submission Testing in Developer Mode
+
+Test the full flow in ChatGPT before submitting:
+1. Go to https://chatgpt.com → Settings → Developer Mode → "Create App"
+2. Paste MCP URL: `https://mcp.frihet.io/mcp`
+3. Complete OAuth flow (should redirect to `mcp.frihet.io/oauth/authorize` → Frihet login → back to ChatGPT)
+4. Test 5 representative tools: `list_invoices`, `create_invoice`, `list_expenses`, `get_business_context`, `get_quarterly_taxes`
+5. Verify structured JSON responses, not prose
+6. Only submit after all 5 pass
+
+---
+
+## Submission Order Recommendation
+
+Submit OpenAI **second** — after Cursor (faster, lower bar) but before Anthropic (longest review). OAuth domain verification adds complexity; allow 1–2 days for preparation.
+
+See `../README.md` for full submission sequencing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@frihet/mcp-server",
-  "version": "1.7.0-beta.1",
+  "version": "1.9.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@frihet/mcp-server",
-      "version": "1.7.0-beta.1",
+      "version": "1.9.0-beta.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

- Adds `marketplace/` directory with copy-paste-ready submission packages for three AI marketplaces
- Updates `README.md` with a Distribution section listing all active + upcoming channels

## What's included

| File | Contents |
|------|----------|
| `marketplace/README.md` | Index + submission order (Cursor → OpenAI → Anthropic) + status table |
| `marketplace/anthropic/SUBMISSION.md` | Claude Connectors Directory — all form fields, OAuth redirect URIs, tool annotations checklist, asset refs, test account guidance |
| `marketplace/cursor/SUBMISSION.md` | Cursor Marketplace — plugin.json template, MCP config snippets, cursor.directory alternative, asset refs |
| `marketplace/openai/SUBMISSION.md` | ChatGPT Apps — domain verification protocol, OAuth 2.1 PKCE requirements, Worker deployment steps, test account |
| `marketplace/assets/ASSETS.md` | Asset index pointing to canonical locations in Frihet-Saas-Website/public/, export commands, screenshot guide |

## Quality gates

- `npm run build` — clean
- `npm test` — 136/136 pass
- No binary assets committed
- No auto-submissions triggered

## Wave Mature 3

Depends on PR #18 (`fix/server-json-desc-100chars`) — merge that first, then merge this.

> All SUBMISSION.md files contain "DO NOT SUBMIT — awaiting Viktor final OK" at top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)