### PR TITLE
feat(contract): MCP<->CF contract integrity (modeloCode, Timestamp seam, offset, quarterly-draft fix)

### DIFF
--- a/marketplace/README.md
+++ b/marketplace/README.md
@@ -35,7 +35,7 @@ Wave Mature 3 — prepared May 2026.
 **3. Anthropic Claude Directory (submit last)**
 - ~2 week review cycle
 - Strictest requirements: production-ready, full OAuth, tool annotations, privacy policy live
-- Requires `-beta` version dropped OR explicitly noted
+- GA / stable version published (no `-beta` tag) — currently `v1.14.2`
 - URL: https://claude.ai/settings/connectors
 - Submission form: https://claude.com/docs/connectors/building/submission
 
@@ -45,7 +45,7 @@ Wave Mature 3 — prepared May 2026.
 
 - [ ] `https://mcp.frihet.io/mcp` reachable with valid MCP response
 - [ ] `server.json` description ≤ 100 chars (PR #fix/server-json-desc-100chars merged)
-- [ ] All 151 tools have `readOnlyHint` correctly set
+- [ ] All 157 tools have `readOnlyHint` correctly set
 - [ ] `https://www.frihet.io/en/privacy` live
 - [ ] `https://www.frihet.io/en/terms` live
 - [ ] `https://docs.frihet.io/desarrolladores/mcp-server` live and public
@@ -69,7 +69,7 @@ No binary files are stored in this repo — assets live in `Frihet-Saas-Website/
 |----------|--------|---------------|
 | Anthropic MCP Registry (`registry.modelcontextprotocol.io`) | LIVE — `io.frihet/erp` | Keep `server.json` updated on releases |
 | Smithery | LIVE — `smithery.ai/server/frihet/frihet-mcp` | Track install rate weekly |
-| npm | LIVE — `@frihet/mcp-server` v1.13.0 | Current stable |
+| npm | LIVE — `@frihet/mcp-server` v1.14.2 | Current stable (GA, 157 tools) |
 | Glama / mcpservers.org | Not verified | Submit separately (15min) |
 | PulseMCP | Not verified | Submit separately (15min) |
 | mcp.so | Not verified | Submit separately (15min) |

--- a/marketplace/anthropic/SUBMISSION.md
+++ b/marketplace/anthropic/SUBMISSION.md
@@ -28,7 +28,7 @@
 | Server identifier (MCP name) | — | `io.frihet/erp` |
 | Server URL (remote endpoint) | — | `https://mcp.frihet.io/mcp` |
 | npm package | — | `@frihet/mcp-server` |
-| Version | — | `1.13.0` |
+| Version | — | `1.14.2` (GA / stable) |
 | License | — | `MIT` |
 | GitHub repository | — | `https://github.com/Frihet-io/frihet-mcp` |
 | Homepage / docs | — | `https://docs.frihet.io/desarrolladores/mcp-server` |
@@ -38,7 +38,7 @@
 ```
 Frihet MCP Server connects your AI assistant to Frihet ERP — the AI-native business platform for freelancers and SMEs in Spain and the EU.
 
-151 tools across 20+ domains: invoices, expenses, clients, CRM, quotes, deposits, banking, fiscal (Modelo 303/130/390/180/347/415/425/418), e-invoicing (XRechnung, Factur-X, FatturaPA, PEPPOL, Facturae, FACe, TicketBAI, KSeF), VeriFactu, IGIC/AIEM, corporate tax, GL audit, vacation rentals, POS, time tracking, HR, payroll, onboarding, period close, gestoria.
+157 tools across 20+ domains: invoices, expenses, clients, CRM, quotes, deposits, banking, fiscal (Modelo 303/130/390/180/347/415/425/418), e-invoicing (XRechnung, Factur-X, FatturaPA, PEPPOL, Facturae, FACe, TicketBAI, KSeF), VeriFactu, IGIC/AIEM, corporate tax, GL audit, vacation rentals, POS, time tracking, HR, payroll, onboarding, period close, gestoria.
 
 11 resources and 10 pre-built prompts (monthly-close, quarterly-tax-prep, year-end-close, cash-flow-forecast, invoice-aging-review and more).
 
@@ -63,7 +63,7 @@ Zero install: connect via the remote endpoint at mcp.frihet.io with OAuth 2.0 + 
 
 ### Section 3 — Tools & Resources
 
-**Tool count:** 151 tools, 11 resources, 10 prompts
+**Tool count:** 157 tools, 11 resources, 10 prompts
 
 **Domains covered:**
 - Invoices (12), Expenses (5), Clients (5), CRM/Contacts (3), CRM/Activities (2), CRM/Notes (3)
@@ -144,19 +144,19 @@ Before submitting:
 
 - [ ] Server is publicly reachable: `curl -s https://mcp.frihet.io/mcp` returns valid MCP response
 - [ ] OAuth redirect URIs include both `https://claude.ai/api/mcp/auth_callback` AND `https://claude.com/api/mcp/auth_callback`
-- [ ] All 151 tools have `readOnlyHint` set correctly (verify in `src/tools/*.ts`)
+- [ ] All 157 tools have `readOnlyHint` set correctly (verify in `src/tools/*.ts`)
 - [ ] Privacy policy page is live at `https://www.frihet.io/en/privacy`
 - [ ] Documentation page is live and public at `https://docs.frihet.io/desarrolladores/mcp-server`
 - [ ] Test account created and credentials ready
 - [ ] Logo/icon assets prepared at required sizes (see Section 6)
 - [ ] Screenshots prepared (see Section 6)
 - [ ] `server.json` description is ≤ 100 chars (verified: 87 chars on branch `fix/server-json-desc-100chars`)
-- [ ] Version is stable (not `-beta`) before submitting to production directory, OR note beta status clearly
+- [x] Version is GA / stable (not `-beta`): `v1.14.2` published to npm — ready for the production directory
 
 ---
 
 ## Submission Order Recommendation
 
-Submit Anthropic **last** among the three marketplaces. Reason: 2-week review cycle + production-readiness requirement. Ship Cursor and OpenAI first (faster turnaround), then submit Anthropic once version is stable.
+Submit Anthropic **last** among the three marketplaces. Reason: 2-week review cycle + production-readiness requirement. Ship Cursor and OpenAI first (faster turnaround), then submit Anthropic. The server is now GA (`v1.14.2`, 157 tools) so the production-readiness bar is met.
 
 See `../README.md` for full submission sequencing.

--- a/marketplace/anthropic/connector/README.md
+++ b/marketplace/anthropic/connector/README.md
@@ -17,7 +17,7 @@ A `.mcpb` is a ZIP archive renamed to `.mcpb`. The archive must contain at minim
 cd ~/Documents/frihet-mcp/marketplace/anthropic/connector
 
 # Pack: zip then rename extension
-zip -r frihet-erp-1.13.0.mcpb manifest.json
+zip -r frihet-erp-1.14.2.mcpb manifest.json
 
 # Verify well-formed JSON before packing
 node -e "JSON.parse(require('fs').readFileSync('manifest.json','utf8')); console.log('manifest.json OK')"
@@ -28,10 +28,10 @@ node -e "JSON.parse(require('fs').readFileSync('manifest.json','utf8')); console
 1. Verify `https://mcp.frihet.io/mcp` is reachable with a valid MCP JSON-RPC response.
 2. Verify OAuth redirect URI `https://claude.ai/api/mcp/auth_callback` AND `https://claude.com/api/mcp/auth_callback` are in the Frihet OAuth allowlist.
 3. Create a test account at `https://app.frihet.io` with sample clients/invoices/expenses.
-4. Pack the bundle: `zip -r frihet-erp-1.13.0.mcpb manifest.json`
+4. Pack the bundle: `zip -r frihet-erp-1.14.2.mcpb manifest.json`
 5. Go to `https://claude.ai/settings/connectors` → "Submit your connector"
 6. Fill in the form using `SUBMISSION.md` (parent directory) as the copy-paste reference.
-7. Upload `frihet-erp-1.13.0.mcpb` where the form requests a bundle.
+7. Upload `frihet-erp-1.14.2.mcpb` where the form requests a bundle.
 8. Expect ~2 week review cycle (per Anthropic FAQ).
 
 ## Alternatively: submit as a remote MCP connector without bundle

--- a/marketplace/anthropic/connector/manifest.json
+++ b/marketplace/anthropic/connector/manifest.json
@@ -3,7 +3,7 @@
   "name": "io.frihet/erp",
   "title": "Frihet ERP",
   "description": "AI-native ERP MCP server — full ES/EU fiscal compliance (VeriFactu/TicketBAI/Facturae) + invoicing, CRM, tax, banking, HR, payroll, period close.",
-  "version": "1.13.0",
+  "version": "1.14.2",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/Frihet-io/frihet-mcp",
@@ -33,7 +33,7 @@
     {
       "registryType": "npm",
       "identifier": "@frihet/mcp-server",
-      "version": "1.13.0",
+      "version": "1.14.2",
       "transport": {
         "type": "stdio"
       },
@@ -49,7 +49,7 @@
     }
   ],
   "capabilities": {
-    "tools": 151,
+    "tools": 157,
     "resources": 11,
     "prompts": 10
   },

--- a/marketplace/cursor/SUBMISSION.md
+++ b/marketplace/cursor/SUBMISSION.md
@@ -54,7 +54,7 @@ Frihet MCP Server connects Cursor directly to your Frihet ERP account.
 
 Talk to your business in natural language from inside Cursor. Create invoices, log expenses, manage clients, check cash flow, prepare quarterly taxes — all without leaving the editor.
 
-151 tools across invoicing, CRM, products, quotes, expenses, deposits, banking, fiscal compliance (Modelo 303/130/390/180/347, VeriFactu, TicketBAI), e-invoicing (PEPPOL, XRechnung, FatturaPA, Facturae, FACe), vacation rental management, point-of-sale, time tracking, HR, payroll, onboarding, period close, and gestoria support.
+157 tools across invoicing, CRM, products, quotes, expenses, deposits, banking, fiscal compliance (Modelo 303/130/390/180/347, VeriFactu, TicketBAI), e-invoicing (PEPPOL, XRechnung, FatturaPA, Facturae, FACe), vacation rental management, point-of-sale, time tracking, HR, payroll, onboarding, period close, and gestoria support.
 
 10 pre-built prompts for monthly close, quarterly tax prep, year-end close, cash flow forecast, invoice aging review and more.
 
