### PR TITLE
fix(mcp): einvoice FACe/TicketBAI/export al CF vivo, stub solo en 404 genuino (compliance)

### DIFF
--- a/src/__tests__/einvoice-day4-tools.test.ts
+++ b/src/__tests__/einvoice-day4-tools.test.ts
@@ -78,6 +78,28 @@ function make403Client(): import("../client-interface.js").IFrihetClient {
   } as unknown as import("../client-interface.js").IFrihetClient;
 }
 
+/**
+ * Simulates a 500 from a LIVE CF — e.g. a real FACe/TicketBAI signature or
+ * submission failure. COMPLIANCE: must rethrow (isError), NEVER masked as a
+ * success stub. This is the case the genuine-404-only fallback contract guards.
+ */
+function make500Client(): import("../client-interface.js").IFrihetClient {
+  const serverError = () => {
+    const err = Object.assign(new Error("Signature/submission failed"), {
+      statusCode: 500,
+      errorCode: "signature_failed",
+    });
+    return Promise.reject(err);
+  };
+  return {
+    exportEInvoice: serverError,
+    faceSubmit: serverError,
+    faceStatus: serverError,
+    ticketbaiSubmit: serverError,
+    ticketbaiStatus: serverError,
+  } as unknown as import("../client-interface.js").IFrihetClient;
+}
+
 /** Simulates CF endpoints live and returning real data. */
 function makeLiveClient(): import("../client-interface.js").IFrihetClient {
   return {
@@ -392,6 +414,86 @@ describe("ticketbai_status — live client", () => {
     assert.equal(sc["status"], "accepted");
     assert.equal(sc["_stub"], undefined);
   });
+});
+
+// ── Compliance smoke: live CF wiring + real-failure-never-masked-as-success ───
+//
+// These 5 tools have a LIVE Cloud Function server-side (Frihet-ERP publicApi.ts).
+// 1. On a live success the tool must return the REAL CF payload (no _stub flag),
+//    proving the client method (correct /invoices/:id/{...} path) was hit, not a stub.
+// 2. On a 500 (genuine FACe/TicketBAI signature/submission failure) the tool must
+//    surface an error (isError) and MUST NOT emit a success stub. A masked failure
+//    would tell the user agent the invoice was submitted/accepted when it was not.
+
+const LIVE_TOOLS: Array<{
+  name: string;
+  args: Record<string, unknown>;
+  /** A field whose value is unique to the live (non-stub) response. */
+  liveAssert: (sc: Record<string, unknown>) => void;
+}> = [
+  {
+    name: "einvoice_export",
+    args: { invoiceId: "inv_smoke", format: "facturae", signed: true },
+    liveAssert: (sc) => assert.ok((sc["xmlUrl"] as string).includes("live")),
+  },
+  {
+    name: "face_submit",
+    args: { invoiceId: "inv_smoke", mode: "production" },
+    liveAssert: (sc) => assert.equal(sc["registroFACe"], "RCF_LIVE_20260513_001"),
+  },
+  {
+    name: "face_status",
+    args: { invoiceId: "inv_smoke" },
+    liveAssert: (sc) => assert.equal(sc["statusCode"], "1400"),
+  },
+  {
+    name: "ticketbai_submit",
+    args: { invoiceId: "inv_smoke" },
+    liveAssert: (sc) => assert.equal(sc["tbaiId"], "TBAI-00001-20260513-LIVE"),
+  },
+  {
+    name: "ticketbai_status",
+    args: { invoiceId: "inv_smoke" },
+    liveAssert: (sc) => assert.equal(sc["tbaiId"], "TBAI-00001-20260513-LIVE"),
+  },
+];
+
+describe("Compliance smoke — 5 live einvoice tools hit the real CF", () => {
+  for (const { name, args, liveAssert } of LIVE_TOOLS) {
+    test(`${name}: live → real CF payload, no _stub`, async () => {
+      const server = await makeServer(makeLiveClient());
+      const tool = server.tools.get(name)!;
+      const result = await tool.handler(args);
+      const sc = result.structuredContent!;
+      assert.equal(sc["_stub"], undefined, `${name} returned a stub on a live CF response`);
+      assert.notEqual(
+        (result as Record<string, unknown>)["isError"],
+        true,
+        `${name} reported isError on a live success`,
+      );
+      liveAssert(sc);
+    });
+  }
+});
+
+describe("Compliance smoke — real CF failure (500) never masked as success", () => {
+  for (const { name, args } of LIVE_TOOLS) {
+    test(`${name}: 500 → isError, NOT a success stub`, async () => {
+      const server = await makeServer(make500Client());
+      const tool = server.tools.get(name)!;
+      const result = await tool.handler(args);
+      // A genuine signature/submission failure must surface as an error...
+      assert.equal(
+        (result as Record<string, unknown>)["isError"],
+        true,
+        `${name} did not surface 500 as an error`,
+      );
+      // ...and must NOT be dressed up as a successful stub.
+      const sc = (result.structuredContent ?? {}) as Record<string, unknown>;
+      assert.notEqual(sc["_stub"], true, `${name} masked a 500 failure as a success stub`);
+      assert.equal(sc["status"], undefined, `${name} emitted a success status on a 500 failure`);
+    });
+  }
 });
 
 // ── ksef_submit tests ─────────────────────────────────────────────────────────

