### PR TITLE
fix(security): scrub leaked Langfuse keys from LANGFUSE_SECRETS.md [P0]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ node_modules/
 dist/
 *.tsbuildinfo
 .env
+.dev.vars
+*.dev.vars
+LANGFUSE_SECRETS.local.md
 .DS_Store
 .mcpregistry_*
 mcp-registry-key.pem

--- a/LANGFUSE_SECRETS.md
+++ b/LANGFUSE_SECRETS.md
@@ -1,24 +1,29 @@
 # Langfuse Observability — Env Var Setup
 
-Self-hosted Langfuse at https://langfuse.frihet.io traces every MCP tool call
+Self-hosted Langfuse at `https://langfuse.frihet.io` traces every MCP tool call
 (tool name, input args, response time, errors). Fail-open: missing keys or
 Langfuse down → tool calls proceed unchanged.
+
+> **Never commit real keys to this repo.** This is a public repository. All values
+> below are placeholders. Obtain the real `pk-lf-…` / `sk-lf-…` pair from the Langfuse
+> project settings (Settings → API Keys) and store them only as Wrangler secrets,
+> `.dev.vars` (gitignored), or your MCP client config — never in tracked files.
 
 ---
 
 ## Cloudflare Worker (mcp.frihet.io)
 
-Run once per secret. These are stored as encrypted Wrangler secrets, never in wrangler.toml.
+Run once per secret. These are stored as encrypted Wrangler secrets, never in `wrangler.toml`.
 
 ```bash
 # From workers/remote-mcp/
 cd workers/remote-mcp
 
 wrangler secret put LANGFUSE_PUBLIC_KEY
-# Enter: pk-lf-0235fa1b-4653-4dc3-92e4-ecb8a3c7e17e
+# Enter: pk-lf-...
 
 wrangler secret put LANGFUSE_SECRET_KEY
-# Enter: sk-lf-558566eb-c3cb-4b34-a93e-ead0407cc9eb
+# Enter: sk-lf-...
 
 wrangler secret put LANGFUSE_BASE_URL
 # Enter: https://langfuse.frihet.io
@@ -46,8 +51,8 @@ Add to the MCP server config in `mcpServers`:
       "args": ["-y", "@frihet/mcp-server"],
       "env": {
         "FRIHET_API_KEY": "fri_...",
-        "LANGFUSE_PUBLIC_KEY": "pk-lf-0235fa1b-4653-4dc3-92e4-ecb8a3c7e17e",
-        "LANGFUSE_SECRET_KEY": "sk-lf-558566eb-c3cb-4b34-a93e-ead0407cc9eb",
+        "LANGFUSE_PUBLIC_KEY": "pk-lf-...",
+        "LANGFUSE_SECRET_KEY": "sk-lf-...",
         "LANGFUSE_BASE_URL": "https://langfuse.frihet.io"
       }
     }
@@ -55,22 +60,23 @@ Add to the MCP server config in `mcpServers`:
 }
 ```
 
-Optional: `FRIHET_CLIENT_NAME` — label to identify the MCP client in Langfuse traces
-(e.g. `"claude-desktop"`, `"cursor"`, `"windsurf"`).
+Langfuse keys are **optional** — omit them and the server runs with tracing disabled
+(fail-open). Optional: `FRIHET_CLIENT_NAME` — label to identify the MCP client in
+Langfuse traces (e.g. `"claude-desktop"`, `"cursor"`, `"windsurf"`).
 
 ---
 
 ## Local dev (Wrangler)
 
-Create `workers/remote-mcp/.dev.vars`:
+Create `workers/remote-mcp/.dev.vars` (gitignored — never tracked):
 
 ```
-LANGFUSE_PUBLIC_KEY=pk-lf-0235fa1b-4653-4dc3-92e4-ecb8a3c7e17e
-LANGFUSE_SECRET_KEY=sk-lf-558566eb-c3cb-4b34-a93e-ead0407cc9eb
+LANGFUSE_PUBLIC_KEY=pk-lf-...
+LANGFUSE_SECRET_KEY=sk-lf-...
 LANGFUSE_BASE_URL=https://langfuse.frihet.io
 ```
 
-`.dev.vars` is gitignored by Wrangler convention.
+`.dev.vars` is gitignored in this repo (see `.gitignore`).
 
 ---
 


### PR DESCRIPTION
## P0 security containment

The Langfuse public/secret key pair was committed verbatim in `LANGFUSE_SECRETS.md` (tracked, **public repo**) since `a57e792` (2026-04-20). Anyone could read traces (`span.input` carries tool args = business data) from `langfuse.frihet.io`.

### Done
- **Rotated** the key pair at `langfuse.frihet.io`; **revoked** the exposed key (old key now returns HTTP 401, new key 207 verified).
- Updated Wrangler secrets in `remote-mcp` (default + `--env openai`) and local `.dev.vars`.
- This PR: replace real values in `LANGFUSE_SECRETS.md` with placeholders + add `.dev.vars`/`*.dev.vars` to `.gitignore`.

### Scope verified
- Only one secret pair in entire git history, only in this file.
- **All 23 published npm tarballs scanned: clean** — `files` allowlist never packed this doc.
- No history rewrite (the key is dead; removing from HEAD suffices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)