@@ -106,9 +106,9 @@ Works with the free Frihet plan. Get an API key at app.frihet.io.
 ```json
 {
   "name": "frihet-erp",
-  "version": "1.13.0",
+  "version": "1.14.2",
   "displayName": "Frihet ERP",
-  "description": "AI-native ERP — full ES/EU fiscal compliance (VeriFactu/TicketBAI/Facturae) + 151 tools for invoicing, CRM, tax & banking.",
+  "description": "AI-native ERP — full ES/EU fiscal compliance (VeriFactu/TicketBAI/Facturae) + 157 tools for invoicing, CRM, tax & banking.",
   "icon": "https://frihet.io/favicon.svg",
   "homepage": "https://frihet.io",
   "repository": "https://github.com/Frihet-io/frihet-mcp",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frihet/mcp-server",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "description": "AI-native MCP server for business management — invoices, expenses, deposits, clients, products, quotes, webhooks, CRM, e-invoicing (Facturae/XRechnung/Factur-X/FatturaPA/PEPPOL + FACe Spain B2G + TicketBAI Basque Country + KSeF Poland), vacation rentals, POS, banking, fiscal (Modelo 303/130/390/180/347/415/425/418, VeriFactu, TicketBAI, IS M200/M202), IGIC, AIEM, GL audit approval, white-label portal domain, VIES EU VAT lookup, bank rules, time tracking, recurring invoices, team management, gestoria. 157 tools. Remote endpoint at mcp.frihet.io (zero install). Works with Claude, Cursor, Windsurf, Cline.",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "npm run build && node --test dist/__tests__/openai-profile.test.js dist/__tests__/tool-exposure.test.js dist/__tests__/einvoice-tools.test.js dist/__tests__/einvoice-day4-tools.test.js dist/__tests__/stay-tools.test.js dist/__tests__/pos-tools.test.js dist/__tests__/kitchen-tools.test.js dist/__tests__/banking-tools.test.js dist/__tests__/banking-client-contract.test.js dist/__tests__/fiscal-tools.test.js dist/__tests__/time-tools.test.js dist/__tests__/recurring-tools.test.js dist/__tests__/team-tools.test.js dist/__tests__/d4b-hr-payroll-onboarding-tools.test.js dist/__tests__/audit-server-version.test.js dist/__tests__/openai-grouped-compose.test.js",
+    "test": "npm run build && node --test dist/__tests__/openai-profile.test.js dist/__tests__/tool-exposure.test.js dist/__tests__/einvoice-tools.test.js dist/__tests__/einvoice-day4-tools.test.js dist/__tests__/stay-tools.test.js dist/__tests__/pos-tools.test.js dist/__tests__/kitchen-tools.test.js dist/__tests__/banking-tools.test.js dist/__tests__/banking-client-contract.test.js dist/__tests__/fiscal-tools.test.js dist/__tests__/time-tools.test.js dist/__tests__/recurring-tools.test.js dist/__tests__/team-tools.test.js dist/__tests__/d4b-hr-payroll-onboarding-tools.test.js dist/__tests__/audit-server-version.test.js dist/__tests__/openai-grouped-compose.test.js dist/__tests__/contract.test.js",
     "start": "node dist/index.js",
     "postinstall": "node scripts/postinstall.js || true",
     "prepublishOnly": "npm run build && npm run audit:mcp-refs -- --repo frihet-mcp",

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/Frihet-io/frihet-mcp",
     "source": "github"
   },
-  "version": "1.14.1",
+  "version": "1.14.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@frihet/mcp-server",
-      "version": "1.14.1",
+      "version": "1.14.2",
       "transport": {
         "type": "stdio"
       }

--- a/src/__tests__/contract.test.ts
+++ b/src/__tests__/contract.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Output-schema CONTRACT tests.
+ *
+ * WHY THIS FILE EXISTS (the bug class it locks down forever):
+ *
+ * The MCP tools declare Zod `outputSchema`s and put the raw Cloud Function (CF)
+ * response into `structuredContent`. The CF response has TWO shapes that have
+ * historically drifted from the schemas and broken tools silently:
+ *
+ *   1. The `{ data, meta }` ENVELOPE. Single-object reads (e.g. the shipped
+ *      `/v1/fiscal/modelo/:code` CF) return `res.json({ data: <item>, meta })`;
+ *      list reads return `{ data: [<item>...], total, limit, offset }`. The
+ *      client unwraps single objects to `body.data` (`requestUnwrapped`) and
+ *      keeps the paginated envelope (`requestPaginated`). If the schema and the
+ *      unwrap disagree, the tool emits a structuredContent the model can't parse.
+ *
+ *   2. Firestore-TIMESTAMP-shaped fields. Firestore-direct reads can leak
+ *      `{ _seconds, _nanoseconds }` objects on date-ish fields instead of ISO
+ *      strings. The enumerated date fields are typed `z.string()`, so a raw
+ *      timestamp on `createdAt` would FAIL — but `.passthrough()` carries extra
+ *      Firestore-internal timestamp fields (`_syncedAt`, `lastTouchedAt`, …)
+ *      through untouched. This test pins BOTH facts: enumerated dates stay ISO
+ *      strings, and extra `{_seconds}` fields pass via `.passthrough()`.
+ *
+ * If a future refactor tightens a schema (drops `.passthrough()`, or retypes a
+ * passthrough timestamp field as `z.string()`), or the CF starts returning a
+ * shape the schema rejects, THIS test goes red in CI — instead of the bug
+ * reaching an LLM as an unparseable tool result.
+ *
+ * Run: npm test (after build) — node:test + node:assert.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  fiscalModeloSummaryOutput,
+  verifactuStatusOutput,
+  paginatedOutput,
+  invoiceItemOutput,
+  expenseItemOutput,
+  clientItemOutput,
+} from "../tools/shared.js";
+
+// ── Fixtures: representative CF responses ────────────────────────────────────
+
+/** A Firestore Timestamp as it appears in a JSON-serialized CF response. */
+const FIRESTORE_TS = { _seconds: 1_771_200_000, _nanoseconds: 0 } as const;
+
+/**
+ * The fiscal-summary CF body AFTER `requestUnwrapped` strips the `{ data, meta }`
+ * envelope — i.e. exactly what the tool receives. Includes the `model` (not
+ * `modeloCode`) shape the live CF emits, the `modelo303` totals block, a
+ * `summary` counts block, and a passthrough Firestore-timestamp field
+ * (`computedAt`) that is NOT in the schema's enumerated fields.
+ */
+const FISCAL_303_UNWRAPPED = {
+  model: "303",
+  period: "2026-Q1",
+  months: ["2026-01", "2026-02", "2026-03"],
+  modelo303: {
+    baseImponible: 10_000,
+    cuotaRepercutida: 2_100,
+    baseDeducible: 4_000,
+    cuotaDeducible: 840,
+    resultado: 1_260,
+  },
+  summary: { invoiceCount: 12, expenseCount: 7 },
+  readonly: true as const,
+  note: "Informational summary — never filed to AEAT.",
+  // Firestore-internal timestamp leaking through .passthrough() — must validate.
+  computedAt: FIRESTORE_TS,
+};
+
+/** The raw `{ data, meta }` envelope as the CF emits it pre-unwrap. */
+const FISCAL_303_ENVELOPE = {
+  data: FISCAL_303_UNWRAPPED,
+  meta: { generatedAt: FIRESTORE_TS, source: "cf:getFiscalModeloSummary" },
+};
+
+/** Mirror of `requestUnwrapped`: pull `.data` out of a single-object envelope. */
+function unwrap(body: unknown): unknown {
+  if (body !== null && typeof body === "object" && !Array.isArray(body) && "data" in body) {
+    const inner = (body as { data: unknown }).data;
+    if (inner !== null && typeof inner === "object" && !Array.isArray(inner)) {
+      return inner;
+    }
+  }
+  return body;
+}
+
+const VERIFACTU_STATUS = {
+  invoiceId: "inv_2026_001",
+  lastSubmissionAt: "2026-04-15T10:30:00.000Z", // enumerated date field stays ISO
+  hash: "a1b2c3",
+  status: "success" as const,
+  aeatResponse: "Aceptado",
+  qrUrl: "https://www2.agenciatributaria.gob.es/qr/...",
+  // Firestore-internal timestamp via passthrough — must validate.
+  _chainTouchedAt: FIRESTORE_TS,
+};
+
+/** A paginated list envelope as `requestPaginated` keeps it: data[] + counts. */
+const INVOICE_LIST_ENVELOPE = {
+  data: [
+    {
+      id: "inv_1",
+      clientName: "ACME SL",
+      items: [{ description: "Consulting", quantity: 1, unitPrice: 1000 }],
+      issueDate: "2026-03-01",
+      dueDate: "2026-03-31",
+      status: "sent",
+      total: 1210,
+      createdAt: "2026-03-01T09:00:00.000Z", // enumerated date → ISO string
+      // Firestore-internal timestamp via passthrough.
+      _firestoreUpdatedAt: FIRESTORE_TS,
+    },
+  ],
+  total: 1,
+  limit: 20,
+  offset: 0,
+  nextCursor: "inv_1",
+};
+
+const EXPENSE_LIST_ENVELOPE = {
+  data: [
+    {
+      id: "exp_1",
+      description: "AWS",
+      amount: 42.5,
+      category: "software",
+      date: "2026-03-02",
+      taxDeductible: true,
+      createdAt: "2026-03-02T00:00:00.000Z",
+      _syncedAt: FIRESTORE_TS,
+    },
+  ],
+  total: 1,
+  limit: 20,
+  offset: 0,
+};
+
+const CLIENT_LIST_ENVELOPE = {
+  data: [
+    {
+      id: "cli_1",
+      name: "ACME SL",
+      email: "facturas@acme.es",
+      taxId: "B12345678",
+      address: { city: "Madrid", country: "ES" },
+      createdAt: "2026-01-10T00:00:00.000Z",
+      _importedAt: FIRESTORE_TS,
+    },
+  ],
+  total: 1,
+  limit: 20,
+  offset: 0,
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("output-schema contract — fiscal single-object reads", () => {
+  test("fiscalModeloSummaryOutput accepts the unwrapped 303 CF body", () => {
+    const unwrapped = unwrap(FISCAL_303_ENVELOPE);
+    const parsed = fiscalModeloSummaryOutput.safeParse(unwrapped);
+    assert.equal(parsed.success, true, parsed.success ? "" : JSON.stringify(parsed.error.issues, null, 2));
+  });
+
+  test("unwrap() strips the { data, meta } envelope (matches client.requestUnwrapped)", () => {
+    const unwrapped = unwrap(FISCAL_303_ENVELOPE) as Record<string, unknown>;
+    assert.equal(unwrapped.model, "303");
+    assert.equal("meta" in unwrapped, false, "meta must NOT leak into the unwrapped item");
+  });
+
+  test("a Firestore-Timestamp {_seconds} field survives via .passthrough()", () => {
+    const parsed = fiscalModeloSummaryOutput.safeParse(unwrap(FISCAL_303_ENVELOPE));
+    assert.equal(parsed.success, true);
+    if (parsed.success) {
+      const ts = (parsed.data as Record<string, unknown>).computedAt as { _seconds?: number };
+      assert.equal(ts?._seconds, FIRESTORE_TS._seconds, "timestamp field must pass through intact");
+    }
+  });
+
+  test("verifactuStatusOutput accepts the status CF body incl. passthrough timestamp", () => {
+    const parsed = verifactuStatusOutput.safeParse(VERIFACTU_STATUS);
+    assert.equal(parsed.success, true, parsed.success ? "" : JSON.stringify(parsed.error.issues, null, 2));
+  });
+
+  test("enumerated date fields MUST stay strings — a raw {_seconds} there is rejected", () => {
+    // This pins the contract: the CF must emit ISO strings for enumerated dates.
+    // If it ever leaks a raw timestamp onto `lastSubmissionAt`, the tool would
+    // emit garbage — so we assert the schema (correctly) refuses it.
+    const bad = { ...VERIFACTU_STATUS, lastSubmissionAt: FIRESTORE_TS };
+    const parsed = verifactuStatusOutput.safeParse(bad);
+    assert.equal(parsed.success, false, "raw timestamp on an enumerated z.string() date must fail");
+  });
+});
+
+describe("output-schema contract — core list reads ({ data, ... } envelope)", () => {
+  test("invoices list envelope validates against paginatedOutput(invoiceItemOutput)", () => {
+    const schema = paginatedOutput(invoiceItemOutput);
+    const parsed = schema.safeParse(INVOICE_LIST_ENVELOPE);
+    assert.equal(parsed.success, true, parsed.success ? "" : JSON.stringify(parsed.error.issues, null, 2));
+  });
+
+  test("a list item carrying a Firestore Timestamp passthrough field validates", () => {
+    const schema = paginatedOutput(invoiceItemOutput);
+    const parsed = schema.safeParse(INVOICE_LIST_ENVELOPE);
+    assert.equal(parsed.success, true);
+    if (parsed.success) {
+      const item = parsed.data.data[0] as Record<string, unknown>;
+      const ts = item._firestoreUpdatedAt as { _seconds?: number };
+      assert.equal(ts?._seconds, FIRESTORE_TS._seconds);
+    }
+  });
+
+  test("expenses list envelope validates against paginatedOutput(expenseItemOutput)", () => {
+    const schema = paginatedOutput(expenseItemOutput);
+    const parsed = schema.safeParse(EXPENSE_LIST_ENVELOPE);
+    assert.equal(parsed.success, true, parsed.success ? "" : JSON.stringify(parsed.error.issues, null, 2));
+  });
+
+  test("clients list envelope validates against paginatedOutput(clientItemOutput)", () => {
+    const schema = paginatedOutput(clientItemOutput);
+    const parsed = schema.safeParse(CLIENT_LIST_ENVELOPE);
+    assert.equal(parsed.success, true, parsed.success ? "" : JSON.stringify(parsed.error.issues, null, 2));
+  });
+
+  test("paginatedOutput requires the envelope counts (data/total/limit/offset)", () => {
+    const schema = paginatedOutput(invoiceItemOutput);
+    // Missing `total`/`limit`/`offset` (a bare array-ish body) must fail — this
+    // is the drift that breaks pagination if the CF stops emitting counts.
+    const parsed = schema.safeParse({ data: INVOICE_LIST_ENVELOPE.data });
+    assert.equal(parsed.success, false, "envelope without counts must be rejected");
+  });
+});

--- a/src/__tests__/tool-exposure.test.ts
+++ b/src/__tests__/tool-exposure.test.ts
@@ -211,7 +211,10 @@ describe("tool-exposure: group taxonomy", () => {
     for (const f of readdirSync(toolsDir)) {
       if (!f.endsWith(".ts")) continue;
       const base = f.replace(/\.ts$/, "");
-      if (base === "register-all" || base === "shared") continue;
+      // Skip helper modules that register ZERO tools (not tool-group files):
+      //   register-all = registration entrypoint, shared = cross-tool helpers,
+      //   backend-availability = the 404→structured-error guard helper.
+      if (base === "register-all" || base === "shared" || base === "backend-availability") continue;
       const fileGroup = FILE_TO_GROUP[base];
       assert.ok(fileGroup, `source file ${base}.ts must be mapped in FILE_TO_GROUP`);
       const txt = readFileSync(join(toolsDir, f), "utf8");

--- a/src/client.ts
+++ b/src/client.ts
@@ -170,6 +170,49 @@ export class FrihetClient {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
+  /**
+   * Wrapper for SINGLE-OBJECT endpoints whose backend wraps the item in a
+   * `{ data, meta }` envelope (e.g. the shipped `/v1/fiscal/modelo/:code` CF).
+   *
+   * The Cloudflare Function returns `res.json({ data: <item>, meta: {...} })`
+   * for single-object reads, so the raw HTTP body is the envelope — NOT the
+   * item. Passing that envelope straight into a tool's `structuredContent`
+   * surfaces `{ data, meta }` instead of the modelo summary, breaking the
+   * tool's output schema. This unwraps to `body.data`.
+   *
+   * Only unwraps when the body is an object carrying a `data` property that is
+   * itself a (non-array) object — i.e. a genuine single-object envelope. It is
+   * deliberately distinct from {@link requestPaginated}, which keeps the
+   * `{ data: [...] , meta }` shape intact for list endpoints. If the body is
+   * not an envelope (legacy endpoints that return the item directly), it is
+   * returned unchanged so existing callers keep working.
+   */
+  private async requestUnwrapped<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    query?: Record<string, string | number | undefined>,
+  ): Promise<T> {
+    const raw = await this.request<unknown>(method, path, body, query);
+
+    if (
+      raw !== null &&
+      typeof raw === "object" &&
+      !Array.isArray(raw) &&
+      "data" in raw
+    ) {
+      const inner = (raw as { data: unknown }).data;
+      // Single-object envelope only. An array `data` belongs to a paginated
+      // response — never reachable here (those go through requestPaginated),
+      // but guard anyway so we never silently strip a list.
+      if (inner !== null && typeof inner === "object" && !Array.isArray(inner)) {
+        return inner as T;
+      }
+    }
+
+    return raw as T;
+  }
+
   /** Wrapper for paginated endpoints — validates response shape has `data` array. */
   private async requestPaginated<T>(
     method: string,
@@ -911,13 +954,20 @@ export class FrihetClient {
   }
 
   // ---------------------------------------------------------------- Fiscal
-  // NOTE: /v1/fiscal/* endpoints are planned — 404 propagates until backend ships.
+  // RESOLVED (was: "planned — 404 propagates until backend ships"). The
+  // /v1/fiscal/modelo/:code summary backend (Modelo 303/130/390 READ-ONLY)
+  // has SHIPPED in Frihet-ERP (publicApi.ts). The CF wraps the single-object
+  // summary in a `{ data, meta }` envelope, so this read MUST unwrap to
+  // `body.data` — otherwise the tool's structuredContent is the envelope, not
+  // the modelo summary. See requestUnwrapped().
+  // NOTE: /v1/fiscal/verifactu/* + /ticketbai/* below remain pending and 404
+  // until those backends ship (they keep the raw `request` path for now).
 
   async getFiscalModeloSummary(
     modeloCode: string,
     period?: string,
   ): Promise<Record<string, unknown>> {
-    return this.request("GET", `/fiscal/modelo/${encodeURIComponent(modeloCode)}`, undefined, {
+    return this.requestUnwrapped("GET", `/fiscal/modelo/${encodeURIComponent(modeloCode)}`, undefined, {
       period,
     });
   }

--- a/src/tools/accountingClose.ts
+++ b/src/tools/accountingClose.ts
@@ -26,6 +26,7 @@ import {
   READ_ONLY_ANNOTATIONS,
   periodStatusOutput,
 } from "./shared.js";
+import { withBackendGuard } from "./backend-availability.js";
 
 export function registerAccountingCloseTools(server: McpServer, client: IFrihetClient): void {
   // -- period_close_status --
@@ -44,13 +45,15 @@ export function registerAccountingCloseTools(server: McpServer, client: IFrihetC
       },
       outputSchema: periodStatusOutput,
     },
-    async ({ periodId }) => withToolLogging("period_close_status", async () => {
-      const result = await client.getCurrentPeriod({ periodId });
-      return {
-        content: [getContent(formatRecord("Period status", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ periodId }) => withToolLogging("period_close_status", () =>
+      withBackendGuard("period_close_status", "/v1/periods/current", async () => {
+        const result = await client.getCurrentPeriod({ periodId });
+        return {
+          content: [getContent(formatRecord("Period status", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- period_close --
@@ -92,11 +95,13 @@ export function registerAccountingCloseTools(server: McpServer, client: IFrihetC
           isError: true,
         };
       }
-      const result = await client.closePeriod({ type });
-      return {
-        content: [mutateContent(formatRecord("Period closed", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
+      return withBackendGuard("period_close", "/v1/periods/close", async () => {
+        const result = await client.closePeriod({ type });
+        return {
+          content: [mutateContent(formatRecord("Period closed", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      });
     }),
   );
 
@@ -139,11 +144,13 @@ export function registerAccountingCloseTools(server: McpServer, client: IFrihetC
           isError: true,
         };
       }
-      const result = await client.reopenPeriod({ periodId, reason });
-      return {
-        content: [mutateContent(formatRecord("Period reopened", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
+      return withBackendGuard("period_reopen", "/v1/periods/reopen", async () => {
+        const result = await client.reopenPeriod({ periodId, reason });
+        return {
+          content: [mutateContent(formatRecord("Period reopened", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      });
     }),
   );
 }

--- a/src/tools/audit_gl.ts
+++ b/src/tools/audit_gl.ts
@@ -25,6 +25,7 @@ import {
   READ_ONLY_ANNOTATIONS,
   UPDATE_ANNOTATIONS,
 } from "./shared.js";
+import { withBackendGuard } from "./backend-availability.js";
 
 export function registerAuditGLTools(server: McpServer, client: IFrihetClient): void {
   // -- frihet_gl_entry_approve -----------------------------------------------
@@ -46,17 +47,19 @@ export function registerAuditGLTools(server: McpServer, client: IFrihetClient): 
         notes: z.string().optional().describe("Optional approval notes / Notas de aprobacion opcionales"),
       },
     },
-    async ({ entryId, notes }) => withToolLogging("frihet_gl_entry_approve", async () => {
-      const result = await client.approveGLEntry(entryId, notes);
-      return {
-        content: [
-          mutateContent(
-            formatRecord(`GL Entry ${entryId} approved`, result),
-          ),
-        ],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ entryId, notes }) => withToolLogging("frihet_gl_entry_approve", () =>
+      withBackendGuard("frihet_gl_entry_approve", "/v1/gl/entries/approve", async () => {
+        const result = await client.approveGLEntry(entryId, notes);
+        return {
+          content: [
+            mutateContent(
+              formatRecord(`GL Entry ${entryId} approved`, result),
+            ),
+          ],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- frihet_gl_entry_reject ------------------------------------------------
@@ -78,17 +81,19 @@ export function registerAuditGLTools(server: McpServer, client: IFrihetClient): 
         reason: z.string().describe("Mandatory rejection reason (visible to submitter) / Razon del rechazo (obligatoria, visible al emisor)"),
       },
     },
-    async ({ entryId, reason }) => withToolLogging("frihet_gl_entry_reject", async () => {
-      const result = await client.rejectGLEntry(entryId, reason);
-      return {
-        content: [
-          mutateContent(
-            formatRecord(`GL Entry ${entryId} rejected`, result),
-          ),
-        ],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ entryId, reason }) => withToolLogging("frihet_gl_entry_reject", () =>
+      withBackendGuard("frihet_gl_entry_reject", "/v1/gl/entries/reject", async () => {
+        const result = await client.rejectGLEntry(entryId, reason);
+        return {
+          content: [
+            mutateContent(
+              formatRecord(`GL Entry ${entryId} rejected`, result),
+            ),
+          ],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- frihet_gl_entry_audit_log ---------------------------------------------
@@ -109,12 +114,14 @@ export function registerAuditGLTools(server: McpServer, client: IFrihetClient): 
         entryId: z.string().describe("GL entry ID / ID del asiento contable"),
       },
     },
-    async ({ entryId }) => withToolLogging("frihet_gl_entry_audit_log", async () => {
-      const result = await client.getGLEntryAuditLog(entryId);
-      return {
-        content: [getContent(formatRecord(`Audit Log for GL Entry ${entryId}`, result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ entryId }) => withToolLogging("frihet_gl_entry_audit_log", () =>
+      withBackendGuard("frihet_gl_entry_audit_log", "/v1/gl/entries/audit-log", async () => {
+        const result = await client.getGLEntryAuditLog(entryId);
+        return {
+          content: [getContent(formatRecord(`Audit Log for GL Entry ${entryId}`, result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 }

--- a/src/tools/backend-availability.ts
+++ b/src/tools/backend-availability.ts
@@ -1,0 +1,123 @@
+/**
+ * Backend-availability guard for MCP tool handlers.
+ *
+ * PROBLEM (the bug this prevents): several tool families are wired here AHEAD of
+ * their Frihet-ERP backend Cloud Functions shipping (fiscal `/v1/fiscal/*`, bank
+ * rules `/v1/banking/rules`, gestoria `/v1/gestoria/*`, GL audit `/v1/gl/*`,
+ * portal domain/onboard, IGIC, IS, VIES onboarding, payroll prep, permissions,
+ * HR leaves/anomalies, accounting periods, webhook test). Until the CF deploys,
+ * the API returns a genuine HTTP 404.
+ *
+ * If that raw 404 reaches `handleToolError` it is mapped to the generic message
+ * "Resource not found. / Recurso no encontrado." — which an LLM reads as "the
+ * thing you asked about does not exist" and then HALLUCINATES a confident answer
+ * ("you have no Modelo 303 to file", "this workspace has no permissions matrix").
+ * That is a Trust-Area failure: the model invents fiscal/compliance facts.
+ *
+ * FIX: wrap the client call in `withBackendGuard`. A genuine 404 is converted into
+ * an explicit STRUCTURED tool error that names the tool and states the backend is
+ * not available yet — never a value the LLM can mistake for real business data.
+ * Any other error (401/403/429/5xx/network) is RE-THROWN unchanged so the normal
+ * `withToolLogging` → `handleToolError` path still surfaces it.
+ *
+ * NOTE: this is intentionally a SEPARATE module from `shared.ts` (owned elsewhere)
+ * and `client.ts`. It only depends on the public content-block shape.
+ */
+
+import { ERROR_CONTENT_ANNOTATIONS, type AnnotatedTextContent } from "./shared.js";
+
+/** Structured-content payload returned alongside a backend-unavailable error. */
+export interface BackendUnavailableStructured {
+  error: "backend_unavailable";
+  tool: string;
+  message: string;
+  /** The planned REST endpoint, if known — aids ops/debugging, not the LLM. */
+  endpoint?: string;
+  /** Machine flag so downstream agents can branch without parsing prose. */
+  _backendUnavailable: true;
+}
+
+export interface BackendGuardErrorResult {
+  /** Index signature mirrors the MCP `ToolResult` shape so this is assignable to it. */
+  [x: string]: unknown;
+  content: AnnotatedTextContent[];
+  structuredContent: Record<string, unknown>;
+  isError: true;
+}
+
+/**
+ * True when an error is a genuine HTTP 404 (FrihetApiError-like or fetch-shaped).
+ * Duck-typed so it works regardless of which client implementation threw.
+ */
+export function isBackendNotFound(error: unknown): boolean {
+  if (error && typeof error === "object") {
+    const e = error as Record<string, unknown>;
+    if (e["statusCode"] === 404) return true;
+    if (e["status"] === 404) return true;
+  }
+  return false;
+}
+
+/**
+ * Builds the explicit, LLM-safe "backend not available" tool error.
+ */
+export function backendUnavailableError(
+  toolName: string,
+  endpoint?: string,
+): BackendGuardErrorResult {
+  const message =
+    `The backend for "${toolName}" is not available yet, so no data could be retrieved. ` +
+    `This is NOT an empty or zero result — the underlying Frihet ERP endpoint ` +
+    (endpoint ? `(${endpoint}) ` : "") +
+    `is not deployed in your workspace. ` +
+    `Do NOT infer or invent a value (e.g. "no records", "0 due", "no permissions"). ` +
+    `Tell the user this feature is not enabled yet and to contact Frihet support / check feature availability. ` +
+    `/ El backend de "${toolName}" aun no esta disponible: el endpoint de Frihet ERP no esta desplegado en este workspace. ` +
+    `NO es un resultado vacio ni cero — no inventes un valor. Indica al usuario que la funcion aun no esta activa.`;
+
+  const structured: BackendUnavailableStructured = {
+    error: "backend_unavailable",
+    tool: toolName,
+    message,
+    ...(endpoint ? { endpoint } : {}),
+    _backendUnavailable: true,
+  };
+
+  return {
+    content: [{ type: "text", text: `Error: ${message}`, annotations: ERROR_CONTENT_ANNOTATIONS }],
+    structuredContent: structured as unknown as Record<string, unknown>,
+    isError: true,
+  };
+}
+
+/**
+ * Wraps a tool's client call. On a genuine 404 (backend not deployed) returns a
+ * structured backend-unavailable error instead of letting the raw 404 surface as
+ * a generic "resource not found" that the LLM would treat as real data. Any other
+ * error is re-thrown so `withToolLogging`/`handleToolError` handle it normally.
+ *
+ * Usage:
+ * ```ts
+ * async ({ period }) => withToolLogging("get_modelo_303_summary", () =>
+ *   withBackendGuard("get_modelo_303_summary", "/v1/fiscal/303", async () => {
+ *     const result = await client.getFiscalModeloSummary("303", period);
+ *     return { content: [getContent(formatRecord("Modelo 303 Summary", result))],
+ *              structuredContent: result as unknown as Record<string, unknown> };
+ *   }),
+ * )
+ * ```
+ */
+export async function withBackendGuard<T extends { content: unknown[] }>(
+  toolName: string,
+  endpoint: string | undefined,
+  fn: () => Promise<T>,
+): Promise<T | BackendGuardErrorResult> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (isBackendNotFound(err)) {
+      return backendUnavailableError(toolName, endpoint);
+    }
+    throw err;
+  }
+}