--- a/src/tools/einvoice.ts
+++ b/src/tools/einvoice.ts
@@ -2,16 +2,24 @@
  * E-Invoicing tools for the Frihet MCP server.
  *
  * Wired to real CF endpoints at api.frihet.io/v1/invoices/:id/einvoice/*.
- * 404-fallback: if the CF endpoint is not yet deployed, returns a stub with
- * { _stub: true, _note: "CF endpoint pending deploy", _plannedEndpoint: "..." }
- * so the MCP server remains usable while the transport Wave ships.
+ *
+ * The 5 per-invoice endpoints below are LIVE server-side (Frihet-ERP publicApi.ts):
+ * einvoice/export, face/submit, face/status, ticketbai/submit, ticketbai/status.
+ * On a successful fetch the tools return the real CF response unchanged.
+ *
+ * COMPLIANCE-CRITICAL 404-fallback contract: the stub is dispatched ONLY when the
+ * CF returns a genuine 404 (jurisdiction without a deployed CF / endpoint not yet
+ * shipped). Any other failure — 4xx auth/validation, 5xx signature/submission
+ * error, network error — is RE-THROWN by isNotFoundError()=false and surfaced as a
+ * tool error. A real FACe/TicketBAI signature or submission failure MUST NEVER be
+ * masked as a successful (queued/accepted) stub.
  *
  * All 10 tools use the shared withToolLogging wrapper (Langfuse tracing applied
  * globally via patchServerWithTracing in register-all.ts).
  *
  * Trace names prefix: mcp.einvoice.*
  * Original 4 CF endpoints: https://api.frihet.io/v1/einvoice/{send,status,validate,export-datev}
- * Day 4 Wave 6 CF endpoints (PR #414 + FACe PR #411 + TicketBAI PR #356):
+ * Day 4 Wave 6 CF endpoints (PR #414 + FACe PR #411 + TicketBAI PR #356) — LIVE:
  *   POST /v1/invoices/:id/einvoice/export  — export XML in specific format (signed Facturae etc.)
  *   POST /v1/invoices/:id/face/submit      — Spain B2G FACe portal submission
  *   GET  /v1/invoices/:id/face/status      — FACe submission status
@@ -961,8 +969,18 @@ export function registerEInvoiceTools(server: McpServer, _client: IFrihetClient)
 /* ------------------------------------------------------------------ */
 
 /**
- * Returns true if the error is a 404 Not Found, indicating the CF endpoint
- * is not yet deployed. Detects both FrihetApiError shape and generic HTTP errors.
+ * Returns true ONLY for a genuine 404 Not Found, indicating the CF endpoint is
+ * not deployed for this jurisdiction / not yet shipped. This is the single gate
+ * that authorises the stub fallback.
+ *
+ * COMPLIANCE INVARIANT: it MUST stay strict on 404. Any other status — 401/403
+ * (auth), 422 (validation), 5xx (signature/submission failure on the live FACe or
+ * TicketBAI CF), or a network/timeout error — returns false, so the caller
+ * re-throws and the failure surfaces as a tool error. Widening this predicate
+ * would let a real e-invoice signature/submission failure be masked as a
+ * successful stub (e.g. status="submitted"/"accepted"), which is non-compliant.
+ *
+ * Detects both FrihetApiError shape (statusCode) and generic HTTP errors (status).
  */
 function isNotFoundError(err: unknown): boolean {
   if (err && typeof err === "object") {


### PR DESCRIPTION
## Hallazgo (compliance audit)

Los 5 tools einvoice per-invoice tienen un **CF vivo** server-side (Frihet-ERP `publicApi.ts`): `einvoice/export`, `face/submit`, `face/status`, `ticketbai/submit`, `ticketbai/status`. La duda del audit era si el cliente MCP apuntaba al path correcto o al genérico `/einvoice/send`, y si el stub enmascaraba fallos reales.

## PASO 1 — Verificación estática (sin cambio de comportamiento)

`src/client.ts` ya enruta los 5 a los paths per-invoice correctos:
- `POST /invoices/:id/einvoice/export`
- `POST /invoices/:id/face/submit` · `GET /invoices/:id/face/status`
- `POST /invoices/:id/ticketbai/submit` · `GET /invoices/:id/ticketbai/status`

**Ninguno** apunta a `/einvoice/send`. No se requiere corrección de path. El cambio es **de-stale de comentarios + smoke tests**, sin tocar la ruta ni el comportamiento.

## Cambios

- **Header del archivo**: marca los 5 endpoints como LIVE y documenta el contrato compliance-critical: el stub se dispara **solo en 404 genuino** (jurisdicción sin CF / endpoint no desplegado).
- **`isNotFoundError`**: comentario de invariante — estricto en 404; 401/403/422/5xx/red → `false` → re-throw. Ensanchar el predicado dejaría que un fallo real de firma/envío FACe/TicketBAI se enmascarara como éxito (`status="submitted"/"accepted"`).
- **Smoke tests (PASO 2)** para los 5 tools:
  - live → payload real del CF, sin `_stub` (prueba que se golpea el CF, no el stub)
  - 500 (fallo de firma/envío) → `isError`, **nunca** un stub de éxito

## No roto (Trust Area compliance)

- Fallback stub permanece **solo para 404 genuino**; manejo de error intacto.
- Un fallo real de firma/envío **nunca** se enmascara como éxito.
- `ksef_submit` queda **BLOCKED** (PR #417) — sin tocar.
- 4 tools einvoice originales (send/status/validate/datev) — sin tocar.

## Gates

- `npm run build` ✅ (tsc clean)
- `npm test` ✅ 331 pass / 0 fail (Day-4 suite 33→43, +10 compliance smokes)
- gemini-proof ✅ exit 0
- (repo sin script lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)