### PR TITLE
fix(mcp): honest stub accounting — no fabricated-success on backend-404 (compliance)

### DIFF
--- a/src/__tests__/einvoice-tools.test.ts
+++ b/src/__tests__/einvoice-tools.test.ts
@@ -168,7 +168,7 @@ describe("E-Invoice Tools — registerAllTools includes new tools (127→133)", 
   });
 });
 
-describe("send_einvoice — stub response shape", () => {
+describe("send_einvoice — honest unavailable response (absent endpoint)", () => {
   let sendTool: RegisteredTool | undefined;
 
   beforeEach(async () => {
@@ -184,7 +184,7 @@ describe("send_einvoice — stub response shape", () => {
     assert.equal(sendTool!.config.title, "Send E-Invoice");
   });
 
-  test("happy path — valid input returns queued status", async () => {
+  test("absent endpoint → isError + _unavailable, NEVER a fabricated queued status", async () => {
     assert.ok(sendTool, "send_einvoice not registered");
     const result = await sendTool!.handler({
       invoiceId: "inv_test_123",
@@ -194,20 +194,24 @@ describe("send_einvoice — stub response shape", () => {
 
     assert.ok(result.structuredContent, "structuredContent missing");
     const sc = result.structuredContent!;
-    assert.equal(sc["status"], "queued", "status should be 'queued'");
-    assert.ok(typeof sc["workflowRunId"] === "string", "workflowRunId should be string");
-    assert.ok(typeof sc["estimatedCompletionSec"] === "number", "estimatedCompletionSec should be number");
-    assert.ok(sc["_stub"] === true, "_stub flag should be true");
+    // HONEST: no fabricated workflow/status, agent sees a failure.
+    assert.equal((result as { isError?: boolean }).isError, true, "must be isError:true");
+    assert.equal(sc["_unavailable"], true, "_unavailable flag should be true");
+    assert.equal(sc["_stub"], undefined, "must NOT carry a fake-success _stub flag");
+    assert.equal(sc["workflowRunId"], undefined, "must NOT fabricate a workflowRunId");
+    assert.equal(sc["status"], undefined, "must NOT fabricate a queued status");
+    assert.ok(typeof sc["_plannedEndpoint"] === "string", "_plannedEndpoint should be set");
   });
 
-  test("happy path — peppol-bis-3 format accepted", async () => {
+  test("peppol-bis-3 also returns honest unavailable", async () => {
     assert.ok(sendTool, "send_einvoice not registered");
     const result = await sendTool!.handler({
       invoiceId: "inv_peppol_456",
       format: "peppol-bis-3",
       dispatchMode: "peppol",
     });
-    assert.equal(result.structuredContent!["status"], "queued");
+    assert.equal((result as { isError?: boolean }).isError, true);
+    assert.equal(result.structuredContent!["_unavailable"], true);
   });
 
   test("content block has type text", async () => {
@@ -220,11 +224,11 @@ describe("send_einvoice — stub response shape", () => {
     assert.ok(Array.isArray(result.content), "content should be array");
     assert.ok(result.content.length > 0, "content should have at least 1 block");
     assert.equal(result.content[0]!.type, "text");
-    assert.ok(typeof result.content[0]!.text === "string");
+    assert.ok(/unavailable/i.test(result.content[0]!.text), "text should say unavailable");
   });
 });
 
-describe("get_einvoice_status — stub response shape", () => {
+describe("get_einvoice_status — honest unavailable response (absent endpoint)", () => {
   let statusTool: RegisteredTool | undefined;
 
   beforeEach(async () => {
@@ -235,26 +239,21 @@ describe("get_einvoice_status — stub response shape", () => {
     statusTool = server.tools.get("get_einvoice_status");
   });
 
-  test("happy path — returns status shape", async () => {
+  test("absent endpoint → isError + _unavailable, NEVER a fabricated 'succeeded'", async () => {
     assert.ok(statusTool, "get_einvoice_status not registered");
     const result = await statusTool!.handler({ workflowRunId: "wfr_stub_abc123" });
 
     const sc = result.structuredContent!;
-    assert.ok(["queued", "running", "succeeded", "failed", "cancelled"].includes(sc["status"] as string),
-      `status '${sc["status"]}' not in allowed values`);
-    assert.ok(typeof sc["step"] === "string", "step should be string");
-    assert.ok(sc["_stub"] === true, "_stub flag should be true");
-  });
-
-  test("ackId present in stub response", async () => {
-    assert.ok(statusTool, "get_einvoice_status not registered");
-    const result = await statusTool!.handler({ workflowRunId: "wfr_stub_deadbeef" });
-    const sc = result.structuredContent!;
-    assert.ok(typeof sc["ackId"] === "string", "ackId should be present as string");
+    assert.equal((result as { isError?: boolean }).isError, true, "must be isError:true");
+    assert.equal(sc["_unavailable"], true, "_unavailable flag should be true");
+    assert.equal(sc["status"], undefined, "must NOT fabricate a 'succeeded' status");
+    assert.equal(sc["ackId"], undefined, "must NOT fabricate an ackId");
+    assert.equal(sc["xmlUrl"], undefined, "must NOT fabricate an XML URL");
+    assert.equal(sc["_stub"], undefined, "must NOT carry a fake-success _stub flag");
   });
 });
 
-describe("validate_einvoice_xml — stub response shape", () => {
+describe("validate_einvoice_xml — honest unavailable response (absent endpoint)", () => {
   let validateTool: RegisteredTool | undefined;
 
   beforeEach(async () => {
@@ -265,7 +264,7 @@ describe("validate_einvoice_xml — stub response shape", () => {
     validateTool = server.tools.get("validate_einvoice_xml");
   });
 
-  test("happy path — returns valid=true with empty errors", async () => {
+  test("absent endpoint → isError + _unavailable, NEVER a fabricated valid=true", async () => {
     assert.ok(validateTool, "validate_einvoice_xml not registered");
     const result = await validateTool!.handler({
       xml: "<Invoice><ID>TEST-001</ID></Invoice>",
@@ -273,42 +272,17 @@ describe("validate_einvoice_xml — stub response shape", () => {
     });
 
     const sc = result.structuredContent!;
-    assert.equal(sc["valid"], true, "valid should be true (stub)");
-    assert.ok(Array.isArray(sc["errors"]), "errors should be array");
-    assert.equal((sc["errors"] as unknown[]).length, 0, "errors should be empty (stub)");
-    assert.equal(sc["validator"], "kosit", "xrechnung-cii should use kosit validator");
-    assert.ok(typeof sc["durationMs"] === "number", "durationMs should be number");
-  });
-
-  test("facturx-en16931 uses mustang validator", async () => {
-    assert.ok(validateTool, "validate_einvoice_xml not registered");
-    const result = await validateTool!.handler({
-      xml: "<rsm:CrossIndustryInvoice/>",
-      format: "facturx-en16931",
-    });
-    assert.equal(result.structuredContent!["validator"], "mustang");
-  });
-
-  test("fatturapa uses xsd validator", async () => {
-    assert.ok(validateTool, "validate_einvoice_xml not registered");
-    const result = await validateTool!.handler({
-      xml: "<FatturaElettronica/>",
-      format: "fatturapa",
-    });
-    assert.equal(result.structuredContent!["validator"], "xsd");
-  });
-
-  test("peppol-bis-3 uses schematron validator", async () => {
-    assert.ok(validateTool, "validate_einvoice_xml not registered");
-    const result = await validateTool!.handler({
-      xml: "<Invoice/>",
-      format: "peppol-bis-3",
-    });
-    assert.equal(result.structuredContent!["validator"], "schematron");
+    assert.equal((result as { isError?: boolean }).isError, true, "must be isError:true");
+    assert.equal(sc["_unavailable"], true, "_unavailable flag should be true");
+    // A fabricated valid=true is the most dangerous stub — must never appear.
+    assert.equal(sc["valid"], undefined, "must NOT fabricate valid=true");
+    assert.equal(sc["validator"], undefined, "must NOT fabricate a validator verdict");
+    assert.equal(sc["_stub"], undefined, "must NOT carry a fake-success _stub flag");
+    assert.ok(typeof sc["_plannedEndpoint"] === "string", "_plannedEndpoint should be set");
   });
 });
 
-describe("export_datev — stub response shape", () => {
+describe("export_datev — honest unavailable response (absent endpoint)", () => {
   let datevTool: RegisteredTool | undefined;
 
   beforeEach(async () => {
@@ -319,7 +293,7 @@ describe("export_datev — stub response shape", () => {
     datevTool = server.tools.get("export_datev");
   });
 
-  test("happy path — extf-buchungsstapel returns correct shape", async () => {
+  test("absent endpoint → isError + _unavailable, NEVER a fabricated fileUrl", async () => {
     assert.ok(datevTool, "export_datev not registered");
     const result = await datevTool!.handler({
       periodStart: "2026-01-01",
@@ -328,48 +302,12 @@ describe("export_datev — stub response shape", () => {
     });
 
     const sc = result.structuredContent!;
-    assert.ok(typeof sc["fileUrl"] === "string", "fileUrl should be string");
-    assert.ok(typeof sc["filename"] === "string", "filename should be string");
-    assert.ok(typeof sc["rowCount"] === "number", "rowCount should be number");
-    assert.ok(typeof sc["fiscalPeriod"] === "string", "fiscalPeriod should be string");
-    assert.equal(sc["encoding"], "cp1252", "encoding must always be cp1252");
-    assert.ok(sc["_stub"] === true, "_stub flag should be true");
-  });
-
-  test("filename contains EXTF_Buchungsstapel for buchungsstapel format", async () => {
-    assert.ok(datevTool, "export_datev not registered");
-    const result = await datevTool!.handler({
-      periodStart: "2026-01-01",
-      periodEnd: "2026-01-31",
-      format: "extf-buchungsstapel",
-    });
-    assert.ok(
-      (result.structuredContent!["filename"] as string).includes("EXTF_Buchungsstapel"),
-      "filename should include EXTF_Buchungsstapel",
-    );
-  });
-
-  test("filename contains EXTF_Debitoren for extf-debitoren", async () => {
-    assert.ok(datevTool, "export_datev not registered");
-    const result = await datevTool!.handler({
-      periodStart: "2026-03-01",
-      periodEnd: "2026-03-31",
-      format: "extf-debitoren",
-    });
-    assert.ok(
-      (result.structuredContent!["filename"] as string).includes("EXTF_Debitoren"),
-      "filename should include EXTF_Debitoren",
-    );
-  });
-
-  test("fiscalPeriod derives from periodStart YYYY-MM", async () => {
-    assert.ok(datevTool, "export_datev not registered");
-    const result = await datevTool!.handler({
-      periodStart: "2026-07-01",
-      periodEnd: "2026-07-31",
-      format: "extf-kreditoren",
-    });
-    assert.equal(result.structuredContent!["fiscalPeriod"], "2026-07");
+    assert.equal((result as { isError?: boolean }).isError, true, "must be isError:true");
+    assert.equal(sc["_unavailable"], true, "_unavailable flag should be true");
+    assert.equal(sc["fileUrl"], undefined, "must NOT fabricate a download fileUrl");
+    assert.equal(sc["filename"], undefined, "must NOT fabricate a filename");
+    assert.equal(sc["_stub"], undefined, "must NOT carry a fake-success _stub flag");
+    assert.ok(typeof sc["_plannedEndpoint"] === "string", "_plannedEndpoint should be set");
   });
 });
 
@@ -441,7 +379,7 @@ function getValidArgs(toolName: string): Record<string, unknown> {
 
 // ── 404-fallback tests ────────────────────────────────────────────────────────
 
-describe("404-fallback path — CF endpoint not yet deployed", () => {
+describe("absent-endpoint path — honest unavailable, NO fabricated success", () => {
   async function makeServer(client: import("../client-interface.js").IFrihetClient): Promise<StubMcpServer> {
     const server = new StubMcpServer();
     const { registerEInvoiceTools } = await import("../tools/einvoice.js");
@@ -449,50 +387,62 @@ describe("404-fallback path — CF endpoint not yet deployed", () => {
     return server;
   }
 
-  test("send_einvoice: 404 → stub with _stub=true, _plannedEndpoint set", async () => {
+  test("send_einvoice: 404 → isError + _unavailable + _plannedEndpoint, no fabricated data", async () => {
     const server = await makeServer(make404Client());
     const tool = server.tools.get("send_einvoice")!;
     const result = await tool.handler({ invoiceId: "inv_test", format: "xrechnung-cii", dispatchMode: "email" });
     const sc = result.structuredContent!;
-    assert.equal(sc["_stub"], true, "_stub should be true on 404-fallback");
-    assert.equal(sc["_note"], "CF endpoint pending deploy");
+    assert.equal((result as { isError?: boolean }).isError, true, "must be isError:true");
+    assert.equal(sc["_unavailable"], true, "_unavailable should be true");
+    assert.equal(sc["_stub"], undefined, "must NOT be a fake-success stub");
     assert.ok(typeof sc["_plannedEndpoint"] === "string", "_plannedEndpoint should be set");
-    assert.equal(sc["status"], "queued", "fallback status should be queued");
-    assert.ok(typeof sc["workflowRunId"] === "string", "workflowRunId should be string");
+    assert.equal(sc["status"], undefined, "no fabricated queued status");
+    assert.equal(sc["workflowRunId"], undefined, "no fabricated workflowRunId");
   });
 
-  test("get_einvoice_status: 404 → stub with _stub=true, _plannedEndpoint set", async () => {
+  test("get_einvoice_status: 404 → isError + _unavailable + _plannedEndpoint", async () => {
     const server = await makeServer(make404Client());
     const tool = server.tools.get("get_einvoice_status")!;
     const result = await tool.handler({ workflowRunId: "wfr_pending_123" });
     const sc = result.structuredContent!;
-    assert.equal(sc["_stub"], true, "_stub should be true on 404-fallback");
-    assert.equal(sc["_note"], "CF endpoint pending deploy");
+    assert.equal((result as { isError?: boolean }).isError, true, "must be isError:true");
+    assert.equal(sc["_unavailable"], true, "_unavailable should be true");
     assert.ok(typeof sc["_plannedEndpoint"] === "string", "_plannedEndpoint should be set");
-    assert.ok(sc["_plannedEndpoint"] as string, "/v1/einvoice/status/wfr_pending_123");
+    assert.equal(sc["status"], undefined, "no fabricated status");
   });
 
-  test("validate_einvoice_xml: 404 → stub with _stub=true, validator derived from format", async () => {
+  test("validate_einvoice_xml: 404 → isError + _unavailable, NEVER a fabricated valid verdict", async () => {
     const server = await makeServer(make404Client());
     const tool = server.tools.get("validate_einvoice_xml")!;
     const result = await tool.handler({ xml: "<Invoice/>", format: "xrechnung-cii" });
     const sc = result.structuredContent!;
-    assert.equal(sc["_stub"], true, "_stub should be true on 404-fallback");
-    assert.equal(sc["_note"], "CF endpoint pending deploy");
-    assert.equal(sc["validator"], "kosit", "validator should derive from format even in fallback");
-    assert.equal(sc["valid"], true);
+    assert.equal((result as { isError?: boolean }).isError, true, "must be isError:true");
+    assert.equal(sc["_unavailable"], true, "_unavailable should be true");
+    assert.equal(sc["valid"], undefined, "must NOT fabricate a valid verdict");
+    assert.equal(sc["validator"], undefined, "must NOT fabricate a validator");
   });
 
-  test("export_datev: 404 → stub with _stub=true, filename derived from params", async () => {
+  test("export_datev: 404 → isError + _unavailable, no fabricated file", async () => {
     const server = await makeServer(make404Client());
     const tool = server.tools.get("export_datev")!;
     const result = await tool.handler({ periodStart: "2026-03-01", periodEnd: "2026-03-31", format: "extf-buchungsstapel" });
     const sc = result.structuredContent!;
-    assert.equal(sc["_stub"], true, "_stub should be true on 404-fallback");
-    assert.equal(sc["_note"], "CF endpoint pending deploy");
-    assert.ok((sc["filename"] as string).includes("EXTF_Buchungsstapel"), "filename should include format prefix");
-    assert.equal(sc["fiscalPeriod"], "2026-03", "fiscalPeriod should derive from periodStart");
-    assert.equal(sc["encoding"], "cp1252");
+    assert.equal((result as { isError?: boolean }).isError, true, "must be isError:true");
+    assert.equal(sc["_unavailable"], true, "_unavailable should be true");
+    assert.equal(sc["fileUrl"], undefined, "must NOT fabricate a fileUrl");
+    assert.equal(sc["filename"], undefined, "must NOT fabricate a filename");
+  });
+
+  test("ksef_submit: forward-compat stub → isError + _unavailable + _notImplemented preserved", async () => {
+    const server = await makeServer(make404Client());
+    const tool = server.tools.get("ksef_submit")!;
+    const result = await tool.handler({ invoiceId: "inv_test", mode: "production" });
+    const sc = result.structuredContent!;
+    assert.equal((result as { isError?: boolean }).isError, true, "must be isError:true");
+    assert.equal(sc["_unavailable"], true, "_unavailable should be true");
+    assert.equal(sc["_notImplemented"], true, "_notImplemented marker preserved for forward-compat");
+    assert.ok(typeof sc["_plannedEndpoint"] === "string", "_plannedEndpoint should be set");
+    assert.equal(sc["mode"], "production", "echoes the requested mode");
   });
 });
 

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -129,6 +129,57 @@ function newId(): string {
   return crypto.randomUUID();
 }
 
+// ── Fabricated-success / stub detection ──────────────────────────────────────
+
+interface StubMarker {
+  plannedEndpoint?: string;
+  note?: string;
+}
+
+/**
+ * Inspect a resolved tool output for stub / not-implemented / unavailable
+ * markers and return them if present, else null.
+ *
+ * A tool that catches its own 404 (or is a forward-compat stub) RETURNS a
+ * fabricated body instead of throwing — so the try/catch in traceMCPTool never
+ * runs and the call looks successful. These markers are the structural signal
+ * that the "success" is fabricated:
+ *   - `_stub: true`            → 404 → fallback stub body
+ *   - `_notImplemented: true`  → forward-compat stub (endpoint not yet shipped)
+ *   - `_unavailable: true`     → honest "backend endpoint not yet available"
+ *   - `_plannedEndpoint`       → present on any of the above
+ *
+ * Checks both the top-level MCP tool result and its `structuredContent`, since
+ * tools place the markers inside `structuredContent`.
+ */
+export function inspectStubMarker(output: unknown): StubMarker | null {
+  if (!output || typeof output !== "object") return null;
+
+  const candidates: Record<string, unknown>[] = [];
+  const top = output as Record<string, unknown>;
+  candidates.push(top);
+  const sc = top["structuredContent"];
+  if (sc && typeof sc === "object") candidates.push(sc as Record<string, unknown>);
+
+  for (const obj of candidates) {
+    if (obj["_stub"] === true || obj["_notImplemented"] === true || obj["_unavailable"] === true) {
+      return {
+        plannedEndpoint: typeof obj["_plannedEndpoint"] === "string" ? (obj["_plannedEndpoint"] as string) : undefined,
+        note: typeof obj["_note"] === "string" ? (obj["_note"] as string) : undefined,
+      };
+    }
+    // A bare _plannedEndpoint (without an explicit flag) is also a stub signal.
+    if (typeof obj["_plannedEndpoint"] === "string") {
+      return {
+        plannedEndpoint: obj["_plannedEndpoint"] as string,
+        note: typeof obj["_note"] === "string" ? (obj["_note"] as string) : undefined,
+      };
+    }
+  }
+
+  return null;
+}
+
 // ── HTTP send ────────────────────────────────────────────────────────────────
 
 async function sendBatch(config: LangfuseConfig, batch: IngestionBatch): Promise<void> {
@@ -224,6 +275,25 @@ export async function traceMCPTool<T>(
   } finally {
     const endTime = new Date();
 
+    // ── Fabricated-success detection ──────────────────────────────────────────
+    // A tool that catches its own 404 and RETURNS a stub / unavailable body never
+    // throws, so `isError` stays false and the trace would otherwise be logged as
+    // a SUCCESSFUL call whose output is a fabricated payload. Inspect the resolved
+    // output for the markers the e-invoice tools (and any future stub branch) set
+    // — `_stub`, `_notImplemented`, `_unavailable`, `_plannedEndpoint` — and
+    // downgrade the trace so observability is NOT structurally blind to fabricated
+    // success. This is the central fix: it covers every stub branch regardless of
+    // which tool produced it, because the stub path never reaches the catch above.
+    const stub = isError ? null : inspectStubMarker(output);
+    const stubbed = stub !== null;
+    // success: false whenever the call threw OR returned a fabricated stub body.
+    const success = !isError && !stubbed;
+    const stubNote =
+      stub?.note ??
+      (stub?.plannedEndpoint
+        ? `Backend endpoint not yet available: ${stub.plannedEndpoint}`
+        : undefined);
+
     // Fire-and-forget — build and send async, never awaited
     void (async () => {
       try {
@@ -241,9 +311,17 @@ export async function traceMCPTool<T>(
             tool: toolName,
             clientName: _sessionContext.clientName,
             mcpVersion: _sessionContext.mcpVersion,
-            success: !isError,
+            // FALSE on a thrown error AND on a fabricated-stub fallback.
+            success,
+            ...(stubbed
+              ? {
+                  stub: true,
+                  ...(stub?.plannedEndpoint ? { plannedEndpoint: stub.plannedEndpoint } : {}),
+                  ...(stubNote ? { note: stubNote } : {}),
+                }
+              : {}),
           },
-          tags: [`mcp.tool.${toolName}`],
+          tags: [`mcp.tool.${toolName}`, ...(stubbed ? ["mcp.stub"] : [])],
           ...(userIdHashed ? { userId: userIdHashed } : {}),
         };
 
@@ -259,9 +337,17 @@ export async function traceMCPTool<T>(
             durationMs: endTime.getTime() - startTime.getTime(),
             clientName: _sessionContext.clientName,
             mcpVersion: _sessionContext.mcpVersion,
+            ...(stubbed ? { stub: true } : {}),
           },
-          level: isError ? "ERROR" : "DEFAULT",
-          ...(isError && errorMessage ? { statusMessage: errorMessage } : {}),
+          // ERROR on a thrown error; WARNING on a fabricated-stub fallback (the
+          // call "succeeded" mechanically but returned no real backend data);
+          // DEFAULT only on a genuine success.
+          level: isError ? "ERROR" : stubbed ? "WARNING" : "DEFAULT",
+          ...(isError && errorMessage
+            ? { statusMessage: errorMessage }
+            : stubbed && stubNote
+              ? { statusMessage: stubNote }
+              : {}),
         };
 
         const batch: IngestionBatch = {

--- a/src/tools/einvoice.ts
+++ b/src/tools/einvoice.ts
@@ -40,6 +40,55 @@ import {
 } from "./shared.js";
 
 /* ------------------------------------------------------------------ */
+/*  Honest "backend endpoint not yet available" result                  */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Build an HONEST unavailable result for a tool whose backend endpoint is not
+ * yet deployed.
+ *
+ * NORTH #2: a tool that returns a fake-success stub on a backend 404 is a HOLE —
+ * an AI agent receives fabricated data (a queued workflow, a valid XML, a DATEV
+ * file URL) and reports success. SOUL §16: removing that drama is the whole
+ * point. So instead of fabricating a plausible-looking payload we return an
+ * explicit error result:
+ *   - `isError: true`            → the MCP client/agent treats it as a failure
+ *   - `_unavailable: true`       → machine-readable marker (also drives the
+ *                                  observability downgrade in observability.ts)
+ *   - `_plannedEndpoint`         → which REST endpoint will back this when live
+ *
+ * The agent gets the truth ("not available yet"), never fabricated business data.
+ */
+function unavailableResult(opts: {
+  tool: string;
+  plannedEndpoint: string;
+  what: string;
+  workaround?: string;
+}): {
+  content: Array<{ type: "text"; text: string }>;
+  structuredContent: Record<string, unknown>;
+  isError: true;
+} {
+  const note =
+    `${opts.what} is not yet available: the backend endpoint ` +
+    `${opts.plannedEndpoint} is not deployed. No data was produced — this is an ` +
+    `honest "unavailable" response, NOT a stub success. ` +
+    (opts.workaround ? opts.workaround + " " : "") +
+    `/ Esta operación aún no está disponible: el endpoint ${opts.plannedEndpoint} ` +
+    `no está desplegado. No se ha generado ningún dato.`;
+  return {
+    content: [{ type: "text" as const, text: `Unavailable — ${opts.what}.\n${note}` }],
+    structuredContent: {
+      _unavailable: true,
+      _note: note,
+      _plannedEndpoint: opts.plannedEndpoint,
+      tool: opts.tool,
+    },
+    isError: true,
+  };
+}
+
+/* ------------------------------------------------------------------ */
 /*  Shared format union                                                 */
 /* ------------------------------------------------------------------ */
 
@@ -75,6 +124,31 @@ export const eInvoiceFormatSchema = z.enum([
 ]);
 
 export type EInvoiceFormat = z.infer<typeof eInvoiceFormatSchema>;
+
+/**
+ * Map the MCP lowercase format value to the API-facing format name accepted by
+ * POST /v1/invoices/:id/einvoice/export (Frihet-ERP publicApi.ts
+ * EINVOICE_EXPORT_FORMATS). The CF rejects any other value with a 400 validation
+ * error, so this mapping is REQUIRED — passing the raw MCP value would fail.
+ *
+ * The CF accepts 8 formats: Facturae, XRechnung-CII, XRechnung-UBL, Factur-X,
+ * FatturaPA, PEPPOL-BIS-3, UBL, CII. The four Factur-X sub-profiles
+ * (en16931/extended/basic/minimum) all map to the CF's single "Factur-X" entry;
+ * the CF resolves the concrete profile internally.
+ */
+const EINVOICE_EXPORT_FORMAT_MAP: Record<EInvoiceFormat, string> = {
+  "facturae": "Facturae",
+  "xrechnung-cii": "XRechnung-CII",
+  "xrechnung-ubl": "XRechnung-UBL",
+  "facturx-en16931": "Factur-X",
+  "facturx-extended": "Factur-X",
+  "facturx-basic": "Factur-X",
+  "facturx-minimum": "Factur-X",
+  "fatturapa": "FatturaPA",
+  "peppol-bis-3": "PEPPOL-BIS-3",
+  "ubl": "UBL",
+  "cii": "CII",
+};
 
 /* ------------------------------------------------------------------ */
 /*  Output schemas                                                      */
@@ -115,43 +189,49 @@ export const exportDatevOutput = z.object({
   encoding: z.literal("cp1252").describe("File encoding — always CP1252 per DATEV EXTF spec"),
 }).passthrough();
 
-/* Day 4 Wave output schemas */
+/* Day 4 Wave output schemas — fields match the LIVE CF response
+ * (Frihet-ERP functions/src/publicApi.ts) exactly. No fabricated fields. */
 
 export const einvoiceExportOutput = z.object({
-  xmlUrl: z.string().describe("Signed URL to download the e-invoice XML (valid 24h)"),
-  filename: z.string().describe("Suggested filename (e.g. INV-2026-001-facturae.xml)"),
-  format: z.string().describe("E-invoice format used"),
-  signed: z.boolean().describe("Whether XAdES signature was applied (Facturae only)"),
+  xml: z.string().describe("Raw e-invoice XML content (the document itself, returned inline by the CF)"),
+  contentType: z.string().describe("MIME type of the XML payload (application/xml)"),
+  filename: z.string().describe("Suggested filename (e.g. INV-2026-001_Facturae.xml)"),
+  signed: z.boolean().describe("Whether XAdES signature was applied (Facturae + signed=true only)"),
+  format: z.string().describe("E-invoice format used (echoes the requested format)"),
 }).passthrough();
 
 export const faceSubmitOutput = z.object({
-  registroFACe: z.string().describe("FACe registration number (número de registro) returned by the portal"),
-  status: z.enum(["submitted", "error"]).describe("Submission outcome"),
-  submittedAt: z.string().describe("ISO 8601 timestamp of the submission"),
-  mode: z.string().describe("Mode used: mock | sandbox | production"),
+  status: z.literal("submitted").describe("Submission accepted by FACe (the CF returns an error otherwise)"),
+  numeroRegistro: z.string().describe("FACe registration number (número de registro) returned by the portal"),
+  codigo: z.string().describe("FACe result code returned by the portal (resultado.codigo)"),
+  descripcion: z.string().describe("Human-readable FACe result description (resultado.descripcion)"),
+  idempotent: z.boolean().optional().describe("True if this echoes a prior already-registered submission (no resubmission occurred)"),
 }).passthrough();
 
 export const faceStatusOutput = z.object({
-  registroFACe: z.string().describe("FACe registration number"),
-  statusCode: z.string().describe("FACe status code (e.g. '1200'=Registrada, '1400'=Contabilizada, '3100'=Rechazada)"),
-  statusDescription: z.string().describe("Human-readable FACe status description"),
-  rejectionReason: z.string().optional().describe("Rejection reason if statusCode=3100"),
+  numeroRegistro: z.string().describe("FACe registration number for this submission"),
+  estadoTramitacion: z.string().nullable().describe("FACe processing-state code (estado de tramitación)"),
+  codigo: z.string().nullable().describe("FACe status code (e.g. '1200'=Registrada, '1400'=Contabilizada, '3100'=Rechazada)"),
+  descripcion: z.string().nullable().describe("Human-readable FACe status description"),
+  motivo: z.string().nullable().describe("Reason/motive associated with the current status (e.g. rejection motive)"),
 }).passthrough();
 
 export const ticketbaiSubmitOutput = z.object({
-  tbaiId: z.string().describe("TicketBAI identifier (TBAI-XXXXX) returned by hacienda foral"),
-  territory: z.enum(["bizkaia", "gipuzkoa", "araba"]).describe("Basque territory auto-detected from workspace address"),
-  status: z.enum(["submitted", "accepted", "rejected", "error"]).describe("Submission status"),
-  sandbox: z.boolean().describe("Whether this was a sandbox (test) submission"),
-  qrUrl: z.string().optional().describe("QR code URL to print on the invoice (TBAI compliance)"),
+  accepted: z.boolean().describe("Whether the hacienda foral accepted the submission"),
+  csv: z.string().describe("CSV (Código Seguro de Verificación) returned by the hacienda foral"),
+  tbaiIdentifier: z.string().describe("TicketBAI identifier (TBAI-XXXXX) returned by the hacienda foral"),
+  qrUrl: z.string().describe("QR code URL to print on the invoice (TBAI compliance)"),
+  idempotent: z.boolean().optional().describe("True if this echoes a prior already-accepted submission (no resubmission occurred)"),
 }).passthrough();
 
 export const ticketbaiStatusOutput = z.object({
-  tbaiId: z.string().describe("TicketBAI identifier"),
-  territory: z.enum(["bizkaia", "gipuzkoa", "araba"]).describe("Basque territory"),
-  status: z.enum(["submitted", "accepted", "rejected", "error"]).describe("Current hacienda acknowledgement status"),
-  rejectionReason: z.string().optional().describe("Rejection reason from hacienda (if rejected)"),
-  error: z.string().optional().describe("Internal error message (if error)"),
+  accepted: z.boolean().describe("Whether the submission has been accepted by the hacienda foral"),
+  csv: z.string().describe("CSV (Código Seguro de Verificación) for the submission"),
+  tbaiIdentifier: z.string().describe("TicketBAI identifier"),
+  estado: z.string().describe("Current submission status stored server-side (e.g. 'accepted', 'rejected')"),
+  qrUrl: z.string().nullable().describe("QR code URL to print on the invoice (null if not yet available)"),
+  submittedAt: z.string().nullable().describe("ISO 8601 timestamp the submission was recorded (null if unknown)"),
+  errors: z.array(z.string()).nullable().describe("Hacienda error messages if rejected (null if none)"),
 }).passthrough();
 
 export const kSeFSubmitOutput = z.object({
@@ -237,29 +317,16 @@ export function registerEInvoiceTools(server: McpServer, _client: IFrihetClient)
           };
         } catch (err: unknown) {
           if (isNotFoundError(err)) {
-            const stubResult = {
-              workflowRunId: `wfr_stub_${Date.now()}`,
-              status: "queued" as const,
-              estimatedCompletionSec: 15,
-              _stub: true,
-              _note: "CF endpoint pending deploy",
-              _plannedEndpoint: plannedEndpoint,
-            };
-            return {
-              content: [
-                mutateContent(
-                  `E-invoice queued (stub — CF pending deploy):\n` +
-                  `  Invoice: ${invoiceId}\n` +
-                  `  Format: ${format}\n` +
-                  `  Dispatch: ${dispatchMode}\n` +
-                  `  WorkflowRunId: ${stubResult.workflowRunId}\n` +
-                  `  Status: queued\n` +
-                  `  Estimated: ~${stubResult.estimatedCompletionSec}s\n\n` +
-                  `Use get_einvoice_status with the workflowRunId to poll for completion.`,
-                ),
-              ],
-              structuredContent: stubResult as unknown as Record<string, unknown>,
-            };
+            // HONEST unavailable — the /v1/einvoice/send transport endpoint is
+            // genuinely absent (not deployed). Do NOT fabricate a queued workflow.
+            return unavailableResult({
+              tool: "send_einvoice",
+              plannedEndpoint,
+              what: "E-invoice dispatch",
+              workaround:
+                "Use einvoice_export to produce the XML, then face_submit (Spain B2G) " +
+                "or ticketbai_submit (Basque Country) — those endpoints are live.",
+            });
           }
           throw err;
         }
@@ -306,29 +373,13 @@ export function registerEInvoiceTools(server: McpServer, _client: IFrihetClient)
           };
         } catch (err: unknown) {
           if (isNotFoundError(err)) {
-            const stubResult = {
-              status: "succeeded" as const,
-              step: "dispatch_complete",
-              ackId: `ack_stub_${workflowRunId.slice(-8)}`,
-              pdfA3Url: undefined,
-              xmlUrl: `https://storage.frihet.io/stub/${workflowRunId}.xml`,
-              _stub: true,
-              _note: "CF endpoint pending deploy",
-              _plannedEndpoint: plannedEndpoint,
-            };
-            return {
-              content: [
-                getContent(
-                  `E-invoice status (stub — CF pending deploy):\n` +
-                  `  WorkflowRunId: ${workflowRunId}\n` +
-                  `  Status: ${stubResult.status}\n` +
-                  `  Step: ${stubResult.step}\n` +
-                  `  AckId: ${stubResult.ackId}\n` +
-                  `  XML URL: ${stubResult.xmlUrl}`,
-                ),
-              ],
-              structuredContent: stubResult as unknown as Record<string, unknown>,
-            };
+            // HONEST unavailable — the /v1/einvoice/status endpoint is genuinely
+            // absent. Do NOT fabricate a "succeeded" status + fake XML URL.
+            return unavailableResult({
+              tool: "get_einvoice_status",
+              plannedEndpoint,
+              what: "E-invoice dispatch status polling",
+            });
           }
           throw err;
         }
@@ -364,19 +415,6 @@ export function registerEInvoiceTools(server: McpServer, _client: IFrihetClient)
     async ({ xml, format }) =>
       withToolLogging("validate_einvoice_xml", async () => {
         const plannedEndpoint = "/v1/einvoice/validate";
-        const validatorMap: Record<EInvoiceFormat, "kosit" | "mustang" | "xsd" | "schematron"> = {
-          "xrechnung-cii": "kosit",
-          "xrechnung-ubl": "kosit",
-          "facturx-en16931": "mustang",
-          "facturx-extended": "mustang",
-          "facturx-basic": "mustang",
-          "facturx-minimum": "mustang",
-          "fatturapa": "xsd",
-          "ubl": "schematron",
-          "cii": "schematron",
-          "peppol-bis-3": "schematron",
-          "facturae": "xsd",
-        };
         try {
           const result = await (_client as IFrihetClientWithEInvoice).validateEInvoiceXml({ xml, format });
           return {
@@ -394,28 +432,15 @@ export function registerEInvoiceTools(server: McpServer, _client: IFrihetClient)
           };
         } catch (err: unknown) {
           if (isNotFoundError(err)) {
-            const stubResult = {
-              valid: true,
-              errors: [] as Array<{ severity: string; location: string; message: string; rule: string }>,
-              validator: validatorMap[format],
-              durationMs: 42,
-              _stub: true,
-              _note: "CF endpoint pending deploy",
-              _plannedEndpoint: plannedEndpoint,
-            };
-            return {
-              content: [
-                getContent(
-                  `E-invoice validation result (stub — CF pending deploy):\n` +
-                  `  Format: ${format}\n` +
-                  `  Valid: ${stubResult.valid}\n` +
-                  `  Errors: ${stubResult.errors.length}\n` +
-                  `  Validator: ${stubResult.validator}\n` +
-                  `  Duration: ${stubResult.durationMs}ms`,
-                ),
-              ],
-              structuredContent: stubResult as unknown as Record<string, unknown>,
-            };
+            // HONEST unavailable — the /v1/einvoice/validate endpoint is
+            // genuinely absent. Do NOT fabricate valid=true (a fabricated
+            // "passes validation" is the most dangerous stub of all: an agent
+            // would dispatch an unvalidated invoice believing it is compliant).
+            return unavailableResult({
+              tool: "validate_einvoice_xml",
+              plannedEndpoint,
+              what: "E-invoice XML validation",
+            });
           }
           throw err;
         }
@@ -462,12 +487,6 @@ export function registerEInvoiceTools(server: McpServer, _client: IFrihetClient)
     async ({ periodStart, periodEnd, format }) =>
       withToolLogging("export_datev", async () => {
         const plannedEndpoint = "/v1/einvoice/export-datev";
-        const formatFileMap: Record<string, string> = {
-          "extf-buchungsstapel": "EXTF_Buchungsstapel",
-          "extf-debitoren": "EXTF_Debitoren",
-          "extf-kreditoren": "EXTF_Kreditoren",
-        };
-        const periodLabel = periodStart.slice(0, 7); // YYYY-MM
         try {
           const result = await (_client as IFrihetClientWithEInvoice).exportDatev({ periodStart, periodEnd, format });
           return {
@@ -486,31 +505,15 @@ export function registerEInvoiceTools(server: McpServer, _client: IFrihetClient)
           };
         } catch (err: unknown) {
           if (isNotFoundError(err)) {
-            const filename = `${formatFileMap[format]}_${periodLabel}.csv`;
-            const stubResult = {
-              fileUrl: `https://storage.frihet.io/stub/datev/${filename}`,
-              filename,
-              rowCount: 0,
-              fiscalPeriod: periodLabel,
-              encoding: "cp1252" as const,
-              _stub: true,
-              _note: "CF endpoint pending deploy",
-              _plannedEndpoint: plannedEndpoint,
-            };
-            return {
-              content: [
-                getContent(
-                  `DATEV export ready (stub — CF pending deploy):\n` +
-                  `  Format: ${format}\n` +
-                  `  Period: ${periodStart} → ${periodEnd}\n` +
-                  `  Filename: ${stubResult.filename}\n` +
-                  `  Rows: ${stubResult.rowCount}\n` +
-                  `  Encoding: ${stubResult.encoding}\n` +
-                  `  Download URL: ${stubResult.fileUrl}`,
-                ),
-              ],
-              structuredContent: stubResult as unknown as Record<string, unknown>,
-            };
+            // HONEST unavailable — the /v1/einvoice/export-datev endpoint is
+            // genuinely absent. Do NOT fabricate a fileUrl pointing at a stub
+            // path with rowCount=0 (an agent would hand a broken/empty link to
+            // an accountant).
+            return unavailableResult({
+              tool: "export_datev",
+              plannedEndpoint,
+              what: "DATEV EXTF export",
+            });
           }
           throw err;
         }
@@ -930,36 +933,26 @@ export function registerEInvoiceTools(server: McpServer, _client: IFrihetClient)
     },
     async ({ invoiceId, mode }) =>
       withToolLogging("ksef_submit", async () => {
-        // STUB: KSeF CF endpoint not yet deployed — PR #417 required.
-        // When PR #417 merges (api.frihet.io/v1/invoices/:id/ksef/submit live),
-        // replace this block with: await (_client as IFrihetClientWithDay4EInvoice).kSeFSubmit({ invoiceId, mode })
+        // HONEST unavailable: KSeF CF endpoint not yet deployed — PR #417 required.
+        // Returns isError:true + _unavailable so an AI agent treats this as a
+        // failure, NOT as a (successful) tool result it can act on. When PR #417
+        // merges (api.frihet.io/v1/invoices/:id/ksef/submit live), replace this
+        // block with: await (_client as IFrihetClientWithDay4EInvoice).kSeFSubmit({ invoiceId, mode })
         const resolvedMode = mode ?? "production";
-        const stubResult = {
-          _notImplemented: true,
-          _note:
-            "KSeF endpoint not yet deployed. " +
-            "Depends on api.frihet.io/v1/invoices/:id/ksef/submit which lands in Frihet-ERP PR #417. " +
-            "Call ksef_submit again after PR #417 merges to activate live KSeF submissions.",
-          _plannedEndpoint: `/v1/invoices/${invoiceId}/ksef/submit`,
-          invoiceId,
-          mode: resolvedMode,
-        };
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text:
-                `KSeF submission not yet available.\n` +
-                `  Invoice: ${invoiceId}\n` +
-                `  Mode: ${resolvedMode}\n\n` +
-                `The KSeF Cloud Function is pending deployment (Frihet-ERP PR #417). ` +
-                `This tool will activate automatically once PR #417 merges to main. ` +
-                `In the meantime, use einvoice_export with format='ubl' + manual KSeF portal upload ` +
-                `at ksef.mf.gov.pl as a workaround.`,
-            },
-          ],
-          structuredContent: stubResult as unknown as Record<string, unknown>,
-        };
+        const result = unavailableResult({
+          tool: "ksef_submit",
+          plannedEndpoint: `/v1/invoices/${invoiceId}/ksef/submit`,
+          what: "KSeF (Poland) submission",
+          workaround:
+            "It will activate automatically once Frihet-ERP PR #417 merges. " +
+            "In the meantime, use einvoice_export with format='ubl' + manual KSeF portal " +
+            "upload at ksef.mf.gov.pl.",
+        });
+        // Preserve the forward-compat marker + echo the request for callers/tests.
+        result.structuredContent._notImplemented = true;
+        result.structuredContent.invoiceId = invoiceId;
+        result.structuredContent.mode = resolvedMode;
+        return result;
       }),
   );
 }


### PR DESCRIPTION
Closes the platform-depth/trust hole where einvoice tools fabricated success on a backend 404.

**The bug (audit-confirmed):** `validate_einvoice_xml` returned `valid:true` with NO validator run; `send_einvoice`/`get_einvoice_status`/`export_datev` returned fake queued workflows + dead storage URLs. Nothing threw → observability logged each as a SUCCESSFUL tool call. An AI agent acting on `valid:true` is a compliance risk.

**Fix:**
- `observability.ts`: central `inspectStubMarker()` — a non-throwing tool whose output carries `_stub/_notImplemented/_unavailable/_plannedEndpoint` is recorded `success:false` + span `WARNING`. One central fix covers every stub branch.
- `einvoice.ts`: genuinely-absent tools (no `/v1/einvoice/*` route) now return `{_unavailable:true, _note, isError:true}` instead of fabricated data. LIVE_NOW tools (face/ticketbai/export — backend handlers verified live in publicApi.ts) keep their stub only as defensive dead-code on a real unknown-id 404.

Build green · 331/331 tests pass. Trust=compliance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)