### PR TITLE
feat(kitchen): 6 Kitchen KDS MCP tools (Wave 6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "npm run build && node --test dist/__tests__/openai-profile.test.js dist/__tests__/tool-exposure.test.js dist/__tests__/einvoice-tools.test.js dist/__tests__/einvoice-day4-tools.test.js dist/__tests__/stay-tools.test.js dist/__tests__/pos-tools.test.js dist/__tests__/banking-tools.test.js dist/__tests__/fiscal-tools.test.js dist/__tests__/time-tools.test.js dist/__tests__/recurring-tools.test.js dist/__tests__/team-tools.test.js dist/__tests__/d4b-hr-payroll-onboarding-tools.test.js dist/__tests__/audit-server-version.test.js dist/__tests__/openai-grouped-compose.test.js",
+    "test": "npm run build && node --test dist/__tests__/openai-profile.test.js dist/__tests__/tool-exposure.test.js dist/__tests__/einvoice-tools.test.js dist/__tests__/einvoice-day4-tools.test.js dist/__tests__/stay-tools.test.js dist/__tests__/pos-tools.test.js dist/__tests__/kitchen-tools.test.js dist/__tests__/banking-tools.test.js dist/__tests__/fiscal-tools.test.js dist/__tests__/time-tools.test.js dist/__tests__/recurring-tools.test.js dist/__tests__/team-tools.test.js dist/__tests__/d4b-hr-payroll-onboarding-tools.test.js dist/__tests__/audit-server-version.test.js dist/__tests__/openai-grouped-compose.test.js",
     "start": "node dist/index.js",
     "postinstall": "node scripts/postinstall.js || true",
     "prepublishOnly": "npm run build && npm run audit:mcp-refs -- --repo frihet-mcp",

--- a/src/__tests__/kitchen-tools.test.ts
+++ b/src/__tests__/kitchen-tools.test.ts
@@ -1,0 +1,509 @@
+/**
+ * Tests for Kitchen MCP tools — Wave 6 (6 tools).
+ *
+ * Uses Node.js built-in test runner (node:test + node:assert).
+ * Run: npm test (after build)
+ *
+ * Coverage:
+ *   1. Tool registration — all 6 tools registered on McpServer
+ *   2. list_kitchen_tickets — success path + structuredContent shape
+ *   3. get_kitchen_ticket — success path + structuredContent shape
+ *   4. update_kitchen_ticket — success path + structuredContent shape
+ *   5. list_kitchen_stations — success path + structuredContent shape
+ *   6. list_menu_items — success path + structuredContent shape
+ *   7. kitchen_flow_summary — success path + bottleneck detection
+ *   8. API error path — 404 propagated through handleToolError
+ */
+
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+// ── Minimal McpServer stub ───────────────────────────────────────────────────
+
+interface ToolConfig {
+  title: string;
+  description: string;
+  annotations?: Record<string, unknown>;
+  inputSchema: Record<string, unknown>;
+  outputSchema?: unknown;
+}
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+}>;
+
+interface RegisteredTool {
+  name: string;
+  config: ToolConfig;
+  handler: ToolHandler;
+}
+
+class StubMcpServer {
+  tools: Map<string, RegisteredTool> = new Map();
+
+  registerTool(name: string, config: ToolConfig, handler: ToolHandler): void {
+    this.tools.set(name, { name, config, handler });
+  }
+}
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const MOCK_TICKET = {
+  id: "tkt_001",
+  stationId: "sta_grill",
+  status: "preparing",
+  tableRef: "T4",
+  items: [
+    { id: "ti_001", menuItemId: "mi_burger", name: "Burger", quantity: 2, notes: "no onions", status: "preparing" },
+  ],
+  createdAt: "2026-06-15T12:00:00Z",
+  updatedAt: "2026-06-15T12:01:00Z",
+};
+
+const MOCK_TICKET_2 = {
+  id: "tkt_002",
+  stationId: "sta_grill",
+  status: "queued",
+  tableRef: "T5",
+  items: [
+    { id: "ti_002", menuItemId: "mi_fries", name: "Fries", quantity: 1, notes: "", status: "queued" },
+  ],
+  createdAt: "2026-06-15T12:02:00Z",
+  updatedAt: "2026-06-15T12:02:00Z",
+};
+
+const MOCK_TICKET_3 = {
+  id: "tkt_003",
+  stationId: "sta_bar",
+  status: "ready",
+  tableRef: "T2",
+  items: [
+    { id: "ti_003", menuItemId: "mi_mojito", name: "Mojito", quantity: 3, notes: "", status: "ready" },
+  ],
+  createdAt: "2026-06-15T12:05:00Z",
+  updatedAt: "2026-06-15T12:06:00Z",
+};
+
+const MOCK_TICKETS_LIST = {
+  data: [MOCK_TICKET, MOCK_TICKET_2, MOCK_TICKET_3],
+  total: 3,
+  limit: 100,
+  offset: 0,
+};
+
+const MOCK_STATION = {
+  id: "sta_grill",
+  name: "Grill",
+  isActive: true,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+const MOCK_STATION_2 = {
+  id: "sta_bar",
+  name: "Bar",
+  isActive: true,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+const MOCK_STATIONS_LIST = {
+  data: [MOCK_STATION, MOCK_STATION_2],
+  total: 2,
+  limit: 100,
+  offset: 0,
+};
+
+const MOCK_MENU_ITEM = {
+  id: "mi_burger",
+  name: "Burger",
+  description: "Classic beef burger",
+  priceCents: 1200,
+  category: "Main",
+  isActive: true,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+const MOCK_MENU_ITEMS_LIST = {
+  data: [MOCK_MENU_ITEM],
+  total: 1,
+  limit: 20,
+  offset: 0,
+};
+
+const MOCK_UPDATED_TICKET = { ...MOCK_TICKET, status: "ready" };
+
+// ── Client stubs ─────────────────────────────────────────────────────────────
+
+function makeSuccessClient(): import("../client-interface.js").IFrihetClient {
+  return {
+    listKitchenTickets: async () => MOCK_TICKETS_LIST,
+    getKitchenTicket: async (_id: string) => MOCK_TICKET,
+    updateKitchenTicket: async (_id: string, _data: Record<string, unknown>) => MOCK_UPDATED_TICKET,
+    listKitchenStations: async () => MOCK_STATIONS_LIST,
+    listMenuItems: async () => MOCK_MENU_ITEMS_LIST,
+  } as unknown as import("../client-interface.js").IFrihetClient;
+}
+
+function make404Client(): import("../client-interface.js").IFrihetClient {
+  const notFound = () => {
+    const err = Object.assign(new Error("Not Found"), { statusCode: 404, errorCode: "not_found" });
+    return Promise.reject(err);
+  };
+  return {
+    listKitchenTickets: notFound,
+    getKitchenTicket: notFound,
+    updateKitchenTicket: notFound,
+    listKitchenStations: notFound,
+    listMenuItems: notFound,
+  } as unknown as import("../client-interface.js").IFrihetClient;
+}
+
+// ── Helper ───────────────────────────────────────────────────────────────────
+
+async function makeServer(
+  clientFn: () => import("../client-interface.js").IFrihetClient,
+): Promise<StubMcpServer> {
+  const server = new StubMcpServer();
+  const { registerKitchenTools } = await import("../tools/kitchen.js");
+  registerKitchenTools(
+    server as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer,
+    clientFn(),
+  );
+  return server;
+}
+
+// ── Registration tests ───────────────────────────────────────────────────────
+
+describe("Kitchen Tools — Registration", () => {
+  let server: StubMcpServer;
+
+  beforeEach(async () => {
+    server = await makeServer(makeSuccessClient);
+  });
+
+  test("registers exactly 6 kitchen tools", () => {
+    assert.equal(server.tools.size, 6);
+  });
+
+  test("registers list_kitchen_tickets", () => {
+    assert.ok(server.tools.has("list_kitchen_tickets"), "list_kitchen_tickets not registered");
+  });
+
+  test("registers get_kitchen_ticket", () => {
+    assert.ok(server.tools.has("get_kitchen_ticket"), "get_kitchen_ticket not registered");
+  });
+
+  test("registers update_kitchen_ticket", () => {
+    assert.ok(server.tools.has("update_kitchen_ticket"), "update_kitchen_ticket not registered");
+  });
+
+  test("registers list_kitchen_stations", () => {
+    assert.ok(server.tools.has("list_kitchen_stations"), "list_kitchen_stations not registered");
+  });
+
+  test("registers list_menu_items", () => {
+    assert.ok(server.tools.has("list_menu_items"), "list_menu_items not registered");
+  });
+
+  test("registers kitchen_flow_summary", () => {
+    assert.ok(server.tools.has("kitchen_flow_summary"), "kitchen_flow_summary not registered");
+  });
+});
+
+// ── Output schemas ────────────────────────────────────────────────────────────
+
+describe("Kitchen Tools — Output schemas", () => {
+  test("all tools have an outputSchema", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const expected = [
+      "list_kitchen_tickets",
+      "get_kitchen_ticket",
+      "update_kitchen_ticket",
+      "list_kitchen_stations",
+      "list_menu_items",
+      "kitchen_flow_summary",
+    ];
+    for (const name of expected) {
+      const tool = server.tools.get(name)!;
+      assert.ok(tool.config.outputSchema, `${name} must have outputSchema`);
+    }
+  });
+});
+
+// ── list_kitchen_tickets ──────────────────────────────────────────────────────
+
+describe("list_kitchen_tickets — success path", () => {
+  test("returns structuredContent with data array", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_kitchen_tickets")!;
+    const result = await tool.handler({ limit: 100, offset: 0 });
+
+    assert.ok(!result.isError, "should not be an error");
+    assert.ok(result.structuredContent, "structuredContent missing");
+    const sc = result.structuredContent!;
+    assert.ok(Array.isArray(sc["data"]), "data should be an array");
+    assert.equal((sc["data"] as unknown[]).length, 3);
+    assert.equal(sc["total"], 3);
+  });
+
+  test("first ticket has expected fields", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_kitchen_tickets")!;
+    const result = await tool.handler({});
+
+    const sc = result.structuredContent!;
+    const first = (sc["data"] as Record<string, unknown>[])[0]!;
+    assert.equal(first["id"], "tkt_001");
+    assert.equal(first["status"], "preparing");
+    assert.equal(first["stationId"], "sta_grill");
+    assert.equal(first["tableRef"], "T4");
+  });
+
+  test("content block has type text and mentions tickets", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_kitchen_tickets")!;
+    const result = await tool.handler({});
+
+    assert.ok(Array.isArray(result.content));
+    assert.equal(result.content[0]!.type, "text");
+    assert.ok(result.content[0]!.text.includes("kitchen tickets"));
+  });
+
+  test("404 error propagates as isError=true", async () => {
+    const server = await makeServer(make404Client);
+    const tool = server.tools.get("list_kitchen_tickets")!;
+    const result = await tool.handler({});
+    assert.ok(result.isError, "should be an error on 404");
+    assert.ok(result.content[0]!.text.includes("Error:"));
+  });
+});
+
+// ── get_kitchen_ticket ────────────────────────────────────────────────────────
+
+describe("get_kitchen_ticket — success path", () => {
+  test("returns single ticket by ID", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("get_kitchen_ticket")!;
+    const result = await tool.handler({ id: "tkt_001" });
+
+    assert.ok(!result.isError);
+    const sc = result.structuredContent!;
+    assert.equal(sc["id"], "tkt_001");
+    assert.equal(sc["status"], "preparing");
+    assert.equal(sc["stationId"], "sta_grill");
+  });
+
+  test("404 error propagates as isError=true", async () => {
+    const server = await makeServer(make404Client);
+    const tool = server.tools.get("get_kitchen_ticket")!;
+    const result = await tool.handler({ id: "tkt_missing" });
+
+    assert.ok(result.isError, "should be an error on 404");
+    assert.ok(result.content[0]!.text.includes("Error:"));
+  });
+});
+
+// ── update_kitchen_ticket ─────────────────────────────────────────────────────
+
+describe("update_kitchen_ticket — success path", () => {
+  test("returns updated ticket with new status", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("update_kitchen_ticket")!;
+    const result = await tool.handler({ id: "tkt_001", status: "ready" });
+
+    assert.ok(!result.isError);
+    const sc = result.structuredContent!;
+    assert.equal(sc["id"], "tkt_001");
+    assert.equal(sc["status"], "ready");
+  });
+
+  test("content block is a mutate-type annotated text", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("update_kitchen_ticket")!;
+    const result = await tool.handler({ id: "tkt_001", status: "ready" });
+
+    assert.equal(result.content[0]!.type, "text");
+    assert.ok(result.content[0]!.text.includes("Kitchen ticket updated"));
+  });
+
+  test("calls client.updateKitchenTicket with correct args", async () => {
+    let calledId: string | undefined;
+    let calledData: Record<string, unknown> | undefined;
+    const client = {
+      updateKitchenTicket: async (id: string, data: Record<string, unknown>) => {
+        calledId = id;
+        calledData = data;
+        return MOCK_UPDATED_TICKET;
+      },
+    } as unknown as import("../client-interface.js").IFrihetClient;
+
+    const server = new StubMcpServer();
+    const { registerKitchenTools } = await import("../tools/kitchen.js");
+    registerKitchenTools(
+      server as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer,
+      client,
+    );
+
+    await server.tools.get("update_kitchen_ticket")!.handler({ id: "tkt_001", status: "ready", stationId: "sta_bar" });
+    assert.equal(calledId, "tkt_001");
+    assert.equal(calledData?.["status"], "ready");
+    assert.equal(calledData?.["stationId"], "sta_bar");
+  });
+});
+
+// ── list_kitchen_stations ─────────────────────────────────────────────────────
+
+describe("list_kitchen_stations — success path", () => {
+  test("returns stations list with total", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_kitchen_stations")!;
+    const result = await tool.handler({});
+
+    assert.ok(!result.isError);
+    const sc = result.structuredContent!;
+    assert.ok(Array.isArray(sc["data"]));
+    assert.equal(sc["total"], 2);
+  });
+
+  test("first station has expected fields", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_kitchen_stations")!;
+    const result = await tool.handler({});
+
+    const first = (result.structuredContent!["data"] as Record<string, unknown>[])[0]!;
+    assert.equal(first["id"], "sta_grill");
+    assert.equal(first["name"], "Grill");
+    assert.equal(first["isActive"], true);
+  });
+});
+
+// ── list_menu_items ───────────────────────────────────────────────────────────
+
+describe("list_menu_items — success path", () => {
+  test("returns menu items list with total", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_menu_items")!;
+    const result = await tool.handler({});
+
+    assert.ok(!result.isError);
+    const sc = result.structuredContent!;
+    assert.ok(Array.isArray(sc["data"]));
+    assert.equal(sc["total"], 1);
+  });
+
+  test("first menu item has expected fields", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("list_menu_items")!;
+    const result = await tool.handler({ isActive: true });
+
+    const first = (result.structuredContent!["data"] as Record<string, unknown>[])[0]!;
+    assert.equal(first["id"], "mi_burger");
+    assert.equal(first["name"], "Burger");
+    assert.equal(first["priceCents"], 1200);
+    assert.equal(first["category"], "Main");
+    assert.equal(first["isActive"], true);
+  });
+});
+
+// ── kitchen_flow_summary ──────────────────────────────────────────────────────
+
+describe("kitchen_flow_summary — success path", () => {
+  test("returns summary with stations array and totalOpenTickets", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("kitchen_flow_summary")!;
+    const result = await tool.handler({});
+
+    assert.ok(!result.isError, "should not be an error");
+    const sc = result.structuredContent!;
+    assert.ok(Array.isArray(sc["stations"]), "stations must be an array");
+    assert.ok(typeof sc["totalOpenTickets"] === "number", "totalOpenTickets must be a number");
+    assert.ok(typeof sc["generatedAt"] === "string", "generatedAt must be a string");
+  });
+
+  test("counts open tickets per station (2 grill, 1 bar — served/cancelled excluded)", async () => {
+    // MOCK_TICKETS_LIST has tkt_001 (grill/preparing), tkt_002 (grill/queued), tkt_003 (bar/ready)
+    // All are open (none served or cancelled)
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("kitchen_flow_summary")!;
+    const result = await tool.handler({});
+
+    const sc = result.structuredContent!;
+    const stations = sc["stations"] as Array<Record<string, unknown>>;
+    assert.equal(sc["totalOpenTickets"], 3);
+
+    const grill = stations.find((s) => s["stationId"] === "sta_grill");
+    const bar = stations.find((s) => s["stationId"] === "sta_bar");
+    assert.ok(grill, "grill station should be present");
+    assert.ok(bar, "bar station should be present");
+    assert.equal(grill!["openTickets"], 2);
+    assert.equal(bar!["openTickets"], 1);
+  });
+
+  test("flags grill as bottleneck (2 open tickets > bar 1)", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("kitchen_flow_summary")!;
+    const result = await tool.handler({});
+
+    const sc = result.structuredContent!;
+    assert.equal(sc["bottleneckStationId"], "sta_grill");
+
+    const stations = sc["stations"] as Array<Record<string, unknown>>;
+    const grill = stations.find((s) => s["stationId"] === "sta_grill");
+    const bar = stations.find((s) => s["stationId"] === "sta_bar");
+    assert.equal(grill!["isBottleneck"], true);
+    assert.equal(bar!["isBottleneck"], false);
+  });
+
+  test("excludes served and cancelled tickets from counts", async () => {
+    const servedTicket = { ...MOCK_TICKET, id: "tkt_served", stationId: "sta_grill", status: "served" };
+    const cancelledTicket = { ...MOCK_TICKET, id: "tkt_cancelled", stationId: "sta_bar", status: "cancelled" };
+    const client = {
+      listKitchenTickets: async () => ({
+        data: [MOCK_TICKET, servedTicket, cancelledTicket],
+        total: 3,
+        limit: 100,
+        offset: 0,
+      }),
+      listKitchenStations: async () => MOCK_STATIONS_LIST,
+    } as unknown as import("../client-interface.js").IFrihetClient;
+
+    const server = new StubMcpServer();
+    const { registerKitchenTools } = await import("../tools/kitchen.js");
+    registerKitchenTools(
+      server as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer,
+      client,
+    );
+
+    const result = await server.tools.get("kitchen_flow_summary")!.handler({});
+    const sc = result.structuredContent!;
+    // Only tkt_001 (grill/preparing) is open
+    assert.equal(sc["totalOpenTickets"], 1);
+
+    const stations = sc["stations"] as Array<Record<string, unknown>>;
+    const grill = stations.find((s) => s["stationId"] === "sta_grill");
+    const bar = stations.find((s) => s["stationId"] === "sta_bar");
+    assert.equal(grill!["openTickets"], 1);
+    assert.equal(bar!["openTickets"], 0);
+  });
+
+  test("content block mentions summary", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("kitchen_flow_summary")!;
+    const result = await tool.handler({});
+
+    assert.ok(Array.isArray(result.content));
+    assert.equal(result.content[0]!.type, "text");
+    assert.ok(result.content[0]!.text.includes("Kitchen flow summary"));
+  });
+
+  test("404 error propagates as isError=true", async () => {
+    const server = await makeServer(make404Client);
+    const tool = server.tools.get("kitchen_flow_summary")!;
+    const result = await tool.handler({});
+    assert.ok(result.isError, "should be an error on 404");
+  });
+});

