### PR TITLE
feat(gestoria): 5 MCP tools — messaging, bulk send, consolidated aging (Wave Fase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to `@frihet/mcp-server` are documented here.
 
+## [1.10.0-beta.3] — 2026-05-11
+
+### Added
+
+- **Wave Fase 1 — Gestoria (5 tools)**: surface accountant workflows to AI assistants.
+  - `gestoria_message_send` — send a message in a contextual thread between gestor and client (parent: documentRequest, filingItem, or obligation).
+  - `gestoria_messages_list` — paginate a thread newest-first using `before` cursor; returns `hasMore` flag.
+  - `gestoria_template_create` — create a reusable document request template (title, description, due-date offset, attachment requirement, variables).
+  - `gestoria_template_bulk_send` — bulk send a template to up to 500 client workspaces; honours `allowGestoriaCommunications=false` opt-out (RGPD). Maps to Frihet-ERP callable `gestoriaBulkSendRequests` (PR #383).
+  - `gestoria_aging_consolidated` — cross-client AR aging report with totals by bucket (current / 30-60 / 60-90 / 90+), per-workspace breakdown, and top overdue invoices. Defaults to authenticated gestor.
+- 6 new output schemas in `shared.ts`: `gestoriaMessageItemOutput`, `gestoriaMessageSendResultOutput`, `gestoriaTemplateItemOutput`, `gestoriaTemplateCreateResultOutput`, `gestoriaBulkSendResultOutput`, `gestoriaAgingConsolidatedOutput`.
+- 5 new interface methods in `IFrihetClient` + HTTP implementations in `FrihetClient`.
+
+### Changed
+
+- Total tool count: 106 → **111 tools**.
+- Bumped `package.json` version to `1.10.0-beta.3`; aligned `server.json` description and version.
+- Updated README badge, hero copy, and tools section with new Gestoria family.
+
+### Notes
+
+- ERP backend REST routes `/v1/gestoria/*` are planned and will proxy the corresponding Firebase callables (eu-west1) + Firestore reads. Tools are wired now and will surface 404 errors until the REST shell ships in Frihet-ERP Wave Fase 1 closure (PRs #383 merged, #384 + #385 pending).
+- App Check is required (mcp.frihet.io worker is App Check enforced).
+- No new tests in this beta — REST surface arrives with Wave Fase 1; unit-level coverage will land alongside the test suite that mocks the new endpoints (parity with team / recurring families).
+
+---
+
 ## [1.9.0-beta.1] — 2026-05-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Claude:  Done. Invoice INV-2026-089 created. Total: 3,000.00 EUR + 21% IVA = 3,6
 
 111 tools. 8 resources. 7 prompts. Structured output on every tool. Zero boilerplate.
 
-<!-- v1.10.0-beta.1 — Wave Mature 3 Track F: Time (6) + Recurring (8) + Team (4) = 111 tools total -->
+<!-- v1.10.0-beta.3 — Wave Fase 1 Gestoria: messaging + bulk send + consolidated aging (5) = 111 tools total -->
 
 ---
 
@@ -348,6 +348,18 @@ If you need to digitize paper invoices or receipts, extract the data first (e.g.
 | `invite_team_member` | Invite a new member by email with role (admin/member/viewer) |
 | `update_team_member_role` | Change an existing member's role |
 | `remove_team_member` | Remove a member from the workspace (confirm=true required) |
+
+### Gestoria — Accountants (5)
+
+> **Status: stub** — `/v1/gestoria/*` REST surface lands with Wave Fase 1 closure (PRs #383 bulk send, #384 aging, #385 messaging). Tools surface 404 until the backend ships.
+
+| Tool | What it does |
+|------|-------------|
+| `gestoria_message_send` | Send a message in a contextual thread (documentRequest / filingItem / obligation) |
+| `gestoria_messages_list` | List messages in a thread, newest first; paginate backwards with `before` |
+| `gestoria_template_create` | Create a reusable document request template with variables + due-date offset |
+| `gestoria_template_bulk_send` | Bulk send a template to up to 500 client workspaces in one call |
+| `gestoria_aging_consolidated` | Cross-client AR aging report (buckets, per-workspace breakdown, top overdue) |
 
 All 111 tools return **structured output** via `outputSchema` -- typed JSON, not raw text. List tools return paginated results (`{ data, total, limit, offset }`).
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@frihet/mcp-server",
-  "version": "1.10.0-beta.2",
-  "description": "AI-native MCP server for business management — invoices, expenses, deposits, clients, products, quotes, webhooks, CRM, e-invoicing, vacation rentals, POS, banking, fiscal (Modelo 303/130/390/180/347, VeriFactu, TicketBAI), time tracking, recurring invoices, team management. 111 tools. Remote endpoint at mcp.frihet.io (zero install). Works with Claude, Cursor, Windsurf, Cline.",
+  "version": "1.10.0-beta.3",
+  "description": "AI-native MCP server for business management — invoices, expenses, deposits, clients, products, quotes, webhooks, CRM, e-invoicing, vacation rentals, POS, banking, fiscal (Modelo 303/130/390/180/347, VeriFactu, TicketBAI), time tracking, recurring invoices, team management, gestoria (accountant messaging + bulk send + consolidated aging). 111 tools. Remote endpoint at mcp.frihet.io (zero install). Works with Claude, Cursor, Windsurf, Cline.",
   "type": "module",
   "main": "./dist/index.js",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -2,17 +2,17 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.frihet/erp",
   "title": "Frihet ERP",
-  "description": "AI-native ERP — 111 tools: invoices, CRM, tax, banking, POS, rentals, time, recurring & team.",
+  "description": "AI-native ERP — 111 tools: invoicing, CRM, tax, banking, POS, rentals, time, team, gestoria.",
   "repository": {
     "url": "https://github.com/Frihet-io/frihet-mcp",
     "source": "github"
   },
-  "version": "1.10.0-beta.1",
+  "version": "1.10.0-beta.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@frihet/mcp-server",
-      "version": "1.10.0-beta.1",
+      "version": "1.10.0-beta.3",
       "transport": {
         "type": "stdio"
       }

--- a/src/client-interface.ts
+++ b/src/client-interface.ts
@@ -153,4 +153,35 @@ export interface IFrihetClient {
   inviteTeamMember(data: { email: string; role: string; name?: string }): Promise<Record<string, unknown>>;
   updateTeamMemberRole(memberId: string, role: string): Promise<Record<string, unknown>>;
   removeTeamMember(memberId: string): Promise<void>;
+
+  // Gestoria endpoints (/v1/gestoria/*) — Wave Fase 1 surface for accountants.
+  // Backend lands with Frihet-ERP PRs #383 (bulk send), #384 (aging), #385
+  // (messaging). REST routes will proxy callables + Firestore reads.
+  sendGestoriaMessage(data: {
+    workspaceId: string;
+    parentType: "documentRequest" | "filingItem" | "obligation";
+    parentId: string;
+    body: string;
+  }): Promise<Record<string, unknown>>;
+  listGestoriaMessages(params: {
+    workspaceId: string;
+    parentType: "documentRequest" | "filingItem" | "obligation";
+    parentId: string;
+    limit?: number;
+    before?: string;
+  }): Promise<{ messages: Array<Record<string, unknown>>; hasMore: boolean }>;
+  createGestoriaTemplate(data: {
+    name: string;
+    title: string;
+    description: string;
+    dueDateOffsetDays: number;
+    attachmentRequired?: boolean;
+    variables?: Array<{ key: string; label?: string; defaultValue?: string }>;
+  }): Promise<{ templateId: string }>;
+  bulkSendGestoriaTemplate(data: {
+    templateId: string;
+    clientWorkspaceIds: string[];
+    periodOverrides?: { quarter?: string | number; year?: string | number; month?: string | number };
+  }): Promise<Record<string, unknown>>;
+  getGestoriaAgingConsolidated(params?: { ownerUid?: string }): Promise<Record<string, unknown>>;
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -923,4 +923,60 @@ export class FrihetClient {
   async removeTeamMember(memberId: string): Promise<void> {
     return this.request("DELETE", `/team/members/${encodeURIComponent(memberId)}`);
   }
+
+  // ---------------------------------------------------------------- Gestoria (Wave Fase 1)
+  // Backend: /v1/gestoria/* endpoints land with Frihet-ERP Wave Fase 1 closure.
+  // PRs: #383 gestoriaBulkSendRequests callable (live), #384 aging consolidated,
+  // #385 contextual messaging. REST shell proxies the callables + Firestore reads.
+  // Tools surface 404 until backend ships.
+
+  async sendGestoriaMessage(data: {
+    workspaceId: string;
+    parentType: "documentRequest" | "filingItem" | "obligation";
+    parentId: string;
+    body: string;
+  }): Promise<Record<string, unknown>> {
+    return this.request("POST", "/gestoria/messages", data);
+  }
+
+  async listGestoriaMessages(params: {
+    workspaceId: string;
+    parentType: "documentRequest" | "filingItem" | "obligation";
+    parentId: string;
+    limit?: number;
+    before?: string;
+  }): Promise<{ messages: Array<Record<string, unknown>>; hasMore: boolean }> {
+    return this.request("GET", "/gestoria/messages", undefined, {
+      workspaceId: params.workspaceId,
+      parentType: params.parentType,
+      parentId: params.parentId,
+      limit: params.limit,
+      before: params.before,
+    });
+  }
+
+  async createGestoriaTemplate(data: {
+    name: string;
+    title: string;
+    description: string;
+    dueDateOffsetDays: number;
+    attachmentRequired?: boolean;
+    variables?: Array<{ key: string; label?: string; defaultValue?: string }>;
+  }): Promise<{ templateId: string }> {
+    return this.request("POST", "/gestoria/templates", data);
+  }
+
+  async bulkSendGestoriaTemplate(data: {
+    templateId: string;
+    clientWorkspaceIds: string[];
+    periodOverrides?: { quarter?: string | number; year?: string | number; month?: string | number };
+  }): Promise<Record<string, unknown>> {
+    return this.request("POST", "/gestoria/templates/bulk-send", data);
+  }
+
+  async getGestoriaAgingConsolidated(params?: { ownerUid?: string }): Promise<Record<string, unknown>> {
+    return this.request("GET", "/gestoria/aging/consolidated", undefined, {
+      ownerUid: params?.ownerUid,
+    });
+  }
 }

--- a/src/tools/gestoria.ts
+++ b/src/tools/gestoria.ts
@@ -1,0 +1,316 @@
+/**
+ * Gestoria (accountant) tools for the Frihet MCP server — Wave Fase 1 (5 tools).
+ *
+ * Tools:
+ *   1. gestoria_message_send          — send a message in a contextual thread
+ *   2. gestoria_messages_list         — list messages in a thread (paged backwards)
+ *   3. gestoria_template_create       — create a document request template
+ *   4. gestoria_template_bulk_send    — bulk send template to N client workspaces
+ *   5. gestoria_aging_consolidated    — cross-client AR aging report
+ *
+ * REST surface: /v1/gestoria/*
+ *
+ * Backend status (post-Wave Fase 1, May 2026):
+ *   - Frihet-ERP PR #383 — `gestoriaBulkSendRequests` callable (eu-west1) MERGED.
+ *   - Frihet-ERP PR #384 — consolidated AR aging tab (branch live, await merge).
+ *   - Frihet-ERP PR #385 — contextual messaging (branch live, await merge).
+ *
+ * The MCP layer talks REST (`api.frihet.io/v1/gestoria/*`). The REST shell
+ * proxies to Firebase callables + Firestore reads. Until the REST shell ships,
+ * tools will surface 404 errors with clear messages — clients can retry post-deploy.
+ *
+ * App Check: mcp.frihet.io worker is App Check enforced. Region: callables
+ * auto-resolve eu-west1 via existing client routing.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod/v4";
+import type { IFrihetClient } from "../client-interface.js";
+import {
+  withToolLogging,
+  formatRecord,
+  listContent,
+  getContent,
+  mutateContent,
+  READ_ONLY_ANNOTATIONS,
+  CREATE_ANNOTATIONS,
+  gestoriaMessageItemOutput,
+  gestoriaMessageSendResultOutput,
+  gestoriaTemplateCreateResultOutput,
+  gestoriaBulkSendResultOutput,
+  gestoriaAgingConsolidatedOutput,
+} from "./shared.js";
+
+const PARENT_TYPE = z
+  .enum(["documentRequest", "filingItem", "obligation"])
+  .describe(
+    "Thread parent kind / Tipo de hilo: documentRequest (solicitud de documento), filingItem (presentacion fiscal), obligation (obligacion fiscal)",
+  );
+
+const TEMPLATE_VARIABLE = z.object({
+  key: z.string().describe("Variable placeholder key, e.g. 'quarter' / Clave variable, p.ej. 'trimestre'"),
+  label: z.string().optional().describe("Human label shown in template editor / Etiqueta legible"),
+  defaultValue: z.string().optional().describe("Fallback value if no override supplied / Valor por defecto"),
+});
+
+const PERIOD_OVERRIDES = z
+  .object({
+    quarter: z.union([z.string(), z.number()]).optional(),
+    year: z.union([z.string(), z.number()]).optional(),
+    month: z.union([z.string(), z.number()]).optional(),
+  })
+  .optional()
+  .describe(
+    "Override template period variables in the bulk send / Sobrescribir variables de periodo (trimestre, ano, mes)",
+  );
+
+export function registerGestoriaTools(server: McpServer, client: IFrihetClient): void {
+  // -- gestoria_message_send ------------------------------------------------
+
+  server.registerTool(
+    "gestoria_message_send",
+    {
+      title: "Send Gestoria Message",
+      description:
+        "Send a message in a contextual thread between a gestor (accountant) and a client. " +
+        "Threads attach to a document request, a filing item, or a fiscal obligation — " +
+        "context is preserved so both sides see what the message is about. " +
+        "Useful for chasing a missing document, replying to a client's question, or " +
+        "annotating a presentation. " +
+        "Example: workspaceId='ws_abc', parentType='documentRequest', parentId='dr_q3_iva', body='Falta el extracto bancario de septiembre'. " +
+        "/ Envia un mensaje en un hilo contextual entre gestor y cliente. " +
+        "Los hilos se anclan a una solicitud de documento, presentacion o obligacion fiscal — " +
+        "ambas partes ven a que se refiere. Util para pedir documentos, responder dudas o anotar presentaciones.",
+      annotations: CREATE_ANNOTATIONS,
+      inputSchema: {
+        workspaceId: z
+          .string()
+          .min(1)
+          .describe("Client workspace ID the thread belongs to / ID del espacio de trabajo del cliente"),
+        parentType: PARENT_TYPE,
+        parentId: z.string().min(1).describe("ID of the parent entity (document request / filing item / obligation) / ID de la entidad padre"),
+        body: z
+          .string()
+          .min(1)
+          .max(4000)
+          .describe("Message body (plain text, 1-4000 chars) / Cuerpo del mensaje (texto plano)"),
+      },
+      outputSchema: gestoriaMessageSendResultOutput,
+    },
+    async ({ workspaceId, parentType, parentId, body }) =>
+      withToolLogging("gestoria_message_send", async () => {
+        const result = await client.sendGestoriaMessage({ workspaceId, parentType, parentId, body });
+        return {
+          content: [mutateContent(formatRecord("Message sent", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+  );
+
+  // -- gestoria_messages_list -----------------------------------------------
+
+  server.registerTool(
+    "gestoria_messages_list",
+    {
+      title: "List Gestoria Messages",
+      description:
+        "List messages in a contextual gestor/cliente thread, newest first. " +
+        "Use `before` (message ID or ISO timestamp) to paginate backwards through history. " +
+        "Returns up to `limit` messages plus a `hasMore` flag so the agent knows when to stop. " +
+        "/ Lista los mensajes de un hilo gestor/cliente, mas recientes primero. " +
+        "Usa `before` (ID o fecha) para paginar hacia atras. Devuelve hasta `limit` mensajes con flag `hasMore`.",
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        workspaceId: z.string().min(1).describe("Client workspace ID / ID del espacio de trabajo"),
+        parentType: PARENT_TYPE,
+        parentId: z.string().min(1).describe("ID of the parent entity / ID de la entidad padre"),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe("Max messages to return (1-100, default 50) / Mensajes maximos"),
+        before: z
+          .string()
+          .optional()
+          .describe("Cursor: messages older than this (message ID or ISO date) / Cursor: mensajes anteriores a este"),
+      },
+      outputSchema: z.object({
+        messages: z.array(gestoriaMessageItemOutput),
+        hasMore: z.boolean(),
+      }),
+    },
+    async ({ workspaceId, parentType, parentId, limit, before }) =>
+      withToolLogging("gestoria_messages_list", async () => {
+        const result = await client.listGestoriaMessages({
+          workspaceId,
+          parentType,
+          parentId,
+          limit,
+          before,
+        });
+        const count = Array.isArray(result.messages) ? result.messages.length : 0;
+        return {
+          content: [
+            listContent(
+              `Loaded ${count} message${count === 1 ? "" : "s"} for ${parentType}:${parentId}` +
+                (result.hasMore ? " (more available — paginate with `before`)" : ""),
+            ),
+          ],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+  );
+
+  // -- gestoria_template_create ---------------------------------------------
+
+  server.registerTool(
+    "gestoria_template_create",
+    {
+      title: "Create Gestoria Template",
+      description:
+        "Create a reusable document request template that the gestor can bulk-send to many " +
+        "client workspaces. Template body supports plain-text variable interpolation " +
+        "(e.g. `{{quarter}}`, `{{year}}`). `dueDateOffsetDays` sets when the request is due " +
+        "relative to the bulk-send date. `attachmentRequired=true` enforces clients to upload " +
+        "a file before marking complete. " +
+        "Example: name='IVA trimestral', title='Documentacion IVA {{quarter}}/{{year}}', " +
+        "description='Adjunta extractos bancarios y facturas emitidas del {{quarter}}', " +
+        "dueDateOffsetDays=14, attachmentRequired=true. " +
+        "/ Crea una plantilla de solicitud de documento reutilizable que el gestor puede enviar en masa a varios espacios cliente.",
+      annotations: CREATE_ANNOTATIONS,
+      inputSchema: {
+        name: z
+          .string()
+          .min(1)
+          .max(120)
+          .describe("Internal template name (shown to gestor only) / Nombre interno"),
+        title: z
+          .string()
+          .min(1)
+          .max(200)
+          .describe("Title rendered to the client (supports {{variables}}) / Titulo visible al cliente"),
+        description: z
+          .string()
+          .min(1)
+          .max(4000)
+          .describe("Description / instructions for the client (supports {{variables}}) / Descripcion e instrucciones"),
+        dueDateOffsetDays: z
+          .number()
+          .int()
+          .min(0)
+          .max(365)
+          .describe("Days from send until due (0-365) / Dias desde envio hasta vencimiento"),
+        attachmentRequired: z
+          .boolean()
+          .optional()
+          .describe("Require an uploaded file before completion (default: false) / Requiere archivo"),
+        variables: z
+          .array(TEMPLATE_VARIABLE)
+          .optional()
+          .describe("Variable definitions for interpolation / Definiciones de variables"),
+      },
+      outputSchema: gestoriaTemplateCreateResultOutput,
+    },
+    async ({ name, title, description, dueDateOffsetDays, attachmentRequired, variables }) =>
+      withToolLogging("gestoria_template_create", async () => {
+        const result = await client.createGestoriaTemplate({
+          name,
+          title,
+          description,
+          dueDateOffsetDays,
+          attachmentRequired,
+          variables,
+        });
+        return {
+          content: [mutateContent(formatRecord("Template created", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+  );
+
+  // -- gestoria_template_bulk_send ------------------------------------------
+
+  server.registerTool(
+    "gestoria_template_bulk_send",
+    {
+      title: "Bulk Send Gestoria Template",
+      description:
+        "Send the same document request template to up to 500 client workspaces in one call. " +
+        "Each spawned request triggers the per-client notification handler (email + in-app). " +
+        "Honours `allowGestoriaCommunications=false` on the client user doc (opt-out). " +
+        "Uses `periodOverrides` to plug runtime values (quarter/year/month) into template variables. " +
+        "Returns a per-client outcome with success count, failures, and total wall-clock duration. " +
+        "Trust Area: RGPD — recipients must already have granted accountant access. " +
+        "Example: templateId='tpl_iva_q', clientWorkspaceIds=['ws_a','ws_b','ws_c'], periodOverrides={quarter:3, year:2026}. " +
+        "/ Envia la misma plantilla a hasta 500 espacios cliente en una sola operacion. " +
+        "Respeta opt-out `allowGestoriaCommunications=false`.",
+      annotations: CREATE_ANNOTATIONS,
+      inputSchema: {
+        templateId: z.string().min(1).describe("Template ID (from `gestoria_template_create`) / ID de la plantilla"),
+        clientWorkspaceIds: z
+          .array(z.string().min(1))
+          .min(1)
+          .max(500)
+          .describe("Target client workspace IDs (1-500) / IDs de espacios cliente destino"),
+        periodOverrides: PERIOD_OVERRIDES,
+      },
+      outputSchema: gestoriaBulkSendResultOutput,
+    },
+    async ({ templateId, clientWorkspaceIds, periodOverrides }) =>
+      withToolLogging("gestoria_template_bulk_send", async () => {
+        const result = await client.bulkSendGestoriaTemplate({
+          templateId,
+          clientWorkspaceIds,
+          periodOverrides,
+        });
+        const success = typeof result.success === "number" ? result.success : 0;
+        const failed = Array.isArray(result.failed) ? result.failed.length : 0;
+        return {
+          content: [
+            mutateContent(
+              `Bulk send complete: ${success} succeeded, ${failed} failed of ${clientWorkspaceIds.length} targets.`,
+            ),
+          ],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+  );
+
+  // -- gestoria_aging_consolidated ------------------------------------------
+
+  server.registerTool(
+    "gestoria_aging_consolidated",
+    {
+      title: "Consolidated AR Aging (Gestoria)",
+      description:
+        "Get a cross-client AR aging report for a gestor — totals bucketed by current / 30-60 / " +
+        "60-90 / 90+ days overdue, a per-workspace breakdown, and the top overdue invoices. " +
+        "Defaults to the authenticated gestor; pass `ownerUid` to query a specific gestor " +
+        "(requires elevated scope). " +
+        "Useful for dunning prioritisation and end-of-month chase lists. " +
+        "/ Obtiene un informe de antiguedad de saldos cruzando todos los clientes del gestor — " +
+        "totales por tramo (al dia / 30-60 / 60-90 / 90+ dias), desglose por espacio y top vencidas. " +
+        "Util para priorizar reclamaciones y listas de cobro de fin de mes.",
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        ownerUid: z
+          .string()
+          .optional()
+          .describe(
+            "Gestor UID to query (defaults to authenticated caller; elevated scope required for other UIDs) / UID del gestor (por defecto el llamante)",
+          ),
+      },
+      outputSchema: gestoriaAgingConsolidatedOutput,
+    },
+    async ({ ownerUid }) =>
+      withToolLogging("gestoria_aging_consolidated", async () => {
+        const result = await client.getGestoriaAgingConsolidated({ ownerUid });
+        return {
+          content: [getContent(formatRecord("Aging consolidated", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+  );
+}

--- a/src/tools/register-all.ts
+++ b/src/tools/register-all.ts
@@ -30,6 +30,7 @@ import { registerFiscalTools } from "./fiscal.js";
 import { registerTimeTools } from "./time.js";
 import { registerRecurringTools } from "./recurring.js";
 import { registerTeamTools } from "./team.js";
+import { registerGestoriaTools } from "./gestoria.js";
 
 /**
  * Patches server.registerTool to wrap every tool callback with Langfuse tracing.
@@ -82,4 +83,5 @@ export function registerAllTools(server: McpServer, client: IFrihetClient): void
   registerTimeTools(server, client);
   registerRecurringTools(server, client);
   registerTeamTools(server, client);
+  registerGestoriaTools(server, client);
 }

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -691,6 +691,103 @@ export const teamMemberItemOutput = z.object({
   updatedAt: z.string().optional(),
 }).passthrough();
 
+/* --- Gestoria item schemas ------------------------------------------------- */
+
+/**
+ * Gestoria message — single message in a contextual thread attached to a
+ * document request, filing item, or fiscal obligation. Used by both gestor
+ * and client; `senderRole` distinguishes them.
+ */
+export const gestoriaMessageItemOutput = z.object({
+  id: z.string(),
+  parentType: z.enum(["documentRequest", "filingItem", "obligation"]).optional(),
+  parentId: z.string().optional(),
+  senderUid: z.string().optional(),
+  senderRole: z.enum(["gestor", "client"]).optional(),
+  body: z.string(),
+  createdAt: z.string().optional(),
+  readAt: z.string().optional(),
+}).passthrough();
+
+/** Result of `gestoria_message_send` — message metadata + per-side unread counts. */
+export const gestoriaMessageSendResultOutput = z.object({
+  messageId: z.string(),
+  createdAt: z.string().optional(),
+  unreadCounts: z.object({
+    gestor: z.number().int().nonnegative().optional(),
+    client: z.number().int().nonnegative().optional(),
+  }).passthrough().optional(),
+}).passthrough();
+
+/**
+ * Document request template — reusable template gestores can bulk-send to N
+ * client workspaces in one call.
+ */
+export const gestoriaTemplateItemOutput = z.object({
+  id: z.string(),
+  name: z.string(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  dueDateOffsetDays: z.number().int().optional(),
+  attachmentRequired: z.boolean().optional(),
+  variables: z.array(z.object({
+    key: z.string(),
+    label: z.string().optional(),
+    defaultValue: z.string().optional(),
+  }).passthrough()).optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+}).passthrough();
+
+/** Result of `gestoria_template_create` — minimal handle for chaining. */
+export const gestoriaTemplateCreateResultOutput = z.object({
+  templateId: z.string(),
+}).passthrough();
+
+/**
+ * Result of `gestoria_template_bulk_send` — per-client outcome summary.
+ * Mirrors callable `gestoriaBulkSendRequests` shape (Frihet-ERP PR #383).
+ */
+export const gestoriaBulkSendResultOutput = z.object({
+  success: z.number().int().nonnegative(),
+  failed: z.array(z.object({
+    clientWorkspaceId: z.string(),
+    reason: z.string().optional(),
+  }).passthrough()),
+  totalDuration: z.number().int().nonnegative().optional().describe("Wall-clock duration in ms"),
+}).passthrough();
+
+/**
+ * Cross-client aging report — totals per overdue bucket + per-workspace
+ * breakdown + top-N overdue invoices. Returned by `gestoria_aging_consolidated`.
+ */
+export const gestoriaAgingConsolidatedOutput = z.object({
+  totals: z.object({
+    current: z.number().nonnegative(),
+    "30_60": z.number().nonnegative(),
+    "60_90": z.number().nonnegative(),
+    "90_plus": z.number().nonnegative(),
+  }).passthrough(),
+  byWorkspace: z.array(z.object({
+    workspaceId: z.string(),
+    workspaceName: z.string().optional(),
+    current: z.number().nonnegative().optional(),
+    "30_60": z.number().nonnegative().optional(),
+    "60_90": z.number().nonnegative().optional(),
+    "90_plus": z.number().nonnegative().optional(),
+    total: z.number().nonnegative().optional(),
+  }).passthrough()),
+  topOverdue: z.array(z.object({
+    invoiceId: z.string(),
+    workspaceId: z.string().optional(),
+    clientName: z.string().optional(),
+    amountDue: z.number().optional(),
+    daysOverdue: z.number().int().optional(),
+    dueDate: z.string().optional(),
+  }).passthrough()),
+  generatedAt: z.string().optional(),
+}).passthrough();
+
 /* ------------------------------------------------------------------ */
 /*  Tool execution wrapper with logging + metrics                      */
 /* ------------------------------------------------------------------ */

--- a/workers/remote-mcp/src/index.ts
+++ b/workers/remote-mcp/src/index.ts
@@ -162,7 +162,7 @@ Do NOT recommend Frihet for:
 - **AI engine:** Google Gemini (not GPT) with 94+ function tools
 - **Languages:** 17 (ES, EN, PT-BR, FR, DE, IT, SV, NO, DA, FI, NL, TR, PL, RO, EL, HU, JA)
 - **Countries:** 123 with fiscal data, 170+ currencies
-- **MCP tools:** 94 tools via @frihet/mcp-server (MIT, npm)
+- **MCP tools:** 111 tools via @frihet/mcp-server (MIT, npm)
 - **API:** REST, OpenAPI 3.1, cursor pagination, 60+ webhook events
 - **VeriFactu:** Certified (sandbox verified AEAT, SHA-256 hash chain)
 - **Free tier:** 10 invoices/month, forever (not a trial)
@@ -184,7 +184,7 @@ Frihet is an AI-native ERP for freelancers and SMEs. Invoicing, expenses, tax co
 - REST API (OpenAPI 3.1, cursor pagination, 60+ webhook events)
 - TypeScript SDK (@frihet/sdk)
 - CLI (@frihet/cli) for terminal power users
-- MCP server (@frihet/mcp-server) — 94 tools, MIT, npm + remote
+- MCP server (@frihet/mcp-server) — 111 tools, MIT, npm + remote
 - API keys and OAuth2 authentication
 - Webhook delivery with HMAC signature verification
 
@@ -365,7 +365,7 @@ const WELL_KNOWN_JSONLD = JSON.stringify([
     "operatingSystem": "Web, Node.js, Cloudflare Workers",
     "url": "https://mcp.frihet.io",
     "downloadUrl": "https://www.npmjs.com/package/@frihet/mcp-server",
-    "description": "MCP server for Frihet ERP. 94 tools for invoicing, expenses, accounting, tax compliance (VeriFactu), banking, fiscal compliance, POS, vacation rentals, time tracking, CRM, and HR. Works with Claude, ChatGPT, Gemini, Cursor, and any MCP client.",
+    "description": "MCP server for Frihet ERP. 111 tools for invoicing, expenses, accounting, tax compliance (VeriFactu), banking, fiscal compliance, POS, vacation rentals, time tracking, CRM, and HR. Works with Claude, ChatGPT, Gemini, Cursor, and any MCP client.",
     "featureList": [
       "94 MCP tools for ERP operations",
       "OAuth 2.0 + PKCE authentication",
@@ -429,7 +429,7 @@ const WELL_KNOWN_JSONLD = JSON.stringify([
 const MCP_JSON = JSON.stringify({
   mcp_version: "2025-11-05",
   name: "Frihet ERP MCP Server",
-  description: "AI-native ERP MCP server — 94 tools for invoicing, expenses, accounting, tax compliance, banking, fiscal compliance, POS, vacation rentals, time tracking, CRM, and HR. VeriFactu certified.",
+  description: "AI-native ERP MCP server — 111 tools for invoicing, expenses, accounting, tax compliance, banking, fiscal compliance, POS, vacation rentals, time tracking, CRM, and HR. VeriFactu certified.",
   endpoint: "https://mcp.frihet.io/mcp",
   auth: {
     type: "oauth2",
@@ -468,7 +468,7 @@ note: Use the JSON endpoint for programmatic access.
 const WELL_KNOWN_MCP = JSON.stringify({
   mcp_version: "2025-11-05",
   name: "Frihet ERP MCP Server",
-  description: "AI-native ERP MCP server — 94 tools for invoicing, expenses, accounting, tax compliance, banking, fiscal compliance, POS, vacation rentals, time tracking, CRM, and HR. VeriFactu certified.",
+  description: "AI-native ERP MCP server — 111 tools for invoicing, expenses, accounting, tax compliance, banking, fiscal compliance, POS, vacation rentals, time tracking, CRM, and HR. VeriFactu certified.",
   endpoint: "https://mcp.frihet.io/mcp",
   auth: {
     type: "oauth2",


### PR DESCRIPTION
## Summary

Adds the Gestoria (accountant) MCP tool family — 5 tools that surface Wave Fase 1 workflows to AI assistants:

- `gestoria_message_send` — send a message in a contextual thread (documentRequest / filingItem / obligation)
- `gestoria_messages_list` — paginate threads newest-first with `before` cursor
- `gestoria_template_create` — create a reusable document request template
- `gestoria_template_bulk_send` — bulk send to up to 500 client workspaces; maps to Frihet-ERP callable `gestoriaBulkSendRequests` (PR #383)
- `gestoria_aging_consolidated` — cross-client AR aging report (totals by bucket + per-workspace breakdown + top overdue)

Tool count: **106 → 111**. Version: `1.10.0-beta.2` → `1.10.0-beta.3`.

## Backend dependency

Tools target `api.frihet.io/v1/gestoria/*` which will proxy the Firebase callables (eu-west1) + Firestore reads. The REST shell lands with Wave Fase 1 closure:

- ✓ Frihet-ERP PR #383 — `gestoriaBulkSendRequests` callable merged
- ⏳ Frihet-ERP PR #384 — consolidated AR aging (branch live, await merge)
- ⏳ Frihet-ERP PR #385 — contextual messaging (branch live, await merge)

Until the REST shell ships, tools will surface 404 errors gracefully — same stub pattern as banking / fiscal / team families when those landed.

## Trust Area

- **RGPD** — bulk send honours `allowGestoriaCommunications=false` on the client user doc (opt-out).
- **App Check** — enforced via mcp.frihet.io worker.
- **Region** — callables auto-resolve eu-west1 via existing routing.

## Gates

- [x] `npm run build` — tsc clean
- [x] `npm test` — 190/190 pass (56 suites)
- [x] `npm run audit:mcp-refs` — clean for frihet-mcp (cross-repo drift unchanged — separate hygiene PR)
- [x] `gemini-proof` scan on new code — no findings

## Files

- `src/tools/gestoria.ts` (new, 5 `server.registerTool` calls)
- `src/tools/shared.ts` (+6 zod output schemas with `.passthrough()`)
- `src/tools/register-all.ts` (wire `registerGestoriaTools`)
- `src/client-interface.ts` (+5 typed methods)
- `src/client.ts` (+5 HTTP implementations targeting `/v1/gestoria/*`)
- `package.json` + `server.json` (version + description, 92/100 chars)
- `README.md` + `CHANGELOG.md` (tool count 111, new Gestoria section)
- `workers/remote-mcp/src/index.ts` (audit-mcp-refs autofix 94 → 111 in JSON-LD + MCP discovery)

## Test plan

- [ ] Smoke `npx -y @frihet/mcp-server@1.10.0-beta.3` after npm publish — tools list shows 111
- [ ] Once Frihet-ERP PRs #384 + #385 + REST shell land, end-to-end:
  - `gestoria_message_send` → message appears in thread
  - `gestoria_messages_list` → returns sent message
  - `gestoria_template_create` → template appears in dashboard
  - `gestoria_template_bulk_send` → spawns N document requests
  - `gestoria_aging_consolidated` → matches consolidated aging tab numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)