### PR TITLE
docs: honest distribution table + tool-count footnote

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ See also: `SOUL.md` (symlink → `Frihet-ERP/SOUL.md`) for product voice, brandi
 MCP server that connects AI assistants (Claude Code, Cursor, Copilot, Codex, Windsurf, Gemini CLI, ChatGPT Desktop) to Frihet ERP. Natural language → invoices, expenses, clients, fiscal reports.
 
 **Live:**
-- npm: https://www.npmjs.com/package/@frihet/mcp-server (v1.12.0-beta.1, 152 tools)
+- npm: https://www.npmjs.com/package/@frihet/mcp-server (v1.12.0-beta.1, 151 tools)
 - MCP remote: https://mcp.frihet.io (Cloudflare Worker)
 - Smithery: https://smithery.ai/server/frihet/frihet-mcp
 - Anthropic registry: https://registry.modelcontextprotocol.io/?q=io.frihet
@@ -37,7 +37,7 @@ MCP server that connects AI assistants (Claude Code, Cursor, Copilot, Codex, Win
 
 | Channel | Status | Action |
 |---|---|---|
-| npm package | LIVE 152 tools | 110+ target exceeded; keep registry listings fresh |
+| npm package | LIVE 151 tools | 110+ target exceeded; keep registry listings fresh |
 | Smithery installs | LIVE | Track install rate weekly |
 | MCP Registry (anthropic) | LIVE | Verify keep updated on major release |
 | ChatGPT MCP marketplace | not submitted | Wave 4 submission |
@@ -59,7 +59,7 @@ MCP server that connects AI assistants (Claude Code, Cursor, Copilot, Codex, Win
 
 ### Tool coverage targets (62 → 110+)
 
-Current (v1.12.0-beta.1, 152 tools):
+Current (v1.12.0-beta.1, 151 tools):
 
 | File | Tools | Coverage |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@
 | **Remote endpoint** | Live | `https://mcp.frihet.io/mcp` (zero install, OAuth or API key) |
 | **Smithery** | Live | [smithery.ai/server/frihet/frihet-mcp](https://smithery.ai/server/frihet/frihet-mcp) |
 | **MCP Registry** | Live | [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io/?q=io.frihet) |
-| **Glama** | Pending submission | [glama.ai/mcp/servers](https://glama.ai/mcp/servers) — `glama.json` ready |
-| **mcp.so** | Pending submission | [mcp.so](https://mcp.so) — indexed from npm + GitHub |
-| **PulseMCP** | Pending submission | [pulsemcp.com](https://pulsemcp.com) — indexed from npm + GitHub |
+| **Glama** | Live | [glama.ai/mcp/servers/@Frihet-io/frihet-mcp](https://glama.ai/mcp/servers/@Frihet-io/frihet-mcp) |
+| **mcp.so** | Auto-index (unverified) | [mcp.so](https://mcp.so) — indexes from npm + GitHub |
+| **PulseMCP** | Auto-index (unverified) | [pulsemcp.com](https://pulsemcp.com) — indexes from npm + GitHub |
 | **Cursor Marketplace** | Coming soon | [cursor.com/marketplace](https://cursor.com/marketplace) |
 | **ChatGPT Apps** | Coming soon | [chatgpt.com](https://chatgpt.com) |
 | **Anthropic Claude Directory** | Coming soon | [claude.ai/settings/connectors](https://claude.ai/settings/connectors) |
+
+> **Tool count:** the 151-tool build is on `@beta` (`npx @frihet/mcp-server@beta`). npm `latest` (1.6.x) currently ships 62 tools — a stable 151-tool release is pending. The remote endpoint (`mcp.frihet.io`) already serves all 151.
 
 ---
 


### PR DESCRIPTION
Honesty pass on the public README distribution table + counts (companion to the P0 secret cleanup PR #32).

- **Glama**: Pending → **Live** (verified: `glama.ai/mcp/servers/@Frihet-io/frihet-mcp` resolves 200, bogus slug 404s).
- **mcp.so / PulseMCP**: marked **Auto-index (unverified)** — catch-all SPA / bot-blocked respectively, so no false "Live" claim.
- **Tool-count footnote**: the 151-tool build is on `@beta`; npm `latest` (1.6.x) ships 62; the remote endpoint serves all 151. Sets honest expectations until a stable 151 publish.
- **CLAUDE.md**: 152 → 151 (factual — `registerTool` count is 151).
- GitHub repo **description** updated 52 → 151 via `gh repo edit`.

npm stable publish (1.12.0) intentionally **not** done here — separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)