--- a/src/tools/bank_rules.ts
+++ b/src/tools/bank_rules.ts
@@ -31,6 +31,7 @@ import {
   CREATE_ANNOTATIONS,
   paginatedOutput,
 } from "./shared.js";
+import { withBackendGuard } from "./backend-availability.js";
 
 const bankRuleItemOutput = z.object({
   id: z.string(),
@@ -72,13 +73,15 @@ export function registerBankRulesTools(server: McpServer, client: IFrihetClient)
       },
       outputSchema: paginatedOutput(bankRuleItemOutput),
     },
-    async ({ isActive, limit, offset }) => withToolLogging("frihet_bank_rules_list", async () => {
-      const result = await client.listBankRules({ isActive, limit, offset });
-      return {
-        content: [listContent(formatPaginatedResponse("bank_rules", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ isActive, limit, offset }) => withToolLogging("frihet_bank_rules_list", () =>
+      withBackendGuard("frihet_bank_rules_list", "/v1/banking/rules", async () => {
+        const result = await client.listBankRules({ isActive, limit, offset });
+        return {
+          content: [listContent(formatPaginatedResponse("bank_rules", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- frihet_bank_rule_create ----------------------------------------------
@@ -114,16 +117,18 @@ export function registerBankRulesTools(server: McpServer, client: IFrihetClient)
         isActive: z.boolean().optional().describe("Whether the rule is active (default true) / Si la regla esta activa (por defecto true)"),
       },
     },
-    async ({ name, conditions, actions, isActive }) => withToolLogging("frihet_bank_rule_create", async () => {
-      const result = await client.createBankRule({ name, conditions, actions, isActive });
-      return {
-        content: [
-          mutateContent(
-            formatRecord(`Bank rule created: ${name}`, result),
-          ),
-        ],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ name, conditions, actions, isActive }) => withToolLogging("frihet_bank_rule_create", () =>
+      withBackendGuard("frihet_bank_rule_create", "/v1/banking/rules", async () => {
+        const result = await client.createBankRule({ name, conditions, actions, isActive });
+        return {
+          content: [
+            mutateContent(
+              formatRecord(`Bank rule created: ${name}`, result),
+            ),
+          ],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 }

--- a/src/tools/fiscal.ts
+++ b/src/tools/fiscal.ts
@@ -30,6 +30,7 @@ import {
   fiscalModeloSummaryOutput,
   verifactuStatusOutput,
 } from "./shared.js";
+import { withBackendGuard } from "./backend-availability.js";
 
 export function registerFiscalTools(server: McpServer, client: IFrihetClient): void {
   // -- get_modelo_303_summary --
@@ -53,13 +54,15 @@ export function registerFiscalTools(server: McpServer, client: IFrihetClient): v
       },
       outputSchema: fiscalModeloSummaryOutput,
     },
-    async ({ period }) => withToolLogging("get_modelo_303_summary", async () => {
-      const result = await client.getFiscalModeloSummary("303", period);
-      return {
-        content: [getContent(formatRecord("Modelo 303 Summary", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ period }) => withToolLogging("get_modelo_303_summary", () =>
+      withBackendGuard("get_modelo_303_summary", "/v1/fiscal/303", async () => {
+        const result = await client.getFiscalModeloSummary("303", period);
+        return {
+          content: [getContent(formatRecord("Modelo 303 Summary", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- get_modelo_130_summary --
@@ -83,13 +86,15 @@ export function registerFiscalTools(server: McpServer, client: IFrihetClient): v
       },
       outputSchema: fiscalModeloSummaryOutput,
     },
-    async ({ period }) => withToolLogging("get_modelo_130_summary", async () => {
-      const result = await client.getFiscalModeloSummary("130", period);
-      return {
-        content: [getContent(formatRecord("Modelo 130 Summary", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ period }) => withToolLogging("get_modelo_130_summary", () =>
+      withBackendGuard("get_modelo_130_summary", "/v1/fiscal/130", async () => {
+        const result = await client.getFiscalModeloSummary("130", period);
+        return {
+          content: [getContent(formatRecord("Modelo 130 Summary", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- get_modelo_390_summary --
@@ -113,13 +118,15 @@ export function registerFiscalTools(server: McpServer, client: IFrihetClient): v
       },
       outputSchema: fiscalModeloSummaryOutput,
     },
-    async ({ period }) => withToolLogging("get_modelo_390_summary", async () => {
-      const result = await client.getFiscalModeloSummary("390", period);
-      return {
-        content: [getContent(formatRecord("Modelo 390 Summary", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ period }) => withToolLogging("get_modelo_390_summary", () =>
+      withBackendGuard("get_modelo_390_summary", "/v1/fiscal/390", async () => {
+        const result = await client.getFiscalModeloSummary("390", period);
+        return {
+          content: [getContent(formatRecord("Modelo 390 Summary", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- get_modelo_180_summary --
@@ -143,13 +150,15 @@ export function registerFiscalTools(server: McpServer, client: IFrihetClient): v
       },
       outputSchema: fiscalModeloSummaryOutput,
     },
-    async ({ period }) => withToolLogging("get_modelo_180_summary", async () => {
-      const result = await client.getFiscalModeloSummary("180", period);
-      return {
-        content: [getContent(formatRecord("Modelo 180 Summary", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ period }) => withToolLogging("get_modelo_180_summary", () =>
+      withBackendGuard("get_modelo_180_summary", "/v1/fiscal/180", async () => {
+        const result = await client.getFiscalModeloSummary("180", period);
+        return {
+          content: [getContent(formatRecord("Modelo 180 Summary", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- get_modelo_347_summary --
@@ -173,13 +182,15 @@ export function registerFiscalTools(server: McpServer, client: IFrihetClient): v
       },
       outputSchema: fiscalModeloSummaryOutput,
     },
-    async ({ period }) => withToolLogging("get_modelo_347_summary", async () => {
-      const result = await client.getFiscalModeloSummary("347", period);
-      return {
-        content: [getContent(formatRecord("Modelo 347 Summary", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ period }) => withToolLogging("get_modelo_347_summary", () =>
+      withBackendGuard("get_modelo_347_summary", "/v1/fiscal/347", async () => {
+        const result = await client.getFiscalModeloSummary("347", period);
+        return {
+          content: [getContent(formatRecord("Modelo 347 Summary", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- verifactu_status --
@@ -199,13 +210,15 @@ export function registerFiscalTools(server: McpServer, client: IFrihetClient): v
       },
       outputSchema: verifactuStatusOutput,
     },
-    async ({ invoiceId }) => withToolLogging("verifactu_status", async () => {
-      const result = await client.getVerifactuStatus(invoiceId);
-      return {
-        content: [getContent(formatRecord("VeriFactu Status", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ invoiceId }) => withToolLogging("verifactu_status", () =>
+      withBackendGuard("verifactu_status", "/v1/fiscal/verifactu/status", async () => {
+        const result = await client.getVerifactuStatus(invoiceId);
+        return {
+          content: [getContent(formatRecord("VeriFactu Status", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- verifactu_resubmit --
@@ -246,11 +259,13 @@ export function registerFiscalTools(server: McpServer, client: IFrihetClient): v
           isError: true,
         };
       }
-      const result = await client.resubmitVerifactu(invoiceId);
-      return {
-        content: [mutateContent(formatRecord("VeriFactu Resubmitted", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
+      return withBackendGuard("verifactu_resubmit", "/v1/fiscal/verifactu/resubmit", async () => {
+        const result = await client.resubmitVerifactu(invoiceId);
+        return {
+          content: [mutateContent(formatRecord("VeriFactu Resubmitted", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      });
     }),
   );
 

--- a/src/tools/gestoria.ts
+++ b/src/tools/gestoria.ts
@@ -40,6 +40,7 @@ import {
   gestoriaBulkSendResultOutput,
   gestoriaAgingConsolidatedOutput,
 } from "./shared.js";
+import { withBackendGuard } from "./backend-availability.js";
 
 const PARENT_TYPE = z
   .enum(["documentRequest", "filingItem", "obligation"])
@@ -98,13 +99,15 @@ export function registerGestoriaTools(server: McpServer, client: IFrihetClient):
       outputSchema: gestoriaMessageSendResultOutput,
     },
     async ({ workspaceId, parentType, parentId, body }) =>
-      withToolLogging("gestoria_message_send", async () => {
-        const result = await client.sendGestoriaMessage({ workspaceId, parentType, parentId, body });
-        return {
-          content: [mutateContent(formatRecord("Message sent", result))],
-          structuredContent: result as unknown as Record<string, unknown>,
-        };
-      }),
+      withToolLogging("gestoria_message_send", () =>
+        withBackendGuard("gestoria_message_send", "/v1/gestoria/messages", async () => {
+          const result = await client.sendGestoriaMessage({ workspaceId, parentType, parentId, body });
+          return {
+            content: [mutateContent(formatRecord("Message sent", result))],
+            structuredContent: result as unknown as Record<string, unknown>,
+          };
+        }),
+      ),
   );
 
   // -- gestoria_messages_list -----------------------------------------------
@@ -142,25 +145,27 @@ export function registerGestoriaTools(server: McpServer, client: IFrihetClient):
       }),
     },
     async ({ workspaceId, parentType, parentId, limit, before }) =>
-      withToolLogging("gestoria_messages_list", async () => {
-        const result = await client.listGestoriaMessages({
-          workspaceId,
-          parentType,
-          parentId,
-          limit,
-          before,
-        });
-        const count = Array.isArray(result.messages) ? result.messages.length : 0;
-        return {
-          content: [
-            listContent(
-              `Loaded ${count} message${count === 1 ? "" : "s"} for ${parentType}:${parentId}` +
-                (result.hasMore ? " (more available — paginate with `before`)" : ""),
-            ),
-          ],
-          structuredContent: result as unknown as Record<string, unknown>,
-        };
-      }),
+      withToolLogging("gestoria_messages_list", () =>
+        withBackendGuard("gestoria_messages_list", "/v1/gestoria/messages", async () => {
+          const result = await client.listGestoriaMessages({
+            workspaceId,
+            parentType,
+            parentId,
+            limit,
+            before,
+          });
+          const count = Array.isArray(result.messages) ? result.messages.length : 0;
+          return {
+            content: [
+              listContent(
+                `Loaded ${count} message${count === 1 ? "" : "s"} for ${parentType}:${parentId}` +
+                  (result.hasMore ? " (more available — paginate with `before`)" : ""),
+              ),
+            ],
+            structuredContent: result as unknown as Record<string, unknown>,
+          };
+        }),
+      ),
   );
 
   // -- gestoria_template_create ---------------------------------------------
@@ -214,20 +219,22 @@ export function registerGestoriaTools(server: McpServer, client: IFrihetClient):
       outputSchema: gestoriaTemplateCreateResultOutput,
     },
     async ({ name, title, description, dueDateOffsetDays, attachmentRequired, variables }) =>
-      withToolLogging("gestoria_template_create", async () => {
-        const result = await client.createGestoriaTemplate({
-          name,
-          title,
-          description,
-          dueDateOffsetDays,
-          attachmentRequired,
-          variables,
-        });
-        return {
-          content: [mutateContent(formatRecord("Template created", result))],
-          structuredContent: result as unknown as Record<string, unknown>,
-        };
-      }),
+      withToolLogging("gestoria_template_create", () =>
+        withBackendGuard("gestoria_template_create", "/v1/gestoria/templates", async () => {
+          const result = await client.createGestoriaTemplate({
+            name,
+            title,
+            description,
+            dueDateOffsetDays,
+            attachmentRequired,
+            variables,
+          });
+          return {
+            content: [mutateContent(formatRecord("Template created", result))],
+            structuredContent: result as unknown as Record<string, unknown>,
+          };
+        }),
+      ),
   );
 
   // -- gestoria_template_bulk_send ------------------------------------------
@@ -259,23 +266,25 @@ export function registerGestoriaTools(server: McpServer, client: IFrihetClient):
       outputSchema: gestoriaBulkSendResultOutput,
     },
     async ({ templateId, clientWorkspaceIds, periodOverrides }) =>
-      withToolLogging("gestoria_template_bulk_send", async () => {
-        const result = await client.bulkSendGestoriaTemplate({
-          templateId,
-          clientWorkspaceIds,
-          periodOverrides,
-        });
-        const success = typeof result.success === "number" ? result.success : 0;
-        const failed = Array.isArray(result.failed) ? result.failed.length : 0;
-        return {
-          content: [
-            mutateContent(
-              `Bulk send complete: ${success} succeeded, ${failed} failed of ${clientWorkspaceIds.length} targets.`,
-            ),
-          ],
-          structuredContent: result as unknown as Record<string, unknown>,
-        };
-      }),
+      withToolLogging("gestoria_template_bulk_send", () =>
+        withBackendGuard("gestoria_template_bulk_send", "/v1/gestoria/templates/bulk-send", async () => {
+          const result = await client.bulkSendGestoriaTemplate({
+            templateId,
+            clientWorkspaceIds,
+            periodOverrides,
+          });
+          const success = typeof result.success === "number" ? result.success : 0;
+          const failed = Array.isArray(result.failed) ? result.failed.length : 0;
+          return {
+            content: [
+              mutateContent(
+                `Bulk send complete: ${success} succeeded, ${failed} failed of ${clientWorkspaceIds.length} targets.`,
+              ),
+            ],
+            structuredContent: result as unknown as Record<string, unknown>,
+          };
+        }),
+      ),
   );
 
   // -- gestoria_aging_consolidated ------------------------------------------
@@ -305,12 +314,14 @@ export function registerGestoriaTools(server: McpServer, client: IFrihetClient):
       outputSchema: gestoriaAgingConsolidatedOutput,
     },
     async ({ ownerUid }) =>
-      withToolLogging("gestoria_aging_consolidated", async () => {
-        const result = await client.getGestoriaAgingConsolidated({ ownerUid });
-        return {
-          content: [getContent(formatRecord("Aging consolidated", result))],
-          structuredContent: result as unknown as Record<string, unknown>,
-        };
-      }),
+      withToolLogging("gestoria_aging_consolidated", () =>
+        withBackendGuard("gestoria_aging_consolidated", "/v1/gestoria/aging/consolidated", async () => {
+          const result = await client.getGestoriaAgingConsolidated({ ownerUid });
+          return {
+            content: [getContent(formatRecord("Aging consolidated", result))],
+            structuredContent: result as unknown as Record<string, unknown>,
+          };
+        }),
+      ),
   );
 }

--- a/src/tools/hr.ts
+++ b/src/tools/hr.ts
@@ -38,6 +38,7 @@ import {
   overtimeReportOutput,
   anomalyItemOutput,
 } from "./shared.js";
+import { withBackendGuard } from "./backend-availability.js";
 
 export function registerHrTools(server: McpServer, client: IFrihetClient): void {
   // -- leave_request_create --
@@ -61,13 +62,15 @@ export function registerHrTools(server: McpServer, client: IFrihetClient): void 
       },
       outputSchema: leaveRequestItemOutput,
     },
-    async (input) => withToolLogging("leave_request_create", async () => {
-      const result = await client.createLeaveRequest(input);
-      return {
-        content: [mutateContent(formatRecord("Leave request created", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async (input) => withToolLogging("leave_request_create", () =>
+      withBackendGuard("leave_request_create", "/v1/leaves", async () => {
+        const result = await client.createLeaveRequest(input);
+        return {
+          content: [mutateContent(formatRecord("Leave request created", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- leave_approve --
@@ -87,13 +90,15 @@ export function registerHrTools(server: McpServer, client: IFrihetClient): void 
       },
       outputSchema: leaveRequestItemOutput,
     },
-    async ({ leaveId, reason }) => withToolLogging("leave_approve", async () => {
-      const result = await client.approveLeave(leaveId, { reason });
-      return {
-        content: [mutateContent(formatRecord("Leave approved", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ leaveId, reason }) => withToolLogging("leave_approve", () =>
+      withBackendGuard("leave_approve", "/v1/leaves/approve", async () => {
+        const result = await client.approveLeave(leaveId, { reason });
+        return {
+          content: [mutateContent(formatRecord("Leave approved", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- leave_reject --
@@ -113,13 +118,15 @@ export function registerHrTools(server: McpServer, client: IFrihetClient): void 
       },
       outputSchema: leaveRequestItemOutput,
     },
-    async ({ leaveId, reason }) => withToolLogging("leave_reject", async () => {
-      const result = await client.rejectLeave(leaveId, { reason });
-      return {
-        content: [mutateContent(formatRecord("Leave rejected", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ leaveId, reason }) => withToolLogging("leave_reject", () =>
+      withBackendGuard("leave_reject", "/v1/leaves/reject", async () => {
+        const result = await client.rejectLeave(leaveId, { reason });
+        return {
+          content: [mutateContent(formatRecord("Leave rejected", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- leave_cancel --
@@ -138,13 +145,15 @@ export function registerHrTools(server: McpServer, client: IFrihetClient): void 
       },
       outputSchema: leaveRequestItemOutput,
     },
-    async ({ leaveId }) => withToolLogging("leave_cancel", async () => {
-      const result = await client.cancelLeave(leaveId);
-      return {
-        content: [mutateContent(formatRecord("Leave cancelled", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ leaveId }) => withToolLogging("leave_cancel", () =>
+      withBackendGuard("leave_cancel", "/v1/leaves/cancel", async () => {
+        const result = await client.cancelLeave(leaveId);
+        return {
+          content: [mutateContent(formatRecord("Leave cancelled", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- leave_list --
@@ -174,13 +183,15 @@ export function registerHrTools(server: McpServer, client: IFrihetClient): void 
       outputSchema: paginatedOutput(leaveRequestItemOutput),
     },
     async ({ employeeId, status, from, to, limit, offset, after }) =>
-      withToolLogging("leave_list", async () => {
-        const result = await client.listLeaves({ employeeId, status, from, to, limit, offset, after });
-        return {
-          content: [listContent(formatPaginatedResponse("leaves", result))],
-          structuredContent: result as unknown as Record<string, unknown>,
-        };
-      }),
+      withToolLogging("leave_list", () =>
+        withBackendGuard("leave_list", "/v1/leaves", async () => {
+          const result = await client.listLeaves({ employeeId, status, from, to, limit, offset, after });
+          return {
+            content: [listContent(formatPaginatedResponse("leaves", result))],
+            structuredContent: result as unknown as Record<string, unknown>,
+          };
+        }),
+      ),
   );
 
   // -- attendance_clock_in --
@@ -202,13 +213,15 @@ export function registerHrTools(server: McpServer, client: IFrihetClient): void 
       },
       outputSchema: attendanceEntryItemOutput,
     },
-    async (input) => withToolLogging("attendance_clock_in", async () => {
-      const result = await client.attendanceClockIn(input);
-      return {
-        content: [mutateContent(formatRecord("Clocked in", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async (input) => withToolLogging("attendance_clock_in", () =>
+      withBackendGuard("attendance_clock_in", "/v1/time-entries/clock-in", async () => {
+        const result = await client.attendanceClockIn(input);
+        return {
+          content: [mutateContent(formatRecord("Clocked in", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- attendance_clock_out --
@@ -227,13 +240,15 @@ export function registerHrTools(server: McpServer, client: IFrihetClient): void 
       },
       outputSchema: attendanceEntryItemOutput,
     },
-    async ({ entryId }) => withToolLogging("attendance_clock_out", async () => {
-      const result = await client.attendanceClockOut(entryId);
-      return {
-        content: [mutateContent(formatRecord("Clocked out", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ entryId }) => withToolLogging("attendance_clock_out", () =>
+      withBackendGuard("attendance_clock_out", "/v1/time-entries/clock-out", async () => {
+        const result = await client.attendanceClockOut(entryId);
+        return {
+          content: [mutateContent(formatRecord("Clocked out", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- overtime_report --
@@ -254,13 +269,15 @@ export function registerHrTools(server: McpServer, client: IFrihetClient): void 
       },
       outputSchema: overtimeReportOutput,
     },
-    async ({ period, employeeId }) => withToolLogging("overtime_report", async () => {
-      const result = await client.getOvertimeReport({ period, employeeId });
-      return {
-        content: [getContent(formatRecord("Overtime report", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ period, employeeId }) => withToolLogging("overtime_report", () =>
+      withBackendGuard("overtime_report", "/v1/time-entries/overtime", async () => {
+        const result = await client.getOvertimeReport({ period, employeeId });
+        return {
+          content: [getContent(formatRecord("Overtime report", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- anomaly_list --
@@ -290,12 +307,14 @@ export function registerHrTools(server: McpServer, client: IFrihetClient): void 
       outputSchema: paginatedOutput(anomalyItemOutput),
     },
     async ({ type, severity, from, to, limit, offset }) =>
-      withToolLogging("anomaly_list", async () => {
-        const result = await client.listAnomalies({ type, severity, from, to, limit, offset });
-        return {
-          content: [listContent(formatPaginatedResponse("anomalies", result))],
-          structuredContent: result as unknown as Record<string, unknown>,
-        };
-      }),
+      withToolLogging("anomaly_list", () =>
+        withBackendGuard("anomaly_list", "/v1/anomalies", async () => {
+          const result = await client.listAnomalies({ type, severity, from, to, limit, offset });
+          return {
+            content: [listContent(formatPaginatedResponse("anomalies", result))],
+            structuredContent: result as unknown as Record<string, unknown>,
+          };
+        }),
+      ),
   );
 }

--- a/src/tools/igic.ts
+++ b/src/tools/igic.ts
@@ -23,6 +23,7 @@ import {
   getContent,
   READ_ONLY_ANNOTATIONS,
 } from "./shared.js";
+import { withBackendGuard } from "./backend-availability.js";
 
 export function registerIgicTools(server: McpServer, client: IFrihetClient): void {
   // -- frihet_modelo_415_summary -------------------------------------------
@@ -43,13 +44,15 @@ export function registerIgicTools(server: McpServer, client: IFrihetClient): voi
         year: z.string().optional().describe("Tax year (e.g. '2025', defaults to previous year) / Ejercicio fiscal (ej. '2025', por defecto ejercicio anterior)"),
       },
     },
-    async ({ year }) => withToolLogging("frihet_modelo_415_summary", async () => {
-      const result = await client.getIgicModeloSummary("415", { year });
-      return {
-        content: [getContent(formatRecord("Modelo 415 Summary (IGIC)", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ year }) => withToolLogging("frihet_modelo_415_summary", () =>
+      withBackendGuard("frihet_modelo_415_summary", "/v1/igic/415", async () => {
+        const result = await client.getIgicModeloSummary("415", { year });
+        return {
+          content: [getContent(formatRecord("Modelo 415 Summary (IGIC)", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- frihet_modelo_425_summary -------------------------------------------
@@ -69,13 +72,15 @@ export function registerIgicTools(server: McpServer, client: IFrihetClient): voi
         year: z.string().optional().describe("Tax year (e.g. '2025', defaults to previous year) / Ejercicio fiscal (ej. '2025', por defecto ejercicio anterior)"),
       },
     },
-    async ({ year }) => withToolLogging("frihet_modelo_425_summary", async () => {
-      const result = await client.getIgicModeloSummary("425", { year });
-      return {
-        content: [getContent(formatRecord("Modelo 425 Summary (IGIC)", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ year }) => withToolLogging("frihet_modelo_425_summary", () =>
+      withBackendGuard("frihet_modelo_425_summary", "/v1/igic/425", async () => {
+        const result = await client.getIgicModeloSummary("425", { year });
+        return {
+          content: [getContent(formatRecord("Modelo 425 Summary (IGIC)", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- frihet_modelo_418_summary -------------------------------------------
@@ -96,13 +101,15 @@ export function registerIgicTools(server: McpServer, client: IFrihetClient): voi
         period: z.string().optional().describe("Period in YYYY-MM format (defaults to last month) / Periodo YYYY-MM (por defecto mes anterior)"),
       },
     },
-    async ({ period }) => withToolLogging("frihet_modelo_418_summary", async () => {
-      const result = await client.getIgicModeloSummary("418", { period });
-      return {
-        content: [getContent(formatRecord("Modelo 418 Summary (IGIC Monthly)", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ period }) => withToolLogging("frihet_modelo_418_summary", () =>
+      withBackendGuard("frihet_modelo_418_summary", "/v1/igic/418", async () => {
+        const result = await client.getIgicModeloSummary("418", { period });
+        return {
+          content: [getContent(formatRecord("Modelo 418 Summary (IGIC Monthly)", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- frihet_aiem_calculate ------------------------------------------------
@@ -126,12 +133,14 @@ export function registerIgicTools(server: McpServer, client: IFrihetClient): voi
         description: z.string().optional().describe("Product description for audit reference / Descripcion del producto (referencia auditoria)"),
       },
     },
-    async ({ ncCode, amount, description }) => withToolLogging("frihet_aiem_calculate", async () => {
-      const result = await client.calculateAiem({ ncCode, amount, description });
-      return {
-        content: [getContent(formatRecord(`AIEM Calculation (NC: ${ncCode})`, result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ ncCode, amount, description }) => withToolLogging("frihet_aiem_calculate", () =>
+      withBackendGuard("frihet_aiem_calculate", "/v1/igic/aiem", async () => {
+        const result = await client.calculateAiem({ ncCode, amount, description });
+        return {
+          content: [getContent(formatRecord(`AIEM Calculation (NC: ${ncCode})`, result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 }

--- a/src/tools/impuesto_sociedades.ts
+++ b/src/tools/impuesto_sociedades.ts
@@ -22,6 +22,7 @@ import {
   getContent,
   READ_ONLY_ANNOTATIONS,
 } from "./shared.js";
+import { withBackendGuard } from "./backend-availability.js";
 
 export function registerImpuestoSociedadesTools(server: McpServer, client: IFrihetClient): void {
   // -- frihet_modelo_200_summary -------------------------------------------
@@ -43,13 +44,15 @@ export function registerImpuestoSociedadesTools(server: McpServer, client: IFrih
         year: z.string().optional().describe("Fiscal year (e.g. '2025', defaults to last closed year) / Ejercicio fiscal (ej. '2025', por defecto ultimo ejercicio cerrado)"),
       },
     },
-    async ({ year }) => withToolLogging("frihet_modelo_200_summary", async () => {
-      const result = await client.getISSummary("200", { year });
-      return {
-        content: [getContent(formatRecord("Modelo 200 Summary (IS Anual)", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ year }) => withToolLogging("frihet_modelo_200_summary", () =>
+      withBackendGuard("frihet_modelo_200_summary", "/v1/is/200", async () => {
+        const result = await client.getISSummary("200", { year });
+        return {
+          content: [getContent(formatRecord("Modelo 200 Summary (IS Anual)", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- frihet_modelo_202_summary -------------------------------------------
@@ -71,15 +74,17 @@ export function registerImpuestoSociedadesTools(server: McpServer, client: IFrih
         installment: z.enum(["1P", "2P", "3P"]).optional().describe("Specific installment (1P=April, 2P=October, 3P=December) or omit for all three / Plazo especifico (1P=abril, 2P=octubre, 3P=diciembre) u omitir para los tres"),
       },
     },
-    async ({ year, installment }) => withToolLogging("frihet_modelo_202_summary", async () => {
-      const result = await client.getISSummary("202", { year, installment });
-      const label = installment
-        ? `Modelo 202 Summary (${installment} ${year ?? ""})`
-        : `Modelo 202 Summary (all installments ${year ?? ""})`;
-      return {
-        content: [getContent(formatRecord(label.trim(), result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ year, installment }) => withToolLogging("frihet_modelo_202_summary", () =>
+      withBackendGuard("frihet_modelo_202_summary", "/v1/is/202", async () => {
+        const result = await client.getISSummary("202", { year, installment });
+        const label = installment
+          ? `Modelo 202 Summary (${installment} ${year ?? ""})`
+          : `Modelo 202 Summary (all installments ${year ?? ""})`;
+        return {
+          content: [getContent(formatRecord(label.trim(), result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 }

--- a/src/tools/onboard_vies.ts
+++ b/src/tools/onboard_vies.ts
@@ -28,6 +28,7 @@ import {
   READ_ONLY_ANNOTATIONS,
   CREATE_ANNOTATIONS,
 } from "./shared.js";
+import { withBackendGuard } from "./backend-availability.js";
 
 export function registerOnboardViesTools(server: McpServer, client: IFrihetClient): void {
   // -- frihet_portal_onboard_link_generate ----------------------------------
@@ -54,19 +55,21 @@ export function registerOnboardViesTools(server: McpServer, client: IFrihetClien
         workspaceId: z.string().optional().describe("Target gestor workspace ID / ID del workspace del gestor"),
       },
     },
-    async ({ email, name, expiresInHours, workspaceId }) => withToolLogging("frihet_portal_onboard_link_generate", async () => {
-      const result = await client.generatePortalOnboardLink({ email, name, expiresInHours, workspaceId });
-      return {
-        content: [
-          mutateContent(
-            formatRecord(`Self-onboard link generated for ${email}`, result) +
-            "\n\nSend this link to the client via email or chat. It is single-use and time-limited." +
-            "\nEnvia este enlace al cliente por email o chat. Es de uso único y tiene caducidad.",
-          ),
-        ],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ email, name, expiresInHours, workspaceId }) => withToolLogging("frihet_portal_onboard_link_generate", () =>
+      withBackendGuard("frihet_portal_onboard_link_generate", "/v1/portal/onboard/link", async () => {
+        const result = await client.generatePortalOnboardLink({ email, name, expiresInHours, workspaceId });
+        return {
+          content: [
+            mutateContent(
+              formatRecord(`Self-onboard link generated for ${email}`, result) +
+              "\n\nSend this link to the client via email or chat. It is single-use and time-limited." +
+              "\nEnvia este enlace al cliente por email o chat. Es de uso único y tiene caducidad.",
+            ),
+          ],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- frihet_tax_id_vies_lookup --------------------------------------------
@@ -88,12 +91,14 @@ export function registerOnboardViesTools(server: McpServer, client: IFrihetClien
         countryCode: z.string().length(2).describe("ISO 3166-1 alpha-2 country code (e.g. 'ES', 'DE', 'FR') / Codigo de pais ISO (ej. 'ES', 'DE', 'FR')"),
       },
     },
-    async ({ vatNumber, countryCode }) => withToolLogging("frihet_tax_id_vies_lookup", async () => {
-      const result = await client.lookupTaxIdViaVIES({ vatNumber, countryCode });
-      return {
-        content: [getContent(formatRecord(`VIES lookup: ${countryCode}${vatNumber}`, result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ vatNumber, countryCode }) => withToolLogging("frihet_tax_id_vies_lookup", () =>
+      withBackendGuard("frihet_tax_id_vies_lookup", "/v1/portal/onboard/vies", async () => {
+        const result = await client.lookupTaxIdViaVIES({ vatNumber, countryCode });
+        return {
+          content: [getContent(formatRecord(`VIES lookup: ${countryCode}${vatNumber}`, result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 }

--- a/src/tools/onboarding.ts
+++ b/src/tools/onboarding.ts
@@ -27,6 +27,7 @@ import {
   onboardingStatusOutput,
   onboardingPersonaResultOutput,
 } from "./shared.js";
+import { withBackendGuard } from "./backend-availability.js";
 
 export function registerOnboardingTools(server: McpServer, client: IFrihetClient): void {
   // -- onboarding_status --
@@ -44,13 +45,15 @@ export function registerOnboardingTools(server: McpServer, client: IFrihetClient
       inputSchema: {},
       outputSchema: onboardingStatusOutput,
     },
-    async () => withToolLogging("onboarding_status", async () => {
-      const result = await client.getOnboardingStatus();
-      return {
-        content: [getContent(formatRecord("Onboarding status", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async () => withToolLogging("onboarding_status", () =>
+      withBackendGuard("onboarding_status", "/v1/onboarding/status", async () => {
+        const result = await client.getOnboardingStatus();
+        return {
+          content: [getContent(formatRecord("Onboarding status", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- onboarding_persona_set --
@@ -77,12 +80,14 @@ export function registerOnboardingTools(server: McpServer, client: IFrihetClient
       },
       outputSchema: onboardingPersonaResultOutput,
     },
-    async ({ persona }) => withToolLogging("onboarding_persona_set", async () => {
-      const result = await client.setOnboardingPersona({ persona });
-      return {
-        content: [mutateContent(formatRecord("Persona set", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ persona }) => withToolLogging("onboarding_persona_set", () =>
+      withBackendGuard("onboarding_persona_set", "/v1/onboarding/persona", async () => {
+        const result = await client.setOnboardingPersona({ persona });
+        return {
+          content: [mutateContent(formatRecord("Persona set", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 }

--- a/src/tools/payroll.ts
+++ b/src/tools/payroll.ts
@@ -26,6 +26,7 @@ import {
   payrollExportOutput,
   payrollChecklistOutput,
 } from "./shared.js";
+import { withBackendGuard } from "./backend-availability.js";
 
 export function registerPayrollTools(server: McpServer, client: IFrihetClient): void {
   // -- payroll_export --
@@ -55,13 +56,15 @@ export function registerPayrollTools(server: McpServer, client: IFrihetClient): 
       },
       outputSchema: payrollExportOutput,
     },
-    async ({ format, month }) => withToolLogging("payroll_export", async () => {
-      const result = await client.exportPayroll({ format, month });
-      return {
-        content: [getContent(formatRecord("Payroll export", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ format, month }) => withToolLogging("payroll_export", () =>
+      withBackendGuard("payroll_export", "/v1/payroll/prep/export", async () => {
+        const result = await client.exportPayroll({ format, month });
+        return {
+          content: [getContent(formatRecord("Payroll export", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- payroll_checklist --
@@ -85,12 +88,14 @@ export function registerPayrollTools(server: McpServer, client: IFrihetClient): 
       },
       outputSchema: payrollChecklistOutput,
     },
-    async ({ month }) => withToolLogging("payroll_checklist", async () => {
-      const result = await client.getPayrollChecklist({ month });
-      return {
-        content: [getContent(formatRecord("Payroll checklist", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ month }) => withToolLogging("payroll_checklist", () =>
+      withBackendGuard("payroll_checklist", "/v1/payroll/prep/employees", async () => {
+        const result = await client.getPayrollChecklist({ month });
+        return {
+          content: [getContent(formatRecord("Payroll checklist", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 }

--- a/src/tools/permissions.ts
+++ b/src/tools/permissions.ts
@@ -24,6 +24,7 @@ import {
   permissionsMatrixOutput,
   permissionsMeOutput,
 } from "./shared.js";
+import { withBackendGuard } from "./backend-availability.js";
 
 export function registerPermissionsTools(server: McpServer, client: IFrihetClient): void {
   // -- permissions_matrix --
@@ -41,13 +42,15 @@ export function registerPermissionsTools(server: McpServer, client: IFrihetClien
       inputSchema: {},
       outputSchema: permissionsMatrixOutput,
     },
-    async () => withToolLogging("permissions_matrix", async () => {
-      const result = await client.getPermissionsMatrix();
-      return {
-        content: [getContent(formatRecord("Permissions matrix", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async () => withToolLogging("permissions_matrix", () =>
+      withBackendGuard("permissions_matrix", "/v1/permissions/matrix", async () => {
+        const result = await client.getPermissionsMatrix();
+        return {
+          content: [getContent(formatRecord("Permissions matrix", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- permissions_me --
@@ -64,12 +67,14 @@ export function registerPermissionsTools(server: McpServer, client: IFrihetClien
       inputSchema: {},
       outputSchema: permissionsMeOutput,
     },
-    async () => withToolLogging("permissions_me", async () => {
-      const result = await client.getMyPermissions();
-      return {
-        content: [getContent(formatRecord("My permissions", result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async () => withToolLogging("permissions_me", () =>
+      withBackendGuard("permissions_me", "/v1/permissions/me", async () => {
+        const result = await client.getMyPermissions();
+        return {
+          content: [getContent(formatRecord("My permissions", result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 }

--- a/src/tools/portal_domain.ts
+++ b/src/tools/portal_domain.ts
@@ -26,6 +26,7 @@ import {
   CREATE_ANNOTATIONS,
   DELETE_ANNOTATIONS,
 } from "./shared.js";
+import { withBackendGuard } from "./backend-availability.js";
 
 export function registerPortalDomainTools(server: McpServer, client: IFrihetClient): void {
   // -- frihet_portal_domain_add ---------------------------------------------
@@ -46,19 +47,21 @@ export function registerPortalDomainTools(server: McpServer, client: IFrihetClie
         workspaceId: z.string().optional().describe("Target workspace ID (defaults to caller's workspace) / ID del workspace destino"),
       },
     },
-    async ({ domain, workspaceId }) => withToolLogging("frihet_portal_domain_add", async () => {
-      const result = await client.addCustomPortalDomain({ domain, workspaceId });
-      return {
-        content: [
-          mutateContent(
-            formatRecord(`Custom portal domain added: ${domain}`, result) +
-            "\n\nNext step: Configure the returned CNAME record at your DNS registrar, then call frihet_portal_domain_verify." +
-            "\nSiguiente paso: Configura el registro CNAME en tu registrador DNS, luego llama a frihet_portal_domain_verify.",
-          ),
-        ],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ domain, workspaceId }) => withToolLogging("frihet_portal_domain_add", () =>
+      withBackendGuard("frihet_portal_domain_add", "/v1/portal/domain/add", async () => {
+        const result = await client.addCustomPortalDomain({ domain, workspaceId });
+        return {
+          content: [
+            mutateContent(
+              formatRecord(`Custom portal domain added: ${domain}`, result) +
+              "\n\nNext step: Configure the returned CNAME record at your DNS registrar, then call frihet_portal_domain_verify." +
+              "\nSiguiente paso: Configura el registro CNAME en tu registrador DNS, luego llama a frihet_portal_domain_verify.",
+            ),
+          ],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- frihet_portal_domain_verify ------------------------------------------
@@ -79,13 +82,15 @@ export function registerPortalDomainTools(server: McpServer, client: IFrihetClie
         domain: z.string().describe("Custom domain to verify / Dominio personalizado a verificar"),
       },
     },
-    async ({ domain }) => withToolLogging("frihet_portal_domain_verify", async () => {
-      const result = await client.verifyCustomPortalDomain({ domain });
-      return {
-        content: [getContent(formatRecord(`Domain verification status: ${domain}`, result))],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ domain }) => withToolLogging("frihet_portal_domain_verify", () =>
+      withBackendGuard("frihet_portal_domain_verify", "/v1/portal/domain/verify", async () => {
+        const result = await client.verifyCustomPortalDomain({ domain });
+        return {
+          content: [getContent(formatRecord(`Domain verification status: ${domain}`, result))],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 
   // -- frihet_portal_domain_remove ------------------------------------------
@@ -105,16 +110,18 @@ export function registerPortalDomainTools(server: McpServer, client: IFrihetClie
         domain: z.string().describe("Custom domain to remove / Dominio personalizado a eliminar"),
       },
     },
-    async ({ domain }) => withToolLogging("frihet_portal_domain_remove", async () => {
-      const result = await client.removeCustomPortalDomain({ domain });
-      return {
-        content: [
-          mutateContent(
-            formatRecord(`Custom portal domain removed: ${domain}`, result),
-          ),
-        ],
-        structuredContent: result as unknown as Record<string, unknown>,
-      };
-    }),
+    async ({ domain }) => withToolLogging("frihet_portal_domain_remove", () =>
+      withBackendGuard("frihet_portal_domain_remove", "/v1/portal/domain/remove", async () => {
+        const result = await client.removeCustomPortalDomain({ domain });
+        return {
+          content: [
+            mutateContent(
+              formatRecord(`Custom portal domain removed: ${domain}`, result),
+            ),
+          ],
+          structuredContent: result as unknown as Record<string, unknown>,
+        };
+      }),
+    ),
   );
 }

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -634,9 +634,79 @@ export const bankTransactionItemOutput = z.object({
 
 /* --- Fiscal item schemas --------------------------------------------------- */
 
+/**
+ * Modelo 303 (IVA trimestral) totals — the READ-ONLY self-assessment view the
+ * shipped CF returns under `modelo303`. All amounts in EUR.
+ */
+const modelo303TotalsSchema = z.object({
+  baseImponible: z.number().optional().describe("IVA devengado base (operaciones interiores sujetas)"),
+  cuotaRepercutida: z.number().optional().describe("Output VAT (cuota repercutida)"),
+  baseDeducible: z.number().optional().describe("Deductible base (input)"),
+  cuotaDeducible: z.number().optional().describe("Input VAT (cuota deducible)"),
+  resultado: z.number().optional().describe("cuotaRepercutida − cuotaDeducible (+ to pay, − to refund/compensate)"),
+  baseExenta: z.number().optional().describe("Base of exempt operations (zero cuota)"),
+  baseNoSujetaORC: z.number().optional().describe("Intra-community / export / reverse-charge base"),
+  outOfScope: z.record(z.string(), z.unknown()).optional().describe("IGIC/IPSI totals — outside the 303 self-assessment"),
+}).passthrough();
+
+/** Modelo 130 (IRPF pago fraccionado) totals returned under `modelo130`. */
+const modelo130TotalsSchema = z.object({
+  ingresos: z.number().optional(),
+  gastos: z.number().optional(),
+  rendimientoNeto: z.number().optional(),
+  pagoFraccionado: z.number().optional().describe("Pago fraccionado IRPF (20% del rendimiento neto)"),
+  retencionesSoportadas: z.number().optional().describe("IRPF withheld by clients on issued invoices"),
+}).passthrough();
+
+/** Modelo 390 (resumen anual IVA) totals returned under `modelo390`. */
+const modelo390TotalsSchema = z.object({
+  baseImponible: z.number().optional(),
+  cuotaRepercutida: z.number().optional(),
+  baseDeducible: z.number().optional(),
+  cuotaDeducible: z.number().optional(),
+  resultadoAnual: z.number().optional(),
+  baseExenta: z.number().optional(),
+  baseNoSujetaORC: z.number().optional(),
+  outOfScope: z.record(z.string(), z.unknown()).optional(),
+}).passthrough();
+
+/** Aggregate counts/totals the CF attaches under `summary`. */
+const fiscalSummaryCountsSchema = z.object({
+  totalRevenue: z.number().optional(),
+  totalExpenses: z.number().optional(),
+  invoiceCount: z.number().optional(),
+  expenseCount: z.number().optional(),
+  clientCount: z.number().optional(),
+}).passthrough();
+
+/**
+ * Output schema for the Modelo 303/130/390 READ-ONLY summary tools.
+ *
+ * Aligned with the SHIPPED Cloudflare Function response (publicApi.ts), which
+ * — after the client unwraps the `{ data, meta }` envelope — returns:
+ *   { model, period, months, modelo303|modelo130|modelo390, summary, readonly, note }
+ *
+ * `model` carries the modelo code ('303'|'130'|'390'). `modeloCode` is kept as
+ * an OPTIONAL alias so legacy callers/fixtures that surface `modeloCode`
+ * validate too (the CF itself emits `model`). The three `modelo*` totals
+ * objects are mutually exclusive per request — each is optional so any one
+ * model validates. `.passthrough()` lets the genuine totals surface even where
+ * a field isn't explicitly enumerated.
+ */
 export const fiscalModeloSummaryOutput = z.object({
-  modeloCode: z.string(),
-  period: z.string().optional(),
+  /** Modelo code as the CF emits it ('303' | '130' | '390'). */
+  model: z.string().optional(),
+  /** Legacy alias for `model`; optional so the CF's `model`-only shape passes. */
+  modeloCode: z.string().optional(),
+  period: z.string().optional().describe("YYYY-QN (303/130) or YYYY (390)"),
+  months: z.array(z.string()).optional().describe("Months covered by the period (YYYY-MM)"),
+  modelo303: modelo303TotalsSchema.optional(),
+  modelo130: modelo130TotalsSchema.optional(),
+  modelo390: modelo390TotalsSchema.optional(),
+  summary: fiscalSummaryCountsSchema.optional(),
+  readonly: z.literal(true).optional().describe("Marks the payload as an informational summary, never filed to AEAT"),
+  note: z.string().optional(),
+  // --- Legacy/back-compat fields (older summary shape) ---------------------
   totalsByRate: z.record(z.string(), z.number()).optional(),
   totalDeductible: z.number().optional(),
   totalDue: z.number().optional(),


### PR DESCRIPTION
## Sprint A — MCP side of the MCP↔CF contract integrity work

Pins the contract between the MCP server and the Cloud Functions public API so agent-facing output stays stable and truthful.

### Fixes
- **fiscal modelo output schema** (`646f3b2`): unwrap single-object envelope + align modelo summary output schema so MCP tool output matches the CF response shape.
- **not-yet-shipped backend guard** (`f5b7d60`): guard backends that aren't shipped so a `404` from the CF is never surfaced to the agent as real/empty business data.
- **contract test pinning** (`f9c113d`): pin fiscal `modeloCode` output-schema + envelope/Timestamp contract with tests, locking the seam against regressions.
- **release** (`d6d13e6`): bump to `1.14.2` + sync marketplace tool count to 157.

### Gates (GREEN)
- `npm run build` (tsc) — pass
- `npm test` — **347 passing / 0 failing** (98 suites)

### Counterpart
Pairs with `sprint/A-contract` on `berthelius/Frihet-ERP` (CF `publicApi.ts`: modeloCode emission, Firestore Timestamp→ISO serialization, offset/total pagination, draft-invoice exclusion from 303/130).

---
**Trust Area (Compliance — fiscal modelo output). No merge/deploy without Viktor order.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)