### PR TITLE
release(mcp): 1.14.2 — CHANGELOG backfill + version-string sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `@frihet/mcp-server` are documented here.
 
+## [1.14.2] — 2026-06-20
+
+### Fixed
+
+- **MCP↔CF contract integrity** (#42): `modeloCode` alignment, Firestore `Timestamp` serialize seam, pagination `offset`, and `/quarterly-draft` fix so MCP tool output matches what the Cloud Function actually returns.
+- **Honest stub accounting** (#43, compliance): tools no longer fabricate success when the backend returns 404. A missing/unwired endpoint now surfaces an explicit error instead of a fake-OK — critical for Trust Area (agents must not act on phantom confirmations).
+
+## [1.14.1] — 2026-06-15
+
+### Changed
+
+- **Banking tools un-staled** (#40, #41): banking surface wired to the live Cloud Function (#848) + E2E smoke. einvoice tools wired al CF vivo.
+
 ## [1.14.0] — 2026-06-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 | **ChatGPT Apps** | Coming soon | [chatgpt.com](https://chatgpt.com) |
 | **Anthropic Claude Directory** | Coming soon | [claude.ai/settings/connectors](https://claude.ai/settings/connectors) |
 
-> **Tool count:** npm `latest` (1.14.1) ships all 157 tools, same as the remote endpoint (`mcp.frihet.io`).
+> **Tool count:** npm `latest` (1.14.2) ships all 157 tools, same as the remote endpoint (`mcp.frihet.io`).
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,7 +146,7 @@ function main(): void {
   // Connect via stdio transport
   const transport = new StdioServerTransport();
   server.connect(transport).then(() => {
-    console.error("[frihet-mcp] v1.14.1 | 157 tools | https://github.com/Frihet-io/frihet-mcp");
+    console.error("[frihet-mcp] v1.14.2 | 157 tools | https://github.com/Frihet-io/frihet-mcp");
     log({
       level: "info",
       message: "Frihet MCP server running on stdio",


### PR DESCRIPTION
Published `@frihet/mcp-server@1.14.2` to npm (was 1.14.1). Backfills 1.14.1+1.14.2 CHANGELOG entries (#42 contract integrity, #43 honest-stub, #40/#41 banking+einvoice) and syncs the version strings in README + index banner that the `audit:mcp-refs` prepublish gate enforces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)