### PR TITLE
feat(openai): grouped+openai composition + server.json publish gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ See also: `SOUL.md` (symlink → `Frihet-ERP/SOUL.md`) for product voice, brandi
 MCP server that connects AI assistants (Claude Code, Cursor, Copilot, Codex, Windsurf, Gemini CLI, ChatGPT Desktop) to Frihet ERP. Natural language → invoices, expenses, clients, fiscal reports.
 
 **Live:**
-- npm: https://www.npmjs.com/package/@frihet/mcp-server (v1.13.0, 151 tools)
+- npm: https://www.npmjs.com/package/@frihet/mcp-server (v1.13.1, 151 tools)
 - MCP remote: https://mcp.frihet.io (Cloudflare Worker)
 - Smithery: https://smithery.ai/server/frihet/frihet-mcp
 - Anthropic registry: https://registry.modelcontextprotocol.io/?q=io.frihet
@@ -59,7 +59,7 @@ MCP server that connects AI assistants (Claude Code, Cursor, Copilot, Codex, Win
 
 ### Tool coverage targets (62 → 110+)
 
-Current (v1.13.0, 151 tools):
+Current (v1.13.1, 151 tools):
 
 | File | Tools | Coverage |
 |---|---|---|

--- a/DECISION_SPEC.md
+++ b/DECISION_SPEC.md
@@ -1,0 +1,138 @@
+# DECISION SPEC — OpenAI × grouped tool-exposure composition
+
+**Status:** implemented, gated on Viktor's prod flip + OpenAI app re-review. **NOT deployed.**
+**Surface affected:** `openai-mcp.frihet.io` only (`env.openai`). `mcp.frihet.io` and the npm package are unchanged.
+**Trust Area:** the OpenAI surface is the one the ChatGPT app review covers.
+
+---
+
+## 1. Problem
+
+`openai-mcp.frihet.io` ran `FRIHET_TOOL_MODE=full`: the OpenAI-safe profile alone, exposing a flat
+list of 53 reviewed tools, each with a multi-paragraph bilingual description. That is exactly the
+context-rot problem the grouped progressive-disclosure profile solves on `mcp.frihet.io`.
+
+The two interceptors did **not** compose. Both wrap `server.registerTool`, and naively layering them
+broke three ways:
+- the OpenAI allow-list dropped the grouped meta-tools, so the collapsed summaries pointed at a
+  `describe_tool()` that no longer existed;
+- the grouped collapse stripped the per-tool `openWorldHint` rationale that OpenAI app review
+  requires on every tool;
+- the OpenAI `descriptionOverrides` (8 tools) overwrote the collapse, un-collapsing them.
+
+## 2. Three invariants the composition must satisfy
+
+1. **Meta-tools present** — `search_tools`, `describe_tool`, `list_tool_groups` are in `tools/list`
+   in OpenAI mode. Live surface = **53 reviewed business tools + 3 meta-tools = 56**.
+2. **Collapsed + open-world rationale on all 53** — each reviewed tool has a terse
+   `[group] summary — full schema via describe_tool('name').` description **and** still carries the
+   `[openWorldHint: true|false — …]` rationale marker. Annotation `openWorldHint` stays an explicit
+   boolean.
+3. **Catalog is allow-list-only** — what `search_tools` / `describe_tool` / `list_tool_groups`
+   surface or accept is **exactly** the 53 reviewed tools. A tool outside the reviewed set can never
+   be returned, described, suggested, or counted.
+
+## 3. Design
+
+Both profiles wrap `registerTool`. Wrapper applied **last** is the **outermost** (runs first on a
+call). The composition pins a deliberate order:
+
+```
+applyToolExposureProfile(server, { allowlist: OPENAI_REVIEWED_TOOL_ALLOWLIST }); // 1. INNER
+applyOpenAIProfile(server);                                                       // 2. OUTER
+registerAllTools(server, client);
+```
+
+Per business-tool registration the flow is: **OpenAI (outer) → grouped (inner) → real server**:
+1. **OpenAI (outer)** gates by the allow-list (drops the ~98 non-reviewed tools), merges annotation
+   overrides (e.g. `send_invoice.openWorldHint = true`), applies `descriptionOverrides`, injects the
+   `openWorldHint` rationale into the description, strips gov-ID / credential input fields, and wraps
+   the handler with output redaction.
+2. **grouped (inner)** catalogs the tool (only if in the allow-list) and **collapses** the
+   description — making the terse line the final description — and **re-derives the `openWorldHint`
+   rationale** from the now-correct `annotations.openWorldHint` and appends it to the collapsed line.
+   The handler it forwards is OpenAI's redaction-wrapped handler, so redaction survives.
+
+**Meta-tools bypass the OpenAI gate.** Because grouped is applied **first**, its
+`originalRegisterTool` is the **real** `server.registerTool`. `registerMetaTools` uses that real fn,
+so the 3 meta-tools register straight onto the server and never hit the OpenAI allow-list. This keeps
+invariant (1) without adding the meta-tool names to `PROFILE.includeTools` — so
+`OPENAI_ALLOWED_TOOL_COUNT` stays **53** and every "53 reviewed tools" doc string remains correct.
+
+**Allow-list pins the catalog.** `applyToolExposureProfile` gained an optional
+`{ allowlist?: ReadonlySet<string> }`. When set, only allow-list members are catalogued + collapsed;
+anything else is passed through untouched and never enters the catalog. So `search_tools` /
+`describe_tool` / `list_tool_groups` (which read only the catalog) can only ever surface the 53.
+In the openai-mcp wiring the OpenAI gate already dropped non-reviewed tools before they reach grouped;
+the allow-list is the **defence-in-depth** that guarantees the catalog is reviewed-only even if the
+upstream gate ever changes.
+
+### Meta-tool annotations
+The 3 meta-tools are closed-world catalog lookups — read-only, no external API. They carry
+`{ readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false }` and their
+descriptions embed `[openWorldHint: false — reads the in-process tool catalog only.]`. `openWorldHint:
+true` is reserved for the 4 business tools that contact an entity outside Frihet (`send_invoice`,
+`send_quote`, `create_webhook`, `update_webhook`).
+
+## 4. Surface change: 53 → 56
+
+| | before (full) | after (grouped) |
+|---|---|---|
+| reviewed business tools in `tools/list` | 53 | 53 |
+| discovery meta-tools | 0 | 3 |
+| **total `tools/list` entries** | **53** | **56** |
+| each business tool description | full bilingual blob | collapsed 1-liner + openWorldHint rationale |
+| advertised "reviewed tools" count (`OPENAI_ALLOWED_TOOL_COUNT`, static docs) | 53 | 53 (unchanged) |
+
+The 3 meta-tools are discovery **plumbing**, not business capability, so the advertised reviewed-tool
+count and all static-doc surfaces (`llms.txt`, `agents.json`, `/.well-known/mcp`, scoped
+`openapi.json`) intentionally still say **53**.
+
+## 5. Why it is compliant
+
+- **No new data collection / capability.** Meta-tools are read-only, closed-world catalog lookups
+  over the in-process catalog. No new external call, no new field, no new business action.
+- **openWorldHint rationale preserved on every reviewed tool** (invariant 2) — the exact annotation
+  OpenAI app review requires, now also on the collapsed surface.
+- **Progressive disclosure cannot widen the surface** (invariant 3) — the catalog is pinned to the
+  reviewed allow-list; `search_tools` / `describe_tool` / `list_tool_groups` provably never surface a
+  regulated tool (fiscal / Stay / POS / HR / payroll), even by group filter or fuzzy query.
+- **Gov-ID / credential redaction + input-strip unchanged** — OpenAI runs first; the grouped collapse
+  forwards OpenAI's redaction-wrapped handler untouched.
+
+## 6. ⚠️ Required before going live
+
+This is a **53 → 56 tools/list change on the ChatGPT-reviewed surface.** It MUST NOT ship silently.
+
+1. **Viktor's explicit prod flip.** `wrangler deploy --env openai` (with `FRIHET_TOOL_MODE=grouped`).
+2. **OpenAI app re-review.** The ChatGPT connector tool list changes (3 new tools, all descriptions
+   restated). Submit for re-review per
+   `https://developers.openai.com/apps-sdk/app-submission-guidelines` before enabling for users.
+3. **Live smoke after deploy:** `node scripts/test-openai-grouped-compose.mjs --key fri_*` (it asserts
+   the 56-tool surface + the 3 invariants against `https://openai-mcp.frihet.io/mcp`). DO NOT run
+   before deploy — it will fail on the meta-tool checks against the current "full" surface.
+
+**Rollback:** set `env.openai.vars.FRIHET_TOOL_MODE` back to `"full"` and redeploy. Code paths for
+openai-only and grouped-only are unchanged, so the rollback is a pure config flip.
+
+## 7. Test wiring (merge note)
+
+`src/__tests__/openai-grouped-compose.test.ts` covers all three invariants (12 assertions). It runs
+clean via `node --test dist/__tests__/openai-grouped-compose.test.js`.
+
+It is **not yet added to `package.json`'s `test` script** because that file currently has an
+unrelated uncommitted edit from a sibling task (the `server.json` version gate adding
+`audit-server-version.test.js`). To avoid a same-line merge conflict, append
+`dist/__tests__/openai-grouped-compose.test.js` to the `test` script's file list **at merge time**,
+alongside the sibling change. Until then, the gate runs it explicitly.
+
+## 8. Files changed
+
+- `src/tool-exposure.ts` — optional `{ allowlist }` param; allow-list filters catalog/collapse; collapse re-derives + appends the openWorldHint rationale in allow-list mode.
+- `src/openai-profile.ts` — export `OPENAI_REVIEWED_TOOL_ALLOWLIST` (the 53-tool `PROFILE.includeTools`).
+- `src/index.ts` (npm/stdio) — compose grouped-first / openai-second; pass allow-list when both on.
+- `workers/remote-mcp/src/index.ts` — same composition wiring for the Worker.
+- `workers/remote-mcp/wrangler.toml` — `env.openai` `FRIHET_TOOL_MODE` `"full"` → `"grouped"` + rationale + compliance note.
+- `src/__tests__/openai-grouped-compose.test.ts` — new composition test (invariants 1/2/3).
+- `scripts/test-openai-grouped-compose.mjs` — new live smoke (write-only; run after deploy).
+- `DECISION_SPEC.md` — this file.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "npm run build && node --test dist/__tests__/openai-profile.test.js dist/__tests__/tool-exposure.test.js dist/__tests__/einvoice-tools.test.js dist/__tests__/einvoice-day4-tools.test.js dist/__tests__/stay-tools.test.js dist/__tests__/pos-tools.test.js dist/__tests__/banking-tools.test.js dist/__tests__/fiscal-tools.test.js dist/__tests__/time-tools.test.js dist/__tests__/recurring-tools.test.js dist/__tests__/team-tools.test.js dist/__tests__/d4b-hr-payroll-onboarding-tools.test.js",
+    "test": "npm run build && node --test dist/__tests__/openai-profile.test.js dist/__tests__/tool-exposure.test.js dist/__tests__/einvoice-tools.test.js dist/__tests__/einvoice-day4-tools.test.js dist/__tests__/stay-tools.test.js dist/__tests__/pos-tools.test.js dist/__tests__/banking-tools.test.js dist/__tests__/fiscal-tools.test.js dist/__tests__/time-tools.test.js dist/__tests__/recurring-tools.test.js dist/__tests__/team-tools.test.js dist/__tests__/d4b-hr-payroll-onboarding-tools.test.js dist/__tests__/audit-server-version.test.js dist/__tests__/openai-grouped-compose.test.js",
     "start": "node dist/index.js",
     "postinstall": "node scripts/postinstall.js || true",
     "prepublishOnly": "npm run build && npm run audit:mcp-refs -- --repo frihet-mcp",

--- a/scripts/audit-mcp-refs.mjs
+++ b/scripts/audit-mcp-refs.mjs
@@ -27,7 +27,7 @@
 import { readFileSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { resolve, join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { homedir } from 'node:os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -167,6 +167,36 @@ const SAFE_PATTERNS = [
 const VERSION_RE = /v?(\d+\.\d+\.\d+(?:-[a-z]+\.\d+)?)/g;
 const MCP_CONTEXT_RE = /(@frihet\/mcp-server|frihet-mcp|servidor\s+mcp|mcp\s+server|mcp\.frihet\.io)/i;
 
+// === server.json version gate (special case) ===
+// server.json carries the version as BARE JSON values (root `.version` and
+// `.packages[0].version`). The generic line-scan version check requires an MCP
+// marker on the SAME line (MCP_CONTEXT_RE), which never matches those bare
+// `"version": "x.y.z"` lines — so a desynced server.json passed silently and
+// caused the Registry 400 "duplicate version" in release 1.13.1.
+//
+// This handler parses server.json as JSON and asserts both version fields equal
+// the SoT VERSION (from package.json). Returns an array of drift findings in the
+// same { kind, found, expected, jsonPath } shape used by the rest of the audit;
+// empty array means in-sync. Pure (no I/O) so it's unit-testable in isolation.
+export function checkServerJsonVersion(serverJson, expectedVersion) {
+  const drifts = [];
+  const rootVer = serverJson?.version;
+  if (rootVer !== expectedVersion) {
+    drifts.push({ kind: 'version', jsonPath: '.version', found: rootVer, expected: expectedVersion });
+  }
+  const pkgVer = serverJson?.packages?.[0]?.version;
+  if (pkgVer !== expectedVersion) {
+    drifts.push({ kind: 'version', jsonPath: '.packages[0].version', found: pkgVer, expected: expectedVersion });
+  }
+  return drifts;
+}
+
+// Run the full audit only when invoked as a CLI. When imported (e.g. by tests)
+// the module exposes its pure helpers without executing the audit or exiting.
+const isMain = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+
+if (isMain) {
+
 // Validate --repo argument
 if (REPO_FILTER && !Object.keys(REPOS).includes(REPO_FILTER)) {
   console.error(`Unknown repo: ${REPO_FILTER}`);
@@ -217,6 +247,44 @@ for (const [repoName, cfg] of Object.entries(REPOS)) {
 
     // History files: skip tool-count checks entirely (entries are historical narrative).
     const isHistoryFile = HISTORY_FILES.has(rel);
+
+    // Special case: server.json carries version as bare JSON values that the
+    // generic MCP-context line scan can't see. Parse + assert both fields.
+    if (repoName === 'frihet-mcp' && rel === 'server.json') {
+      let serverJson;
+      try {
+        serverJson = JSON.parse(readFileSync(abs, 'utf8'));
+      } catch (err) {
+        findings.push({ repo: repoName, file: rel, severity: 'fail', kind: 'parse', msg: `invalid JSON: ${err.message}` });
+        serverJson = null;
+      }
+      if (serverJson) {
+        for (const drift of checkServerJsonVersion(serverJson, VERSION)) {
+          findings.push({
+            repo: repoName,
+            file: rel,
+            line: drift.jsonPath,
+            severity: 'fail',
+            kind: drift.kind,
+            found: drift.found,
+            expected: drift.expected,
+            snippet: `${drift.jsonPath} = ${JSON.stringify(drift.found)}`,
+          });
+        }
+        if (FIX) {
+          let mutated = false;
+          if (serverJson.version !== VERSION) { serverJson.version = VERSION; mutated = true; }
+          if (serverJson.packages?.[0] && serverJson.packages[0].version !== VERSION) {
+            serverJson.packages[0].version = VERSION;
+            mutated = true;
+          }
+          if (mutated) {
+            writeFileSync(abs, JSON.stringify(serverJson, null, 2) + '\n');
+            findings.push({ repo: repoName, file: rel, severity: 'fixed', msg: 'server.json version fields synced' });
+          }
+        }
+      }
+    }
 
     lines.forEach((line, idx) => {
       // Skip safe-pattern lines for tool-count check
@@ -329,3 +397,5 @@ if (JSON_OUT) {
 
 const exitFail = findings.some((f) => f.severity === 'fail');
 process.exit(exitFail && !FIX ? 1 : 0);
+
+} // end if (isMain)

--- a/scripts/test-openai-grouped-compose.mjs
+++ b/scripts/test-openai-grouped-compose.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+/**
+ * LIVE smoke for the OpenAI × grouped COMPOSITION on openai-mcp.frihet.io.
+ *
+ * ⚠️ DO NOT RUN until the openai-mcp Worker has been deployed with
+ *    FRIHET_TOOL_MODE=grouped (env.openai). The composition is gated behind
+ *    Viktor's prod flip + an OpenAI app re-review (see DECISION_SPEC.md).
+ *    Running it before deploy asserts against the OLD ("full") surface and will
+ *    fail on the meta-tool checks — that failure is expected pre-deploy.
+ *
+ * What it asserts against the LIVE MCP endpoint (after a deploy):
+ *   (1) tools/list returns 56 tools: the 53 reviewed business tools + the 3
+ *       discovery meta-tools (search_tools, describe_tool, list_tool_groups).
+ *   (2) Every reviewed business tool has a collapsed description that still
+ *       carries an openWorldHint rationale marker.
+ *   (3) search_tools (browse-all) and describe_tool only ever surface tools that
+ *       are in tools/list — i.e. the catalog never leaks a non-reviewed tool.
+ *
+ * Usage (AFTER deploy only):
+ *   FRIHET_API_KEY=fri_xxx node scripts/test-openai-grouped-compose.mjs
+ *   node scripts/test-openai-grouped-compose.mjs --endpoint https://openai-mcp.frihet.io/mcp --key fri_xxx
+ *
+ * Exit 0 = all invariants hold. Exit 1 = a violation. Exit 2 = setup/transport error.
+ */
+
+const ARGS = process.argv.slice(2);
+function arg(flag) {
+  const i = ARGS.indexOf(flag);
+  return i >= 0 ? ARGS[i + 1] : undefined;
+}
+
+const ENDPOINT = arg("--endpoint") || "https://openai-mcp.frihet.io/mcp";
+const API_KEY = arg("--key") || process.env.FRIHET_API_KEY;
+
+// The 3 grouped discovery meta-tools (must be PRESENT in the composed surface).
+const META_TOOLS = ["list_tool_groups", "search_tools", "describe_tool"];
+// A handful of tools that exist on the FULL server but must NEVER surface here.
+const MUST_NOT_LEAK = [
+  "get_quarterly_taxes",
+  "get_invoice_einvoice",
+  "send_einvoice",
+  "get_modelo_303_summary",
+  "create_reservation",
+  "payroll_export",
+];
+const EXPECTED_BUSINESS = 53;
+const EXPECTED_TOTAL = EXPECTED_BUSINESS + META_TOOLS.length; // 56
+
+if (!API_KEY || !API_KEY.startsWith("fri_")) {
+  console.error("✗ Missing/invalid API key. Pass --key fri_* or set FRIHET_API_KEY (fri_*).");
+  process.exit(2);
+}
+
+let nextId = 1;
+async function rpc(method, params) {
+  const res = await fetch(ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      Authorization: `Bearer ${API_KEY}`,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: nextId++, method, params }),
+  });
+  if (!res.ok) throw new Error(`${method} → HTTP ${res.status} ${res.statusText}`);
+  const ct = res.headers.get("content-type") || "";
+  let payload;
+  if (ct.includes("text/event-stream")) {
+    // Parse the last data: line of an SSE response.
+    const text = await res.text();
+    const dataLines = text
+      .split("\n")
+      .filter((l) => l.startsWith("data:"))
+      .map((l) => l.slice(5).trim())
+      .filter(Boolean);
+    if (!dataLines.length) throw new Error(`${method} → empty SSE body`);
+    payload = JSON.parse(dataLines[dataLines.length - 1]);
+  } else {
+    payload = await res.json();
+  }
+  if (payload.error) throw new Error(`${method} → JSON-RPC error: ${JSON.stringify(payload.error)}`);
+  return payload.result;
+}
+
+function parseToolText(callResult) {
+  const block = (callResult?.content || []).find((c) => c.type === "text");
+  return block ? JSON.parse(block.text) : null;
+}
+
+async function main() {
+  const failures = [];
+  const note = (ok, label) => {
+    console.log(`${ok ? "✓" : "✗"} ${label}`);
+    if (!ok) failures.push(label);
+  };
+
+  // Handshake.
+  await rpc("initialize", {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "openai-grouped-compose-smoke", version: "1.0.0" },
+  });
+
+  // ---- tools/list ----------------------------------------------------------
+  const list = await rpc("tools/list", {});
+  const tools = list.tools || [];
+  const names = new Set(tools.map((t) => t.name));
+
+  // Invariant (1): 56 tools, meta-tools present.
+  note(tools.length === EXPECTED_TOTAL, `tools/list returns ${EXPECTED_TOTAL} tools (got ${tools.length})`);
+  for (const m of META_TOOLS) note(names.has(m), `meta-tool present: ${m}`);
+  const businessCount = tools.filter((t) => !META_TOOLS.includes(t.name)).length;
+  note(businessCount === EXPECTED_BUSINESS, `exactly ${EXPECTED_BUSINESS} reviewed business tools (got ${businessCount})`);
+  for (const leak of MUST_NOT_LEAK) note(!names.has(leak), `non-reviewed tool absent: ${leak}`);
+
+  // Meta-tools are read-only + closed-world.
+  for (const m of META_TOOLS) {
+    const t = tools.find((x) => x.name === m);
+    const ann = t?.annotations || {};
+    note(ann.readOnlyHint === true && ann.openWorldHint === false, `${m} is read-only + closed-world`);
+  }
+
+  // Invariant (2): every business tool collapsed + carries openWorldHint rationale.
+  let collapsedOk = true;
+  let owOk = true;
+  for (const t of tools) {
+    if (META_TOOLS.includes(t.name)) continue;
+    const d = t.description || "";
+    if (!/^\[[a-z]+\] /.test(d) || !d.includes(`describe_tool('${t.name}')`)) collapsedOk = false;
+    if (!d.includes("openWorldHint")) owOk = false;
+  }
+  note(collapsedOk, "every reviewed tool has a collapsed [group] … describe_tool() description");
+  note(owOk, "every reviewed tool's collapsed description carries an openWorldHint rationale");
+
+  // Invariant (3): catalog only ever surfaces tools that are in tools/list.
+  const search = await rpc("tools/call", { name: "search_tools", arguments: { query: "", limit: 500 } });
+  const searchPayload = parseToolText(search);
+  const searchNames = (searchPayload?.tools || []).map((x) => x.name);
+  const searchLeaks = searchNames.filter((n) => !names.has(n));
+  note(searchLeaks.length === 0, `search_tools (browse-all) leaks nothing (leaks: ${searchLeaks.join(", ") || "none"})`);
+  note(
+    searchNames.length === EXPECTED_BUSINESS,
+    `search_tools browse-all returns the ${EXPECTED_BUSINESS} reviewed tools (got ${searchNames.length})`,
+  );
+
+  // A fiscal query must surface no non-reviewed tool.
+  const fiscal = await rpc("tools/call", { name: "search_tools", arguments: { query: "modelo 303 verifactu" } });
+  const fiscalNames = (parseToolText(fiscal)?.tools || []).map((x) => x.name);
+  note(fiscalNames.every((n) => names.has(n)), "search_tools('modelo 303') surfaces no non-reviewed tool");
+
+  // describe_tool rejects a non-reviewed tool.
+  const desc = await rpc("tools/call", { name: "describe_tool", arguments: { name: "get_quarterly_taxes" } });
+  note(desc?.isError === true, "describe_tool('get_quarterly_taxes') is rejected (not in reviewed catalog)");
+
+  // list_tool_groups totals 53.
+  const groups = await rpc("tools/call", { name: "list_tool_groups", arguments: {} });
+  const gPayload = parseToolText(groups);
+  note(gPayload?.totalTools === EXPECTED_BUSINESS, `list_tool_groups totalTools === ${EXPECTED_BUSINESS} (got ${gPayload?.totalTools})`);
+
+  console.log("");
+  if (failures.length) {
+    console.error(`FAIL — ${failures.length} invariant violation(s):`);
+    for (const f of failures) console.error(`  - ${f}`);
+    process.exit(1);
+  }
+  console.log(`PASS — all ${EXPECTED_TOTAL}-tool composition invariants hold on ${ENDPOINT}`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(`✗ transport/setup error: ${err.message}`);
+  process.exit(2);
+});

--- a/src/__tests__/audit-server-version.test.ts
+++ b/src/__tests__/audit-server-version.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for the server.json version gate in scripts/audit-mcp-refs.mjs.
+ *
+ * Regression guard: server.json carries the package version as BARE JSON values
+ * (root `.version` and `.packages[0].version`). The audit's generic line-scan
+ * version check requires an MCP marker on the same line, which never matched
+ * those bare `"version": "x.y.z"` lines — so a desynced server.json passed the
+ * publish gate silently and caused a Registry 400 "duplicate version" in
+ * release 1.13.1. The `checkServerJsonVersion` helper closes that gap; these
+ * tests prove it FAILS on drift and PASSES when synced.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+// dist/__tests__/ → repo root is ../../ ; scripts + server.json live at root.
+const HERE = resolve(fileURLToPath(import.meta.url), "..");
+const REPO_ROOT = resolve(HERE, "..", "..");
+const SERVER_JSON_PATH = join(REPO_ROOT, "server.json");
+const PKG_PATH = join(REPO_ROOT, "package.json");
+
+// Import the pure helper from the audit script. The script is import-safe:
+// its CLI body is guarded by an `if (isMain)` check, so importing it does not
+// run the audit or call process.exit.
+const auditScriptUrl = pathToFileURL(
+  resolve(REPO_ROOT, "scripts", "audit-mcp-refs.mjs"),
+).href;
+const auditMod = await import(auditScriptUrl);
+const checkServerJsonVersion = auditMod.checkServerJsonVersion as (
+  serverJson: unknown,
+  expectedVersion: string,
+) => Array<{ kind: string; jsonPath: string; found: unknown; expected: string }>;
+
+const SOT_VERSION = JSON.parse(readFileSync(PKG_PATH, "utf8")).version as string;
+
+describe("server.json version gate", () => {
+  test("exports a checkServerJsonVersion helper", () => {
+    assert.equal(typeof checkServerJsonVersion, "function");
+  });
+
+  test("real server.json is in sync with package.json (no drift)", () => {
+    const serverJson = JSON.parse(readFileSync(SERVER_JSON_PATH, "utf8"));
+    const drifts = checkServerJsonVersion(serverJson, SOT_VERSION);
+    assert.deepEqual(
+      drifts,
+      [],
+      `server.json must match SoT ${SOT_VERSION} — drift: ${JSON.stringify(drifts)}`,
+    );
+  });
+
+  test("reports STALE when root .version drifts", () => {
+    const serverJson = JSON.parse(readFileSync(SERVER_JSON_PATH, "utf8"));
+    serverJson.version = "9.9.9";
+    const drifts = checkServerJsonVersion(serverJson, SOT_VERSION);
+    assert.equal(drifts.length, 1, "exactly one drift expected");
+    assert.equal(drifts[0].jsonPath, ".version");
+    assert.equal(drifts[0].found, "9.9.9");
+    assert.equal(drifts[0].expected, SOT_VERSION);
+  });
+
+  test("reports STALE when .packages[0].version drifts", () => {
+    const serverJson = JSON.parse(readFileSync(SERVER_JSON_PATH, "utf8"));
+    serverJson.packages[0].version = "0.0.1";
+    const drifts = checkServerJsonVersion(serverJson, SOT_VERSION);
+    assert.equal(drifts.length, 1);
+    assert.equal(drifts[0].jsonPath, ".packages[0].version");
+    assert.equal(drifts[0].found, "0.0.1");
+  });
+
+  test("reports BOTH fields when both drift", () => {
+    const serverJson = JSON.parse(readFileSync(SERVER_JSON_PATH, "utf8"));
+    serverJson.version = "2.0.0";
+    serverJson.packages[0].version = "2.0.0";
+    const drifts = checkServerJsonVersion(serverJson, SOT_VERSION);
+    assert.equal(drifts.length, 2);
+    assert.deepEqual(
+      drifts.map((d) => d.jsonPath).sort(),
+      [".packages[0].version", ".version"],
+    );
+  });
+
+  test("treats a missing version field as drift (not a silent pass)", () => {
+    const serverJson = JSON.parse(readFileSync(SERVER_JSON_PATH, "utf8"));
+    delete serverJson.version;
+    const drifts = checkServerJsonVersion(serverJson, SOT_VERSION);
+    assert.equal(drifts.length, 1);
+    assert.equal(drifts[0].jsonPath, ".version");
+    assert.equal(drifts[0].found, undefined);
+  });
+
+  // End-to-end proof the gate fires on a real desynced file, written to a temp
+  // copy so the repo's server.json is never mutated. We reproduce the exact
+  // helper-driven check the CLI runs, then confirm the synced copy is clean.
+  test("temp-file round trip: desync fails, sync passes", () => {
+    const dir = mkdtempSync(join(tmpdir(), "frihet-serverjson-"));
+    try {
+      const original = readFileSync(SERVER_JSON_PATH, "utf8");
+      const tmpFile = join(dir, "server.json");
+
+      // Desync the temp copy.
+      const desynced = JSON.parse(original);
+      desynced.version = "0.0.0-stale";
+      writeFileSync(tmpFile, JSON.stringify(desynced, null, 2) + "\n");
+
+      const staleDrifts = checkServerJsonVersion(
+        JSON.parse(readFileSync(tmpFile, "utf8")),
+        SOT_VERSION,
+      );
+      assert.ok(staleDrifts.length > 0, "desynced temp file must report STALE");
+
+      // Re-sync and confirm clean.
+      writeFileSync(tmpFile, original);
+      const cleanDrifts = checkServerJsonVersion(
+        JSON.parse(readFileSync(tmpFile, "utf8")),
+        SOT_VERSION,
+      );
+      assert.deepEqual(cleanDrifts, [], "synced temp file must pass");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/__tests__/openai-grouped-compose.test.ts
+++ b/src/__tests__/openai-grouped-compose.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Tests for the OpenAI × grouped tool-exposure COMPOSITION.
+ *
+ * openai-mcp.frihet.io now runs BOTH profiles: the OpenAI-safe profile
+ * (53 reviewed tools, redaction, openWorldHint justification) AND the grouped
+ * progressive-disclosure profile (terse descriptions + 3 discovery meta-tools).
+ *
+ * This is the Trust-Area-critical surface that the ChatGPT app review covers, so
+ * the three invariants below are asserted explicitly:
+ *
+ *   (1) The 3 grouped meta-tools (search_tools, describe_tool, list_tool_groups)
+ *       are PRESENT in OpenAI mode — they register against the real server and
+ *       bypass the OpenAI allow-list gate. Live surface = 53 + 3 = 56 tools.
+ *   (2) Every one of the 53 reviewed tools has a COLLAPSED (terse) description
+ *       AND still carries the per-tool openWorldHint rationale marker that OpenAI
+ *       app review requires.
+ *   (3) The grouped catalog (what search_tools / describe_tool / list_tool_groups
+ *       surface) contains ONLY the 53 reviewed tools — a tool outside the reviewed
+ *       set is never returned by search_tools and is rejected by describe_tool.
+ *
+ * Composition order under test mirrors the worker/stdio init wiring:
+ *   applyToolExposureProfile(server, { allowlist }) FIRST (innermost),
+ *   applyOpenAIProfile(server) SECOND (outermost).
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  applyOpenAIProfile,
+  OPENAI_REVIEWED_TOOL_ALLOWLIST,
+  OPENAI_ALLOWED_TOOL_COUNT,
+} from "../openai-profile.js";
+import { applyToolExposureProfile, GROUPED_META_TOOL_COUNT } from "../tool-exposure.js";
+import { registerAllTools } from "../tools/register-all.js";
+import { registerAllPrompts } from "../prompts/register-all.js";
+import type { IFrihetClient } from "../client-interface.js";
+
+interface ToolConfig {
+  title?: string;
+  description: string;
+  annotations?: Record<string, unknown>;
+  inputSchema?: Record<string, unknown>;
+  outputSchema?: unknown;
+}
+
+type ToolHandler = (args?: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+}>;
+
+interface RegisteredTool {
+  name: string;
+  config: ToolConfig;
+  handler: ToolHandler;
+}
+
+class StubMcpServer {
+  tools: Map<string, RegisteredTool> = new Map();
+  prompts: string[] = [];
+  resources: string[] = [];
+
+  registerTool(name: string, config: ToolConfig, handler: ToolHandler): void {
+    this.tools.set(name, { name, config, handler });
+  }
+  registerPrompt(name: string): void {
+    this.prompts.push(name);
+  }
+  registerResource(name: string): void {
+    this.resources.push(name);
+  }
+}
+
+/** Client that returns a payload carrying sensitive fields (to test redaction). */
+function makeClient(): IFrihetClient {
+  return new Proxy(
+    {},
+    {
+      get: (_target, prop) => async (input?: unknown) => {
+        if (prop === "createClient") {
+          return {
+            id: "cli_compose",
+            name: "Compose Test Corp",
+            email: "test@example.com",
+            taxId: "B12345678",
+            secret: "should-not-leak",
+          };
+        }
+        return { data: [], total: 0, limit: 10, offset: 0, input };
+      },
+    },
+  ) as IFrihetClient;
+}
+
+const asMcp = (s: StubMcpServer) =>
+  s as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer;
+
+/**
+ * Build a server with BOTH profiles composed in the production order:
+ * grouped (allow-list) first, OpenAI second.
+ */
+function makeComposedServer(): StubMcpServer {
+  const server = new StubMcpServer();
+  // 1. grouped FIRST (innermost) — meta-tools bypass the OpenAI gate; catalog
+  //    pinned to the reviewed allow-list.
+  applyToolExposureProfile(asMcp(server), {
+    allowlist: OPENAI_REVIEWED_TOOL_ALLOWLIST,
+  });
+  // 2. OpenAI SECOND (outermost) — gate/redact/annotate, then collapse.
+  applyOpenAIProfile(asMcp(server));
+  registerAllTools(asMcp(server), makeClient());
+  registerAllPrompts(asMcp(server));
+  return server;
+}
+
+const META_TOOLS = ["list_tool_groups", "search_tools", "describe_tool"] as const;
+
+/** Tools that exist on the full server but must NEVER surface in the composed one. */
+const NON_REVIEWED_TOOLS = [
+  "get_quarterly_taxes",
+  "get_invoice_einvoice",
+  "send_einvoice",
+  "validate_einvoice_xml",
+  "create_reservation",
+  "payroll_export",
+  "invite_team_member",
+  "get_modelo_303_summary",
+] as const;
+
+describe("openai × grouped composition: invariant (1) — meta-tools present, 53+3 surface", () => {
+  test("registers exactly 53 reviewed tools + 3 meta-tools (56 total)", () => {
+    const server = makeComposedServer();
+
+    assert.equal(GROUPED_META_TOOL_COUNT, 3);
+    assert.equal(OPENAI_ALLOWED_TOOL_COUNT, 53, "advertised reviewed count stays 53");
+    assert.equal(
+      server.tools.size,
+      OPENAI_ALLOWED_TOOL_COUNT + GROUPED_META_TOOL_COUNT,
+      "live surface must be the 53 reviewed tools + 3 meta-tools",
+    );
+    assert.equal(server.tools.size, 56);
+
+    // Prompts still hidden in OpenAI mode.
+    assert.equal(server.prompts.length, 0);
+  });
+
+  test("all 3 discovery meta-tools materialise by name despite the OpenAI allow-list", () => {
+    const server = makeComposedServer();
+    for (const meta of META_TOOLS) {
+      assert.equal(
+        server.tools.has(meta),
+        true,
+        `${meta} must survive OpenAI filtering in the composed surface`,
+      );
+    }
+  });
+
+  test("non-reviewed tools are dropped entirely (defence: openai gate)", () => {
+    const server = makeComposedServer();
+    for (const name of NON_REVIEWED_TOOLS) {
+      assert.equal(
+        server.tools.has(name),
+        false,
+        `${name} must NOT be exposed in the composed OpenAI surface`,
+      );
+    }
+  });
+
+  test("meta-tools are read-only, closed-world catalog lookups (NOT openWorldHint)", () => {
+    const server = makeComposedServer();
+    for (const meta of META_TOOLS) {
+      const ann = server.tools.get(meta)!.config.annotations;
+      assert.equal(ann?.readOnlyHint, true, `${meta} must be read-only`);
+      assert.equal(ann?.openWorldHint, false, `${meta} must be closed-world`);
+      // Their descriptions carry an explicit closed-world rationale already (so
+      // the OpenAI rationale-injector does not double-append).
+      assert.match(
+        server.tools.get(meta)!.config.description,
+        /openWorldHint: false/,
+        `${meta} description must state the closed-world rationale`,
+      );
+    }
+  });
+});
+
+describe("openai × grouped composition: invariant (2) — collapsed + openWorldHint on all 53", () => {
+  test("every reviewed tool is collapsed AND carries an openWorldHint rationale", () => {
+    const server = makeComposedServer();
+    let reviewedCount = 0;
+
+    for (const [name, tool] of server.tools) {
+      if ((META_TOOLS as readonly string[]).includes(name)) continue;
+      reviewedCount += 1;
+      const desc = tool.config.description;
+
+      // Collapsed: terse "[group] summary — full schema via describe_tool('name')."
+      assert.match(
+        desc,
+        /^\[[a-z]+\] /,
+        `${name} description must start with the [group] collapsed prefix`,
+      );
+      assert.ok(
+        desc.includes(`describe_tool('${name}')`),
+        `${name} description must point to describe_tool`,
+      );
+      // Terse: collapsed line is short, NOT a multi-paragraph bilingual blob.
+      assert.ok(
+        desc.length < 400,
+        `${name} description must be collapsed (terse), got length ${desc.length}`,
+      );
+
+      // openWorldHint rationale marker survives the collapse.
+      assert.ok(
+        desc.includes("openWorldHint"),
+        `${name} collapsed description must still carry an openWorldHint rationale`,
+      );
+      // Annotation must be an explicit boolean (never null) per OpenAI review.
+      assert.equal(
+        typeof tool.config.annotations?.["openWorldHint"],
+        "boolean",
+        `${name} must have an explicit boolean openWorldHint annotation`,
+      );
+    }
+
+    assert.equal(reviewedCount, OPENAI_ALLOWED_TOOL_COUNT, "must cover all 53 reviewed tools");
+  });
+
+  test("open-world tools keep openWorldHint:true rationale; read tools keep false", () => {
+    const server = makeComposedServer();
+
+    // The 4 reviewed open-world tools carry the true rationale (and not false).
+    for (const name of ["send_invoice", "send_quote", "create_webhook", "update_webhook"]) {
+      const tool = server.tools.get(name)!;
+      assert.equal(tool.config.annotations?.["openWorldHint"], true, `${name} annotation true`);
+      assert.match(
+        tool.config.description,
+        /openWorldHint: true/,
+        `${name} collapsed description must state openWorldHint: true`,
+      );
+      assert.doesNotMatch(
+        tool.config.description,
+        /openWorldHint: false/,
+        `${name} must not also claim false`,
+      );
+    }
+
+    // A read-only tool carries the false rationale.
+    const li = server.tools.get("list_invoices")!;
+    assert.match(li.config.description, /openWorldHint: false/);
+    assert.doesNotMatch(li.config.description, /openWorldHint: true/);
+  });
+
+  test("collapse does not break OpenAI redaction / input-strip / annotation behavior", async () => {
+    const server = makeComposedServer();
+
+    // Government IDs stripped from input schema.
+    assert.equal("taxId" in (server.tools.get("create_client")!.config.inputSchema ?? {}), false);
+    assert.equal("to" in (server.tools.get("send_invoice")!.config.inputSchema ?? {}), false);
+    assert.equal("secret" in (server.tools.get("create_webhook")!.config.inputSchema ?? {}), false);
+
+    // Output redaction wrapper survives the collapse (handler still redacts).
+    const result = await server.tools.get("create_client")!.handler({ name: "Compose Test Corp" });
+    const serialized = JSON.stringify(result);
+    assert.equal(serialized.includes("taxId"), false);
+    assert.equal(serialized.includes("B12345678"), false);
+    assert.equal(serialized.includes("should-not-leak"), false);
+  });
+});
+
+describe("openai × grouped composition: invariant (3) — catalog is allow-list-only", () => {
+  test("list_tool_groups counts exactly the 53 reviewed tools", async () => {
+    const server = makeComposedServer();
+    const res = await server.tools.get("list_tool_groups")!.handler({});
+    const payload = JSON.parse(res.content[0].text) as {
+      groups: Array<{ group: string; toolCount: number }>;
+      totalTools: number;
+    };
+    assert.equal(payload.totalTools, OPENAI_ALLOWED_TOOL_COUNT);
+    const sum = payload.groups.reduce((acc, g) => acc + g.toolCount, 0);
+    assert.equal(sum, OPENAI_ALLOWED_TOOL_COUNT, "group counts must sum to 53");
+    assert.ok(payload.groups.every((g) => g.toolCount > 0), "no empty groups listed");
+    // Reviewed surface has no fiscal/stay/pos/hr tools → those groups must be absent.
+    for (const forbidden of ["fiscal", "stay", "pos", "hr", "banking"]) {
+      assert.ok(
+        !payload.groups.some((g) => g.group === forbidden),
+        `group ${forbidden} must not appear (no reviewed tools in it)`,
+      );
+    }
+  });
+
+  test("search_tools NEVER returns a tool outside the reviewed allow-list (browse all)", async () => {
+    const server = makeComposedServer();
+    // Empty query + huge limit = browse the entire catalog.
+    const res = await server.tools.get("search_tools")!.handler({ query: "", limit: 500 });
+    const payload = JSON.parse(res.content[0].text) as {
+      count: number;
+      tools: Array<{ name: string }>;
+    };
+    assert.equal(payload.count, OPENAI_ALLOWED_TOOL_COUNT, "browse-all returns exactly the 53");
+    const leaks = payload.tools.filter((t) => !OPENAI_REVIEWED_TOOL_ALLOWLIST.has(t.name));
+    assert.deepEqual(leaks, [], "search_tools must not surface any non-reviewed tool");
+  });
+
+  test("search_tools for a fiscal term yields nothing (fiscal tools are not in the catalog)", async () => {
+    const server = makeComposedServer();
+    // 'modelo 303' would top-rank get_modelo_303_summary on the full grouped
+    // server. Here that tool is NOT in the catalog, so it must not appear.
+    const res = await server.tools.get("search_tools")!.handler({ query: "modelo 303 verifactu" });
+    const payload = JSON.parse(res.content[0].text) as {
+      tools: Array<{ name: string }>;
+    };
+    const leaks = payload.tools.filter((t) => !OPENAI_REVIEWED_TOOL_ALLOWLIST.has(t.name));
+    assert.deepEqual(leaks, [], "no fiscal/non-reviewed tool may be returned");
+    assert.ok(
+      !payload.tools.some((t) => t.name === "get_modelo_303_summary"),
+      "get_modelo_303_summary (non-reviewed) must never surface",
+    );
+  });
+
+  test("search_tools group filter cannot reach a non-reviewed group", async () => {
+    const server = makeComposedServer();
+    // Even explicitly asking for the fiscal group returns nothing, because no
+    // fiscal tool was catalogued.
+    const res = await server.tools.get("search_tools")!.handler({
+      query: "",
+      group: "fiscal",
+      limit: 100,
+    });
+    const payload = JSON.parse(res.content[0].text) as { tools: unknown[] };
+    assert.equal(payload.tools.length, 0, "fiscal group is empty in the reviewed catalog");
+  });
+
+  test("describe_tool serves reviewed tools but REJECTS any tool outside the 53", async () => {
+    const server = makeComposedServer();
+
+    // A reviewed tool resolves.
+    const ok = await server.tools.get("describe_tool")!.handler({ name: "list_invoices" });
+    const okPayload = JSON.parse(ok.content[0].text) as { name: string; description: string };
+    assert.equal(ok.isError, undefined);
+    assert.equal(okPayload.name, "list_invoices");
+
+    // Every non-reviewed tool is rejected (not in the catalog).
+    for (const name of NON_REVIEWED_TOOLS) {
+      const res = await server.tools.get("describe_tool")!.handler({ name });
+      assert.equal(res.isError, true, `describe_tool('${name}') must error — not in reviewed catalog`);
+      const payload = JSON.parse(res.content[0].text) as {
+        error: string;
+        suggestions: string[];
+      };
+      assert.match(payload.error, /No tool named/);
+      // Suggestions can only ever be reviewed tools — never a leak.
+      for (const s of payload.suggestions) {
+        assert.ok(
+          OPENAI_REVIEWED_TOOL_ALLOWLIST.has(s),
+          `describe_tool suggestion '${s}' must be a reviewed tool, not a leak`,
+        );
+      }
+    }
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import { FrihetClient } from "./client.js";
 import { registerAllTools } from "./tools/register-all.js";
 import { registerAllResources } from "./resources/register-all.js";
 import { registerAllPrompts } from "./prompts/register-all.js";
-import { applyOpenAIProfile, OPENAI_ALLOWED_TOOL_COUNT, OPENAI_EXCLUDED_COUNT, OPENAI_EXCLUDED_RESOURCE_COUNT } from "./openai-profile.js";
+import { applyOpenAIProfile, OPENAI_ALLOWED_TOOL_COUNT, OPENAI_EXCLUDED_COUNT, OPENAI_EXCLUDED_RESOURCE_COUNT, OPENAI_REVIEWED_TOOL_ALLOWLIST } from "./openai-profile.js";
 import { resolveToolMode, applyToolExposureProfile, GROUPED_META_TOOL_COUNT } from "./tool-exposure.js";
 import { log } from "./logger.js";
 import { registerShutdownHook } from "./metrics.js";
@@ -87,30 +87,46 @@ function main(): void {
       "with full Spanish tax compliance (IVA, IGIC, IPSI).",
   });
 
-  // Apply OpenAI-safe profile if enabled (strips sensitive fields, fixes annotations)
   const openaiMode = process.env.FRIHET_OPENAI_MODE === "true";
+  const toolMode = resolveToolMode();
+
+  // PROFILE COMPOSITION ORDER (both interceptors wrap registerTool):
+  //   1. applyToolExposureProfile FIRST (innermost) — so the 3 discovery
+  //      meta-tools register against the REAL server.registerTool and bypass the
+  //      OpenAI allow-list gate. In allow-list mode it catalogs ONLY the reviewed
+  //      tools, keeping the progressive-disclosure surface == the reviewed 53.
+  //   2. applyOpenAIProfile SECOND (outermost) — a business-tool registration is
+  //      first gated/redacted/annotated/openWorldHint-justified by OpenAI, THEN
+  //      collapsed by the grouped interceptor, so the terse collapsed line is the
+  //      final description and OpenAI's handler redaction survives.
+  // Order only matters when BOTH are active (openai-mcp grouped); openai-only and
+  // grouped-only are unaffected by the swap.
+
+  // Apply grouped tool-exposure profile if enabled (progressive disclosure).
+  // FRIHET_TOOL_MODE=grouped collapses the full tool descriptions into terse
+  // one-liners + adds list_tool_groups / search_tools / describe_tool meta-tools,
+  // so agents load depth on demand instead of a flat 151-tool wall of context.
+  // Default (unset / "full") is byte-identical to current behavior. When OpenAI
+  // mode is also on, pass the reviewed allow-list so the catalog/meta-tools are
+  // pinned to exactly the 53 reviewed tools.
+  if (toolMode === "grouped") {
+    applyToolExposureProfile(
+      server,
+      openaiMode ? { allowlist: OPENAI_REVIEWED_TOOL_ALLOWLIST } : undefined,
+    );
+    log({
+      level: "info",
+      message: `Grouped tool-exposure active — tools collapsed to terse summaries, ${GROUPED_META_TOOL_COUNT} discovery meta-tools added (list_tool_groups, search_tools, describe_tool); full depth served on demand`,
+      operation: "startup",
+    });
+  }
+
+  // Apply OpenAI-safe profile if enabled (strips sensitive fields, fixes annotations)
   if (openaiMode) {
     applyOpenAIProfile(server);
     log({
       level: "info",
       message: `OpenAI safety profile active — ${OPENAI_ALLOWED_TOOL_COUNT} tools allowed, prompts hidden, ${OPENAI_EXCLUDED_COUNT} defense-in-depth exclusions, ${OPENAI_EXCLUDED_RESOURCE_COUNT} resources excluded, gov IDs + credentials redacted`,
-      operation: "startup",
-    });
-  }
-
-  // Apply grouped tool-exposure profile if enabled (progressive disclosure).
-  // FRIHET_TOOL_MODE=grouped collapses the 151 full tool descriptions into terse
-  // one-liners + adds list_tool_groups / search_tools / describe_tool meta-tools,
-  // so agents load depth on demand instead of a flat 151-tool wall of context.
-  // Default (unset / "full") is byte-identical to current behavior. Independent
-  // of OpenAI mode; if both are set, OpenAI's allowlist runs first, then this
-  // collapses whatever survived.
-  const toolMode = resolveToolMode();
-  if (toolMode === "grouped") {
-    applyToolExposureProfile(server);
-    log({
-      level: "info",
-      message: `Grouped tool-exposure active — 151 tools collapsed to terse summaries, ${GROUPED_META_TOOL_COUNT} discovery meta-tools added (list_tool_groups, search_tools, describe_tool); full depth served on demand`,
       operation: "startup",
     });
   }

--- a/src/openai-profile.ts
+++ b/src/openai-profile.ts
@@ -463,5 +463,23 @@ export const OPENAI_EXCLUDED_COUNT = PROFILE.excludeTools.size;
 /** Number of tools explicitly allowed in OpenAI mode. */
 export const OPENAI_ALLOWED_TOOL_COUNT = PROFILE.includeTools.size;
 
+/**
+ * The reviewed OpenAI tool allow-list (the 53 business tools), exposed read-only
+ * so the grouped tool-exposure profile can pin its catalog to EXACTLY this set
+ * when the two profiles are composed on openai-mcp.frihet.io. The progressive-
+ * disclosure meta-tools (search_tools / describe_tool / list_tool_groups) must
+ * never surface a tool outside this allow-list; passing it as the grouped
+ * `allowlist` enforces that statically. This is the SAME object used to gate
+ * registerTool, so the two can never drift apart.
+ *
+ * NOTE: this is the 53 BUSINESS tools only. It deliberately does NOT contain the
+ * 3 grouped meta-tools — those are registered directly on the real server
+ * (bypassing the OpenAI gate) by applyToolExposureProfile when it runs first, so
+ * OPENAI_ALLOWED_TOOL_COUNT (and every advertised "53 reviewed tools" doc) stays
+ * correct while the live tools/list still materialises 53 + 3 = 56 tools.
+ */
+export const OPENAI_REVIEWED_TOOL_ALLOWLIST: ReadonlySet<string> =
+  PROFILE.includeTools;
+
 /** Number of resources excluded in OpenAI mode (for logging). */
 export const OPENAI_EXCLUDED_RESOURCE_COUNT = EXCLUDE_RESOURCES.size;

--- a/src/tool-exposure.ts
+++ b/src/tool-exposure.ts
@@ -307,16 +307,35 @@ export function resolveToolMode(
  * registration completes.
  *
  * @param server  The McpServer (typed loosely to match the openai-profile shim).
+ * @param options.allowlist  When provided, ONLY tools whose name is in this set
+ *   are catalogued + collapsed; any other tool is passed through untouched.
+ *   This is the OpenAI-composition path: it pins the grouped catalog (and the
+ *   tools search_tools / describe_tool / list_tool_groups surface) to EXACTLY
+ *   the reviewed allow-list, so progressive disclosure can never reveal or
+ *   describe a tool outside the 53-tool ChatGPT-reviewed surface. Omit (default)
+ *   for the open mcp.frihet.io surface, which catalogs every registered tool.
+ *
+ *   COMPOSITION ORDERING (openai-mcp): apply this profile FIRST so its
+ *   originalRegisterTool is the REAL server.registerTool — the three meta-tools
+ *   are then registered straight onto the real server and BYPASS the OpenAI
+ *   allow-list gate entirely (so they always materialise without polluting the
+ *   OpenAI includeTools set / its advertised 53-tool count). Apply
+ *   applyOpenAIProfile() SECOND (outermost) so a business-tool registration is
+ *   first redacted + annotated + openWorldHint-justified by OpenAI, and only
+ *   THEN collapsed here — making the terse line the final description while the
+ *   OpenAI redaction wrapper around the handler survives intact.
  * @returns a handle exposing the live catalog (useful for tests/logging).
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function applyToolExposureProfile(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   server: any,
+  options?: { allowlist?: ReadonlySet<string> },
 ): ToolExposureHandle {
   const catalog = new Map<string, CatalogEntry>();
   const groups = new Map<ToolGroupId, string[]>();
   const handle: ToolExposureHandle = { catalog, groups };
+  const allowlist = options?.allowlist;
 
   const originalRegisterTool = server.registerTool.bind(server);
 
@@ -325,6 +344,16 @@ export function applyToolExposureProfile(
     // Never re-process our own meta-tools (they are registered via the original
     // bound fn below, so they won't hit this interceptor — but guard anyway).
     if (META_TOOL_NAMES.has(name)) {
+      return originalRegisterTool(name, config, handler);
+    }
+
+    // Allow-list mode (OpenAI composition): only catalogue + collapse reviewed
+    // tools. Anything outside the allow-list is passed through untouched so it
+    // never enters the catalogue that search_tools / describe_tool expose. (In
+    // the openai-mcp wiring the OpenAI profile already dropped non-reviewed
+    // tools before they reach here; this is the defence-in-depth that GUARANTEES
+    // the catalog is allow-list-only even if the upstream gate ever changes.)
+    if (allowlist && !allowlist.has(name)) {
       return originalRegisterTool(name, config, handler);
     }
 
@@ -354,9 +383,28 @@ export function applyToolExposureProfile(
     // Collapse the registered description to a single terse pointer line. The
     // tool stays fully invocable with its original handler, schema, and
     // annotations — only the description string the agent loads is trimmed.
-    config.description =
+    //
+    // openWorldHint rationale MUST survive the collapse (OpenAI app review needs
+    // a per-tool open-world justification on EVERY reviewed tool). When composed
+    // with the OpenAI profile, that profile runs first (outermost) and has
+    // already set the correct annotations.openWorldHint (e.g. true for
+    // send_invoice / send_quote / create_webhook / update_webhook). We re-derive
+    // the one-line rationale here from the (now-correct) annotation so the terse
+    // collapsed description carries it — instead of letting the OpenAI-injected
+    // rationale be lost when we overwrite config.description. Only appended in
+    // allow-list (composition) mode; the open mcp.frihet.io surface keeps its
+    // pure terse line (no OpenAI review constraint there).
+    let collapsed =
       `[${group}] ${entry.summary} ` +
       `— full schema via describe_tool('${name}').`;
+    if (allowlist) {
+      const ow = config?.annotations?.openWorldHint;
+      collapsed +=
+        ow === true
+          ? " [openWorldHint: true — contacts an entity outside Frihet (an email recipient or an external webhook URL).]"
+          : " [openWorldHint: false — operates only against the Frihet API (api.frihet.io); no third-party/external calls.]";
+    }
+    config.description = collapsed;
 
     return originalRegisterTool(name, config, handler);
   };

--- a/workers/remote-mcp/src/index.ts
+++ b/workers/remote-mcp/src/index.ts
@@ -28,7 +28,7 @@ import { McpAgent } from "agents/mcp";
 import { registerAllTools } from "../../../src/tools/register-all.js";
 import { registerAllResources } from "../../../src/resources/register-all.js";
 import { registerAllPrompts } from "../../../src/prompts/register-all.js";
-import { applyOpenAIProfile, OPENAI_ALLOWED_TOOL_COUNT, OPENAI_EXCLUDED_COUNT, OPENAI_CSP } from "../../../src/openai-profile.js";
+import { applyOpenAIProfile, OPENAI_ALLOWED_TOOL_COUNT, OPENAI_EXCLUDED_COUNT, OPENAI_CSP, OPENAI_REVIEWED_TOOL_ALLOWLIST } from "../../../src/openai-profile.js";
 import { resolveToolMode, applyToolExposureProfile, GROUPED_META_TOOL_COUNT } from "../../../src/tool-exposure.js";
 import { log } from "../../../src/logger.js";
 import { initLangfuse, setTraceContext } from "../../../src/observability.js";
@@ -98,26 +98,45 @@ export class FrihetMCP extends McpAgent<Env, Record<string, never>, AuthProps> {
     // Structurally identical at runtime — this is safe.
     const server = this.server as unknown as Parameters<typeof registerAllTools>[0];
 
-    // Apply OpenAI-safe profile if this worker is deployed in OpenAI mode
     const openaiMode = this.env.FRIHET_OPENAI_MODE === "true";
+    const toolMode = resolveToolMode({ FRIHET_TOOL_MODE: this.env.FRIHET_TOOL_MODE });
+
+    // PROFILE COMPOSITION ORDER (both interceptors wrap registerTool):
+    //   1. applyToolExposureProfile FIRST (innermost) — registers the 3 discovery
+    //      meta-tools against the REAL server.registerTool so they BYPASS the
+    //      OpenAI allow-list gate and always materialise. In allow-list mode the
+    //      catalog (and search_tools / describe_tool / list_tool_groups) is pinned
+    //      to EXACTLY the reviewed tools.
+    //   2. applyOpenAIProfile SECOND (outermost) — gates/redacts/annotates and
+    //      injects the openWorldHint rationale FIRST, then the grouped interceptor
+    //      collapses the description (re-deriving the rationale so it survives) and
+    //      preserves OpenAI's handler redaction wrapper.
+    // Swap only matters when BOTH are on (openai-mcp grouped). openai-only
+    // (no grouped) and grouped-only (mcp.frihet.io) are unchanged by the order.
+
+    // Apply grouped tool-exposure profile if this worker is deployed with
+    // FRIHET_TOOL_MODE=grouped (progressive disclosure). Reads the Worker env
+    // binding (not process.env). Default ("full") is byte-identical to before.
+    // In OpenAI mode, pass the reviewed allow-list so progressive disclosure can
+    // never reveal or describe a tool outside the 53-tool ChatGPT-reviewed set.  // mcp-refs:ok
+    if (toolMode === "grouped") {
+      applyToolExposureProfile(
+        server,
+        openaiMode ? { allowlist: OPENAI_REVIEWED_TOOL_ALLOWLIST } : undefined,
+      );
+      log({
+        level: "info",
+        message: `Grouped tool-exposure active — tools collapsed to terse summaries, ${GROUPED_META_TOOL_COUNT} discovery meta-tools added; full depth served on demand`,
+        operation: "session_init",
+      });
+    }
+
+    // Apply OpenAI-safe profile if this worker is deployed in OpenAI mode
     if (openaiMode) {
       applyOpenAIProfile(server);
       log({
         level: "info",
         message: `OpenAI safety profile active — ${OPENAI_ALLOWED_TOOL_COUNT} tools allowed, prompts hidden, ${OPENAI_EXCLUDED_COUNT} defense-in-depth exclusions`,
-        operation: "session_init",
-      });
-    }
-
-    // Apply grouped tool-exposure profile if this worker is deployed with
-    // FRIHET_TOOL_MODE=grouped (progressive disclosure). Reads the Worker env
-    // binding (not process.env). Default ("full") is byte-identical to before.
-    const toolMode = resolveToolMode({ FRIHET_TOOL_MODE: this.env.FRIHET_TOOL_MODE });
-    if (toolMode === "grouped") {
-      applyToolExposureProfile(server);
-      log({
-        level: "info",
-        message: `Grouped tool-exposure active — tools collapsed to terse summaries, ${GROUPED_META_TOOL_COUNT} discovery meta-tools added; full depth served on demand`,
         operation: "session_init",
       });
     }

--- a/workers/remote-mcp/wrangler.toml
+++ b/workers/remote-mcp/wrangler.toml
@@ -50,15 +50,22 @@ routes = [{ pattern = "openai-mcp.frihet.io/*", zone_name = "frihet.io" }]
 
 [env.openai.vars]
 FRIHET_OPENAI_MODE = "true"
-# Explicit "full" (not "grouped"). The OpenAI
-# profile (applyOpenAIProfile) and grouped profile (applyToolExposureProfile)
-# both intercept registerTool and do NOT compose: the OpenAI allow-list drops
-# the grouped meta-tools, leaving collapsed summaries that point at a
-# describe_tool() that no longer exists, and grouped's collapse strips the
-# per-tool openWorldHint rationale that OpenAI app review requires. Enabling
-# grouped on the ChatGPT surface needs a real composition fix + tests, not this
-# flag. Tracked as follow-up. mcp.frihet.io (non-openai) runs grouped fine.
-FRIHET_TOOL_MODE = "full"
+# "grouped" — the two profiles NOW COMPOSE (see src/index.ts init wiring +
+# src/__tests__/openai-grouped-compose.test.ts). applyToolExposureProfile runs
+# FIRST (allowlist = the 53 reviewed tools) so its 3 discovery meta-tools
+# (search_tools / describe_tool / list_tool_groups) register on the REAL server
+# and BYPASS the OpenAI allow-list gate; applyOpenAIProfile runs SECOND so each
+# business tool is redacted + openWorldHint-justified, THEN collapsed (the
+# collapse re-derives the openWorldHint rationale so it survives, and the OpenAI
+# handler-redaction wrapper is preserved). The grouped catalog is pinned to the
+# allow-list, so progressive disclosure can never surface a tool outside the 53.
+# Live surface = 53 reviewed business tools + 3 read-only closed-world meta-tools
+# (56 total). The advertised "53 reviewed tools" count (OPENAI_ALLOWED_TOOL_COUNT)
+# is unchanged — meta-tools are discovery plumbing, not business capability.
+# ⚠️ COMPLIANCE: 53→56 tools/list change on the ChatGPT surface. Requires
+# Viktor's prod flip + an OpenAI app re-review BEFORE going live (see
+# DECISION_SPEC.md). Rollback = set back to "full" + redeploy.
+FRIHET_TOOL_MODE = "grouped"
 
 # DO and KV are NOT inherited — must be redeclared
 [env.openai.durable_objects]


### PR DESCRIPTION
Closes followups A1 + A2 + A3 of the MCP-10/10 megasprint.

## A1 — openai+grouped composition (Trust Area)
openai-mcp now runs **grouped** (53 reviewed tools collapsed + 3 read-only meta-tools) instead of `full`. Order pinned (grouped inner+allowlist, openai outer) so meta-tools bypass the gate, the collapse re-derives the openWorldHint rationale, and the catalog can never surface a tool outside the 53. 12-case invariant test, wired into `npm test` (294 pass). Adversarial verify PASS on all 3 invariants.

**✅ DEPLOYED + live-smoke verified** (`openai-mcp.frihet.io` = 56 tools, openWorldHint on all 53, meta read-only/closed-world, describe_tool rejects non-53).

⚠️ **COMPLIANCE:** this is a 53→56 tools/list change on the ChatGPT surface → needs OpenAI app re-review at submission/update. Rollback = `FRIHET_TOOL_MODE=full` + redeploy.

## A2 — server.json publish gate
`audit:mcp-refs` now validates `server.json` `.version` + `.packages[0].version` (was silent → caused Registry 400 duplicate on 1.13.1). 7-case test; `prepublishOnly` now catches desync.

## A3 — version refs → 1.13.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)