### PR TITLE
fix(mcp): enforce kitchen ticket-status enum instead of z.string()

### DIFF
--- a/src/tools/kitchen.ts
+++ b/src/tools/kitchen.ts
@@ -43,11 +43,11 @@ export function registerKitchenTools(server: McpServer, client: IFrihetClient): 
       annotations: READ_ONLY_ANNOTATIONS,
       inputSchema: {
         status: z
-          .string()
+          .enum(["on_hold", "queued", "preparing", "ready", "served", "voided"])
           .optional()
           .describe(
-            "Filter by ticket status: queued, preparing, ready, served, cancelled. " +
-            "/ Filtrar por estado: queued, preparing, ready, served, cancelled.",
+            "Filter by ticket status: on_hold, queued, preparing, ready, served, voided. " +
+            "/ Filtrar por estado: on_hold, queued, preparing, ready, served, voided.",
           ),
         stationId: z
           .string()
@@ -114,11 +114,11 @@ export function registerKitchenTools(server: McpServer, client: IFrihetClient): 
       inputSchema: {
         id: z.string().describe("Ticket ID to update / ID del ticket a actualizar"),
         status: z
-          .string()
+          .enum(["on_hold", "queued", "preparing", "ready", "served", "voided"])
           .optional()
           .describe(
-            "New ticket status: queued, preparing, ready, served, cancelled. " +
-            "/ Nuevo estado: queued, preparing, ready, served, cancelled.",
+            "New ticket status: on_hold, queued, preparing, ready, served, voided. " +
+            "/ Nuevo estado: on_hold, queued, preparing, ready, served, voided.",
           ),
         stationId: z
           .string()


### PR DESCRIPTION
## What

Tightens the `status` param on `list_kitchen_tickets` (`src/tools/kitchen.ts:45`) and `update_kitchen_ticket` (`:116`) from permissive `z.string().optional()` to `z.enum(...).optional()`, so agents can't send an arbitrary status string that the ERP API will reject downstream.

## Verified status set (NOT the assumed set)

The audit assumed `queued, preparing, ready, served, cancelled`. The **real** canonical set from the ERP is:

```ts
// Frihet-ERP/apps/kitchen/src/types.ts:15
export type KitchenTicketStatus = 'on_hold' | 'queued' | 'preparing' | 'ready' | 'served' | 'voided';
```

Two material differences vs the assumption:
- `on_hold` exists (was missing from the assumed set)
- The terminal cancel state is `voided`, **not** `cancelled` — confirmed by the ERP functions writing `status: 'voided'` (`functions/src/kitchen/aggregator-ingestion.ts:826`); `cancelled` appears nowhere in the kitchen ticket domain.

Used the verified set. Updated the `.describe()` bilingual text to match (the old text listed `cancelled`, which would now mislead an agent into sending a value the enum rejects).

## Scope note

This is merged-but-unpublished (#36) — branch fix only, no publish.

## Gates

- `npm run build` clean (tsc)
- `npm test` — 321/321 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)