--- a/src/__tests__/tool-exposure.test.ts
+++ b/src/__tests__/tool-exposure.test.ts
@@ -114,9 +114,9 @@ describe("tool-exposure: mode resolution", () => {
 });
 
 describe("tool-exposure: full mode is byte-identical", () => {
-  test("registers exactly 151 tools, no meta-tools, descriptions untouched", () => {
+  test("registers exactly 157 tools, no meta-tools, descriptions untouched", () => {
     const full = makeFullServer();
-    assert.equal(full.tools.size, 151);
+    assert.equal(full.tools.size, 157);
     for (const meta of META_TOOLS) {
       assert.equal(full.tools.has(meta), false, `${meta} must NOT exist in full mode`);
     }
@@ -134,15 +134,15 @@ describe("tool-exposure: full mode is byte-identical", () => {
 });
 
 describe("tool-exposure: grouped mode", () => {
-  test("registers 151 tools + 3 meta-tools and a complete catalog", () => {
+  test("registers 157 tools + 3 meta-tools and a complete catalog", () => {
     const { server, handle } = makeGroupedServer();
-    assert.equal(server.tools.size, 151 + GROUPED_META_TOOL_COUNT);
+    assert.equal(server.tools.size, 157 + GROUPED_META_TOOL_COUNT);
     assert.equal(GROUPED_META_TOOL_COUNT, 3);
     for (const meta of META_TOOLS) {
       assert.equal(server.tools.has(meta), true, `${meta} must exist in grouped mode`);
     }
     // Catalog holds every real tool (meta-tools excluded).
-    assert.equal(handle.catalog.size, 151);
+    assert.equal(handle.catalog.size, 157);
     for (const meta of META_TOOLS) {
       assert.equal(handle.catalog.has(meta), false);
     }
@@ -203,7 +203,7 @@ describe("tool-exposure: grouped mode", () => {
 });
 
 describe("tool-exposure: group taxonomy", () => {
-  test("groupForTool reproduces the source-file grouping for all 151 tools", () => {
+  test("groupForTool reproduces the source-file grouping for all 157 tools", () => {
     const here = dirname(fileURLToPath(import.meta.url));
     const toolsDir = join(here, "..", "..", "src", "tools");
     let checked = 0;
@@ -222,7 +222,7 @@ describe("tool-exposure: group taxonomy", () => {
         if (ng !== fileGroup) mismatches.push(`${name}: name=${ng} file=${fileGroup}`);
       }
     }
-    assert.equal(checked, 151, "should have scanned all 151 registration sites");
+    assert.equal(checked, 157, "should have scanned all 157 registration sites");
     assert.deepEqual(mismatches, [], "groupForTool must match the source-file group");
   });
 
@@ -251,16 +251,16 @@ describe("tool-exposure: group taxonomy", () => {
 });
 
 describe("tool-exposure: meta-tools", () => {
-  test("list_tool_groups returns non-empty groups with counts summing to 151", async () => {
+  test("list_tool_groups returns non-empty groups with counts summing to 157", async () => {
     const { server } = makeGroupedServer();
     const res = await server.tools.get("list_tool_groups")!.handler({});
     const payload = JSON.parse(res.content[0].text) as {
       groups: Array<{ group: string; toolCount: number }>;
       totalTools: number;
     };
-    assert.equal(payload.totalTools, 151);
+    assert.equal(payload.totalTools, 157);
     const sum = payload.groups.reduce((acc, g) => acc + g.toolCount, 0);
-    assert.equal(sum, 151);
+    assert.equal(sum, 157);
     // No empty groups are listed.
     assert.ok(payload.groups.every((g) => g.toolCount > 0));
     // Fiscal is a headline group (compliance depth).

--- a/src/client-interface.ts
+++ b/src/client-interface.ts
@@ -125,6 +125,13 @@ export interface IFrihetClient {
   listSales(params?: { terminalId?: string; status?: string; from?: string; to?: string; limit?: number; offset?: number; after?: string }): Promise<PaginatedResponse<Record<string, unknown>>>;
   refundSale(id: string, data?: { amountCents?: number; reason?: string }): Promise<Record<string, unknown>>;
 
+  // Kitchen — kitchen display system endpoints (/v1/kitchen/*)
+  listKitchenTickets(params?: { status?: string; stationId?: string; limit?: number; offset?: number; after?: string }): Promise<PaginatedResponse<Record<string, unknown>>>;
+  getKitchenTicket(id: string): Promise<Record<string, unknown>>;
+  updateKitchenTicket(id: string, data: Record<string, unknown>): Promise<Record<string, unknown>>;
+  listKitchenStations(params?: { limit?: number; offset?: number }): Promise<PaginatedResponse<Record<string, unknown>>>;
+  listMenuItems(params?: { q?: string; isActive?: boolean; limit?: number; offset?: number; after?: string }): Promise<PaginatedResponse<Record<string, unknown>>>;
+
   // Banking endpoints (/v1/banking/*)
   listBankAccounts(params?: { limit?: number; offset?: number }): Promise<PaginatedResponse<Record<string, unknown>>>;
   getBankAccount(id: string): Promise<Record<string, unknown>>;

--- a/src/client.ts
+++ b/src/client.ts
@@ -799,6 +799,51 @@ export class FrihetClient {
     return this.request("POST", `/pos/sales/${encodeURIComponent(id)}/refund`, data ?? {});
   }
 
+  // ---------------------------------------------------------------- Kitchen (KDS)
+  // ----------------------------------------------------------------
+  // NOTE: ERP backend endpoints /v1/kitchen/* target the live kitchen display system.
+
+  async listKitchenTickets(
+    params?: { status?: string; stationId?: string; limit?: number; offset?: number; after?: string },
+  ): Promise<PaginatedResponse<Record<string, unknown>>> {
+    return this.requestPaginated("GET", "/kitchen/tickets", undefined, {
+      status: params?.status,
+      stationId: params?.stationId,
+      limit: params?.limit,
+      offset: params?.offset,
+      after: params?.after,
+    });
+  }
+
+  async getKitchenTicket(id: string): Promise<Record<string, unknown>> {
+    return this.request("GET", `/kitchen/tickets/${encodeURIComponent(id)}`);
+  }
+
+  async updateKitchenTicket(id: string, data: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return this.request("PATCH", `/kitchen/tickets/${encodeURIComponent(id)}`, data);
+  }
+
+  async listKitchenStations(
+    params?: { limit?: number; offset?: number },
+  ): Promise<PaginatedResponse<Record<string, unknown>>> {
+    return this.requestPaginated("GET", "/kitchen/stations", undefined, {
+      limit: params?.limit,
+      offset: params?.offset,
+    });
+  }
+
+  async listMenuItems(
+    params?: { q?: string; isActive?: boolean; limit?: number; offset?: number; after?: string },
+  ): Promise<PaginatedResponse<Record<string, unknown>>> {
+    return this.requestPaginated("GET", "/kitchen/menuItems", undefined, {
+      q: params?.q,
+      isActive: params?.isActive !== undefined ? (params.isActive ? 1 : 0) : undefined,
+      limit: params?.limit,
+      offset: params?.offset,
+      after: params?.after,
+    });
+  }
+
   // ---------------------------------------------------------------- Intelligence
   // ----------------------------------------------------------------
 

--- a/src/tool-exposure.ts
+++ b/src/tool-exposure.ts
@@ -166,6 +166,7 @@ export const FILE_TO_GROUP: Record<string, ToolGroupId> = {
   stay: "stay",
 
   pos: "pos",
+  kitchen: "pos",
 
   intelligence: "intelligence",
   gestoria: "intelligence",
@@ -219,6 +220,7 @@ export function groupForTool(name: string): ToolGroupId {
     return "hr";
   if (/(reservation|propert|channel)/.test(n)) return "stay";
   if (/(terminal|sale)/.test(n)) return "pos";
+  if (/(kitchen|menu_item)/.test(n)) return "pos";
   if (/(business_context|monthly_summary|gestoria)/.test(n)) return "intelligence";
   if (/(product)/.test(n)) return "catalog";
   if (/(webhook|portal_domain)/.test(n)) return "platform";

--- a/src/tools/kitchen.ts
+++ b/src/tools/kitchen.ts
@@ -1,0 +1,348 @@
+/**
+ * Kitchen (KDS) tools for the Frihet MCP server.
+ *
+ * Wave 6 — 6 tools for kitchen display system management:
+ *   list_kitchen_tickets, get_kitchen_ticket, update_kitchen_ticket,
+ *   list_kitchen_stations, list_menu_items, kitchen_flow_summary
+ *
+ * ERP backend endpoints at /v1/kitchen/* are live.
+ * Flow summary aggregates ticket + station data to surface bottlenecks.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod/v4";
+import type { IFrihetClient } from "../client-interface.js";
+import {
+  withToolLogging,
+  formatPaginatedResponse,
+  formatRecord,
+  listContent,
+  getContent,
+  mutateContent,
+  READ_ONLY_ANNOTATIONS,
+  UPDATE_ANNOTATIONS,
+  paginatedOutput,
+  kitchenTicketItemOutput,
+  kitchenStationItemOutput,
+  kitchenMenuItemOutput,
+  kitchenFlowSummaryItemOutput,
+} from "./shared.js";
+
+export function registerKitchenTools(server: McpServer, client: IFrihetClient): void {
+  // -- list_kitchen_tickets --
+
+  server.registerTool(
+    "list_kitchen_tickets",
+    {
+      title: "List Kitchen Tickets",
+      description:
+        "List all kitchen order tickets for the live order board, with optional filters by " +
+        "status or station. Returns ticket id, station, status, table ref, and items. " +
+        "/ Lista todos los tickets de cocina del panel en vivo, con filtros opcionales " +
+        "por estado o estacion. Devuelve id, estacion, estado, mesa e items.",
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        status: z
+          .string()
+          .optional()
+          .describe(
+            "Filter by ticket status: queued, preparing, ready, served, cancelled. " +
+            "/ Filtrar por estado: queued, preparing, ready, served, cancelled.",
+          ),
+        stationId: z
+          .string()
+          .optional()
+          .describe("Filter by station ID / Filtrar por ID de estacion"),
+        limit: z.number().int().min(1).max(100).optional().describe("Max results (1-100)"),
+        offset: z.number().int().min(0).optional().describe("Offset / Desplazamiento"),
+        after: z
+          .string()
+          .optional()
+          .describe("Cursor for cursor-based pagination / Cursor de paginacion"),
+      },
+      outputSchema: paginatedOutput(kitchenTicketItemOutput),
+    },
+    async (args) =>
+      withToolLogging("list_kitchen_tickets", async () => {
+        const result = await client.listKitchenTickets(args);
+        return {
+          content: [listContent(formatPaginatedResponse("kitchen tickets", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+  );
+
+  // -- get_kitchen_ticket --
+
+  server.registerTool(
+    "get_kitchen_ticket",
+    {
+      title: "Get Kitchen Ticket",
+      description:
+        "Get a single kitchen ticket by ID. Returns full ticket details including all items, " +
+        "their individual statuses, station assignment, and table reference. " +
+        "/ Obtiene un ticket de cocina por ID. Devuelve todos los detalles: items, " +
+        "estados individuales, estacion asignada y referencia de mesa.",
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        id: z.string().describe("Ticket ID / ID del ticket"),
+      },
+      outputSchema: kitchenTicketItemOutput,
+    },
+    async ({ id }) =>
+      withToolLogging("get_kitchen_ticket", async () => {
+        const result = await client.getKitchenTicket(id);
+        return {
+          content: [getContent(formatRecord("Kitchen ticket", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+  );
+
+  // -- update_kitchen_ticket --
+
+  server.registerTool(
+    "update_kitchen_ticket",
+    {
+      title: "Update Kitchen Ticket",
+      description:
+        "Advance a kitchen ticket through the workflow — update its status (e.g. queued → " +
+        "preparing → ready → served) or reassign it to a different station. " +
+        "/ Avanza un ticket de cocina en el flujo: actualiza estado (queued → preparing → " +
+        "ready → served) o reasigna a otra estacion.",
+      annotations: UPDATE_ANNOTATIONS,
+      inputSchema: {
+        id: z.string().describe("Ticket ID to update / ID del ticket a actualizar"),
+        status: z
+          .string()
+          .optional()
+          .describe(
+            "New ticket status: queued, preparing, ready, served, cancelled. " +
+            "/ Nuevo estado: queued, preparing, ready, served, cancelled.",
+          ),
+        stationId: z
+          .string()
+          .optional()
+          .describe("Reassign to station ID / Reasignar a estacion"),
+      },
+      outputSchema: kitchenTicketItemOutput,
+    },
+    async ({ id, ...rest }) =>
+      withToolLogging("update_kitchen_ticket", async () => {
+        const result = await client.updateKitchenTicket(id, rest as Record<string, unknown>);
+        return {
+          content: [mutateContent(formatRecord("Kitchen ticket updated", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+  );
+
+  // -- list_kitchen_stations --
+
+  server.registerTool(
+    "list_kitchen_stations",
+    {
+      title: "List Kitchen Stations",
+      description:
+        "List all kitchen stations. Returns station id, name, and active status. " +
+        "Use kitchen_flow_summary to see per-station ticket load and bottlenecks. " +
+        "/ Lista todas las estaciones de cocina. Devuelve id, nombre y estado activo. " +
+        "Usa kitchen_flow_summary para ver carga por estacion y cuellos de botella.",
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        limit: z.number().int().min(1).max(100).optional().describe("Max results (1-100)"),
+        offset: z.number().int().min(0).optional().describe("Offset / Desplazamiento"),
+      },
+      outputSchema: paginatedOutput(kitchenStationItemOutput),
+    },
+    async (args) =>
+      withToolLogging("list_kitchen_stations", async () => {
+        const result = await client.listKitchenStations(args);
+        return {
+          content: [listContent(formatPaginatedResponse("kitchen stations", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+  );
+
+  // -- list_menu_items --
+
+  server.registerTool(
+    "list_menu_items",
+    {
+      title: "List Menu Items",
+      description:
+        "List the kitchen menu catalog. Supports free-text search and active/inactive filter. " +
+        "Returns item id, name, description, price, category, and active status. " +
+        "/ Lista el catálogo de menu de cocina. Admite búsqueda de texto y filtro activo/inactivo. " +
+        "Devuelve id, nombre, descripcion, precio, categoria y estado activo.",
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        q: z
+          .string()
+          .optional()
+          .describe("Free-text search by name or description / Busqueda por nombre o descripcion"),
+        isActive: z
+          .boolean()
+          .optional()
+          .describe("Filter by active status / Filtrar por activos"),
+        limit: z.number().int().min(1).max(100).optional().describe("Max results (1-100)"),
+        offset: z.number().int().min(0).optional().describe("Offset / Desplazamiento"),
+        after: z
+          .string()
+          .optional()
+          .describe("Cursor for cursor-based pagination / Cursor de paginacion"),
+      },
+      outputSchema: paginatedOutput(kitchenMenuItemOutput),
+    },
+    async (args) =>
+      withToolLogging("list_menu_items", async () => {
+        const result = await client.listMenuItems(args);
+        return {
+          content: [listContent(formatPaginatedResponse("menu items", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+  );
+
+  // -- kitchen_flow_summary --
+
+  server.registerTool(
+    "kitchen_flow_summary",
+    {
+      title: "Kitchen Flow Summary",
+      description:
+        "Slow-station detection: aggregates open kitchen tickets per station and flags the " +
+        "bottleneck (station with the highest open-ticket count). Returns per-station openTickets " +
+        "count, oldest wait time in seconds, and an isBottleneck flag. Call this first to " +
+        "diagnose kitchen throughput issues before drilling into individual tickets. " +
+        "/ Deteccion de cuello de botella: agrega tickets abiertos por estacion y marca la " +
+        "mas saturada. Devuelve openTickets, tiempo de espera mas antiguo y flag isBottleneck " +
+        "por estacion. Llamar primero para diagnosticar problemas de rendimiento de cocina.",
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {},
+      outputSchema: z.object({
+        stations: z.array(kitchenFlowSummaryItemOutput),
+        bottleneckStationId: z.string().optional(),
+        totalOpenTickets: z.number().int().nonnegative(),
+        generatedAt: z.string(),
+      }),
+    },
+    async () =>
+      withToolLogging("kitchen_flow_summary", async () => {
+        // Fetch all open tickets and all stations in parallel
+        const [ticketsResult, stationsResult] = await Promise.all([
+          client.listKitchenTickets({ limit: 100 }),
+          client.listKitchenStations({ limit: 100 }),
+        ]);
+
+        const now = Date.now();
+
+        // Build a per-station map from the stations list
+        const stationMap = new Map<string, string>(); // id → name
+        for (const s of stationsResult.data) {
+          const station = s as Record<string, unknown>;
+          if (typeof station["id"] === "string") {
+            stationMap.set(station["id"], typeof station["name"] === "string" ? station["name"] : station["id"]);
+          }
+        }
+
+        // Aggregate open tickets (all non-served/non-cancelled) per station
+        interface StationAgg {
+          openTickets: number;
+          oldestCreatedAt: number | null;
+        }
+        const agg = new Map<string, StationAgg>();
+
+        for (const t of ticketsResult.data) {
+          const ticket = t as Record<string, unknown>;
+          const status = typeof ticket["status"] === "string" ? ticket["status"] : "";
+          if (status === "served" || status === "cancelled") continue;
+
+          const stationId = typeof ticket["stationId"] === "string" ? ticket["stationId"] : "__unassigned__";
+          const createdAt = typeof ticket["createdAt"] === "string"
+            ? new Date(ticket["createdAt"]).getTime()
+            : null;
+
+          const existing = agg.get(stationId) ?? { openTickets: 0, oldestCreatedAt: null };
+          existing.openTickets += 1;
+          if (createdAt !== null && (existing.oldestCreatedAt === null || createdAt < existing.oldestCreatedAt)) {
+            existing.oldestCreatedAt = createdAt;
+          }
+          agg.set(stationId, existing);
+        }
+
+        // Build station summaries, also include stations with zero open tickets
+        let maxLoad = 0;
+        let bottleneckId: string | undefined;
+
+        const summaries: Array<{
+          stationId: string;
+          stationName: string | undefined;
+          openTickets: number;
+          oldestWaitSeconds: number | undefined;
+          isBottleneck: boolean;
+        }> = [];
+
+        // Include all known stations (even idle ones)
+        for (const [stationId, stationName] of stationMap) {
+          const data = agg.get(stationId) ?? { openTickets: 0, oldestCreatedAt: null };
+          summaries.push({
+            stationId,
+            stationName,
+            openTickets: data.openTickets,
+            oldestWaitSeconds: data.oldestCreatedAt !== null
+              ? Math.round((now - data.oldestCreatedAt) / 1000)
+              : undefined,
+            isBottleneck: false,
+          });
+          if (data.openTickets > maxLoad) {
+            maxLoad = data.openTickets;
+            bottleneckId = stationId;
+          }
+        }
+
+        // Include __unassigned__ bucket if present
+        const unassigned = agg.get("__unassigned__");
+        if (unassigned) {
+          summaries.push({
+            stationId: "__unassigned__",
+            stationName: "Unassigned / Sin estacion",
+            openTickets: unassigned.openTickets,
+            oldestWaitSeconds: unassigned.oldestCreatedAt !== null
+              ? Math.round((now - unassigned.oldestCreatedAt) / 1000)
+              : undefined,
+            isBottleneck: false,
+          });
+          if (unassigned.openTickets > maxLoad) {
+            maxLoad = unassigned.openTickets;
+            bottleneckId = "__unassigned__";
+          }
+        }
+
+        // Mark the bottleneck (only if there are open tickets)
+        if (bottleneckId && maxLoad > 0) {
+          for (const s of summaries) {
+            if (s.stationId === bottleneckId) {
+              s.isBottleneck = true;
+              break;
+            }
+          }
+        }
+
+        const totalOpenTickets = summaries.reduce((acc, s) => acc + s.openTickets, 0);
+
+        const result = {
+          stations: summaries,
+          bottleneckStationId: maxLoad > 0 ? bottleneckId : undefined,
+          totalOpenTickets,
+          generatedAt: new Date().toISOString(),
+        };
+
+        return {
+          content: [getContent(formatRecord("Kitchen flow summary", result as unknown as Record<string, unknown>))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+  );
+}

--- a/src/tools/register-all.ts
+++ b/src/tools/register-all.ts
@@ -25,6 +25,7 @@ import { registerDepositTools } from "./deposits.js";
 import { registerEInvoiceTools } from "./einvoice.js";
 import { registerStayTools } from "./stay.js";
 import { registerPosTools } from "./pos.js";
+import { registerKitchenTools } from "./kitchen.js";
 import { registerBankingTools } from "./banking.js";
 import { registerFiscalTools } from "./fiscal.js";
 import { registerTimeTools } from "./time.js";
@@ -101,6 +102,7 @@ export function registerAllTools(server: McpServer, client: IFrihetClient): void
   registerEInvoiceTools(server, client);
   registerStayTools(server, client);
   registerPosTools(server, client);
+  registerKitchenTools(server, client);
   registerBankingTools(server, client);
   registerFiscalTools(server, client);
   registerTimeTools(server, client);

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -522,6 +522,52 @@ export const propertyItemOutput = z.object({
   updatedAt: z.string().optional(),
 }).passthrough();
 
+/* --- Kitchen item schemas -------------------------------------------------- */
+
+export const kitchenTicketItemOutput = z.object({
+  id: z.string(),
+  stationId: z.string().optional(),
+  status: z.string().optional().describe("queued | preparing | ready | served | cancelled"),
+  tableRef: z.string().optional(),
+  items: z.array(z.object({
+    id: z.string(),
+    menuItemId: z.string().optional(),
+    name: z.string().optional(),
+    quantity: z.number().optional(),
+    notes: z.string().optional(),
+    status: z.string().optional(),
+  })).optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+}).passthrough();
+
+export const kitchenStationItemOutput = z.object({
+  id: z.string(),
+  name: z.string().optional(),
+  isActive: z.boolean().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+}).passthrough();
+
+export const kitchenMenuItemOutput = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  priceCents: z.number().int().nonnegative().optional(),
+  category: z.string().optional(),
+  isActive: z.boolean().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+}).passthrough();
+
+export const kitchenFlowSummaryItemOutput = z.object({
+  stationId: z.string(),
+  stationName: z.string().optional(),
+  openTickets: z.number().int().nonnegative(),
+  oldestWaitSeconds: z.number().nonnegative().optional(),
+  isBottleneck: z.boolean(),
+});
+
 /* --- POS item schemas ------------------------------------------------------ */
 
 export const posTerminalItemOutput = z.object({


### PR DESCRIPTION
## Summary
Adds the **Kitchen** MCP tool surface to \`@frihet/mcp-server\` — the missing 3rd app (Stay + POS already shipped). Completes V2 doctrine pillar #2 (operable via MCP) for Kitchen. Targets the live ERP \`/v1/kitchen/*\` REST endpoints.

## Tools (6)
\`list_kitchen_tickets\` · \`get_kitchen_ticket\` · \`update_kitchen_ticket\` (flow) · \`list_kitchen_stations\` · \`list_menu_items\` · \`kitchen_flow_summary\` (slow-station/bottleneck aggregation).

## Changes
- \`src/tools/kitchen.ts\` (new, 6 tools) + \`registerKitchenTools\` wired in \`register-all.ts\`
- \`client-interface.ts\` +5 method sigs · \`client.ts\` +5 HTTP impls (\`/v1/kitchen/*\`)
- \`shared.ts\` +4 output schemas · \`tool-exposure.ts\` grouping + count 151→157
- \`kitchen-tools.test.ts\` (27 tests). Build clean, **321 tests pass**.

## Notes / follow-up
- Ticket status filter uses permissive \`z.string()\` (exact ERP enum not verifiable from this repo; assumed \`queued|preparing|ready|served|cancelled\`). Description-only update if the enum differs.
- Pairs with ERP PR declaring \`mcpTools\` in the kitchen manifest.

HOLD — draft, no publish/version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)