### PR TITLE
chore(release): 1.12.0 stable — npm latest ships 151 tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `@frihet/mcp-server` are documented here.
 
+## [1.12.0] — 2026-06-10
+
+### Changed
+
+- Stable release — promotes the beta build below to npm `latest`, shipping all 151 tools and matching the remote endpoint (`mcp.frihet.io`).
+- README distribution footnote updated (beta note removed); startup banner and server metadata report `1.12.0`.
+
 ## [1.12.0-beta.1] — 2026-05-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ See also: `SOUL.md` (symlink → `Frihet-ERP/SOUL.md`) for product voice, brandi
 MCP server that connects AI assistants (Claude Code, Cursor, Copilot, Codex, Windsurf, Gemini CLI, ChatGPT Desktop) to Frihet ERP. Natural language → invoices, expenses, clients, fiscal reports.
 
 **Live:**
-- npm: https://www.npmjs.com/package/@frihet/mcp-server (v1.12.0-beta.1, 151 tools)
+- npm: https://www.npmjs.com/package/@frihet/mcp-server (v1.12.0, 151 tools)
 - MCP remote: https://mcp.frihet.io (Cloudflare Worker)
 - Smithery: https://smithery.ai/server/frihet/frihet-mcp
 - Anthropic registry: https://registry.modelcontextprotocol.io/?q=io.frihet
@@ -59,7 +59,7 @@ MCP server that connects AI assistants (Claude Code, Cursor, Copilot, Codex, Win
 
 ### Tool coverage targets (62 → 110+)
 
-Current (v1.12.0-beta.1, 151 tools):
+Current (v1.12.0, 151 tools):
 
 | File | Tools | Coverage |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 | **ChatGPT Apps** | Coming soon | [chatgpt.com](https://chatgpt.com) |
 | **Anthropic Claude Directory** | Coming soon | [claude.ai/settings/connectors](https://claude.ai/settings/connectors) |
 
-> **Tool count:** the 151-tool build is on `@beta` (`npx @frihet/mcp-server@beta`). npm `latest` (1.6.x) currently ships 62 tools — a stable 151-tool release is pending. The remote endpoint (`mcp.frihet.io`) already serves all 151.
+> **Tool count:** npm `latest` (1.12.0) ships all 151 tools, same as the remote endpoint (`mcp.frihet.io`).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@frihet/mcp-server",
-  "version": "1.9.0-beta.1",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@frihet/mcp-server",
-      "version": "1.9.0-beta.1",
+      "version": "1.12.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frihet/mcp-server",
-  "version": "1.12.0-beta.1",
+  "version": "1.12.0",
   "description": "AI-native MCP server for business management — invoices, expenses, deposits, clients, products, quotes, webhooks, CRM, e-invoicing (Facturae/XRechnung/Factur-X/FatturaPA/PEPPOL + FACe Spain B2G + TicketBAI Basque Country + KSeF Poland), vacation rentals, POS, banking, fiscal (Modelo 303/130/390/180/347/415/425/418, VeriFactu, TicketBAI, IS M200/M202), IGIC, AIEM, GL audit approval, white-label portal domain, VIES EU VAT lookup, bank rules, time tracking, recurring invoices, team management, gestoria. 151 tools. Remote endpoint at mcp.frihet.io (zero install). Works with Claude, Cursor, Windsurf, Cline.",
   "type": "module",
   "main": "./dist/index.js",

--- a/server.json
+++ b/server.json
@@ -2,17 +2,17 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.frihet/erp",
   "title": "Frihet ERP",
-  "description": "AI-native ERP — 151 tools: invoicing, CRM, tax, IGIC/AIEM, IS, GL audit, portal domain, VIES, banking rules, POS, rentals, time, team, gestoria, HR, payroll, onboarding, period close.",
+  "description": "AI-native ERP MCP server — 151 tools: invoicing, CRM, tax, banking, HR, payroll, period close.",
   "repository": {
     "url": "https://github.com/Frihet-io/frihet-mcp",
     "source": "github"
   },
-  "version": "1.12.0-beta.1",
+  "version": "1.12.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@frihet/mcp-server",
-      "version": "1.12.0-beta.1",
+      "version": "1.12.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ function main(): void {
 
   const server = new McpServer({
     name: "frihet-erp",
-    version: "1.12.0-beta.1",
+    version: "1.12.0",
     description:
       "AI-native MCP server for Frihet ERP — invoices, expenses, clients, products, quotes, webhooks, and deposits. " +
       "Provides 151 tools (including business context, monthly summaries, quarterly taxes, invoice duplication, CRM subcollections, and deposit management), " +
@@ -112,12 +112,12 @@ function main(): void {
   // Connect via stdio transport
   const transport = new StdioServerTransport();
   server.connect(transport).then(() => {
-    console.error("[frihet-mcp] v1.12.0-beta.1 | 151 tools | https://github.com/Frihet-io/frihet-mcp");
+    console.error("[frihet-mcp] v1.12.0 | 151 tools | https://github.com/Frihet-io/frihet-mcp");
     log({
       level: "info",
       message: "Frihet MCP server running on stdio",
       operation: "startup",
-      metadata: { version: "1.12.0-beta.1", transport: "stdio" },
+      metadata: { version: "1.12.0", transport: "stdio" },
     });
   }).catch((error: unknown) => {
     log({

--- a/workers/remote-mcp/src/index.ts
+++ b/workers/remote-mcp/src/index.ts
@@ -502,7 +502,7 @@ const WELL_KNOWN_MCP = JSON.stringify({
 // The default docs above advertise the FULL 151-tool server (payroll, e-invoice,
 // VIES, Stay/PMS, POS, fiscal models) and government IDs (NIF/CIF/DNI/passport).
 // OpenAI's reviewer crawls these BEFORE authenticating, so the openai-mcp host
-// must serve a surface consistent with the 53-tool reviewed profile: no regulated
+// must serve a surface consistent with the 53-tool reviewed profile: no regulated  // mcp-refs:ok
 // workflows, no gov-ID/payment fields, all self-references on openai-mcp.frihet.io.
 // applyOpenAIProfile() only scopes the live tools/list; these scope the static docs.
 // ===========================================================================
@@ -1012,7 +1012,7 @@ export default {
             }
             headers.set("Content-Type", "application/json; charset=utf-8");
             headers.set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400");
-            // In OpenAI mode, serve a scoped spec: only the 53-tool path families,
+            // In OpenAI mode, serve a scoped spec: only the 53-tool path families,  // mcp-refs:ok
             // gov-ID / banking / credential properties stripped (see scopeOpenApiForOpenAI).
             if (openai) {
               const scoped = scopeOpenApiForOpenAI(await assetResp.text());


### PR DESCRIPTION
Published `@frihet/mcp-server@1.12.0` to npm `latest` (smoke E2E stdio PASS: init + 151 tools + real `list_invoices` call, fresh install verified).

- Bump package.json + banner/metadata to 1.12.0
- README: drop beta footnote — latest now matches the remote endpoint
- CHANGELOG 1.12.0 entry
- `mcp-refs:ok` annotations on intentional 53-tool OpenAI-profile comments (audit:mcp-refs now green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)