### PR TITLE
fix(einvoice): kill 5 fabricated-compliance-identifier stubs → honest unavailable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build-test-audit:
+    name: Build · Test · Drift audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      # Version/tool-count drift gate. Scoped to this repo: sister repos
+      # (Frihet-ERP/Saas/docs) aren't checked out in CI, so we only assert the
+      # package's OWN refs (server.json, README, index.ts, CHANGELOG) match the
+      # package.json SoT. Cross-repo drift is caught by the local pre-publish run.
+      - name: Drift audit (self)
+        run: npm run audit:mcp-refs -- --repo frihet-mcp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `@frihet/mcp-server` are documented here.
 
+## [1.14.3] — 2026-06-21
+
+### Fixed
+
+- **Killed 5 fabricated-compliance-identifier stubs** (#45, compliance/Trust Area): the einvoice tools no longer mint fake registration identifiers (`RCF_stub*`, `TBAI-stub*`, fabricated `qrUrl`, fake `"accepted"`/`"submitted"` status) when the backend transport is unavailable. They now return an honest `unavailable` result so an agent never reports a phantom AEAT/TicketBAI confirmation it can act on. 4 tool descriptions corrected to stop advertising stub behaviour as live.
+- **Version drift killed structurally**: the server version now reads from `package.json` at runtime (`PKG_VERSION` in `src/index.ts`) instead of three hardcoded literals that repeatedly desynced (`server.json` / `index.ts` / startup console). `npm version` is now the single place the version lives. `audit:mcp-refs` (run in `prepublishOnly`) stays as the cross-repo backstop.
+
 ## [1.14.2] — 2026-06-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 | **ChatGPT Apps** | Coming soon | [chatgpt.com](https://chatgpt.com) |
 | **Anthropic Claude Directory** | Coming soon | [claude.ai/settings/connectors](https://claude.ai/settings/connectors) |
 
-> **Tool count:** npm `latest` (1.14.2) ships all 157 tools, same as the remote endpoint (`mcp.frihet.io`).
+> **Tool count:** npm `latest` (1.14.3) ships all 157 tools, same as the remote endpoint (`mcp.frihet.io`).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@frihet/mcp-server",
-  "version": "1.14.1",
+  "version": "1.14.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@frihet/mcp-server",
-      "version": "1.14.1",
+      "version": "1.14.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frihet/mcp-server",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "description": "AI-native MCP server for business management — invoices, expenses, deposits, clients, products, quotes, webhooks, CRM, e-invoicing (Facturae/XRechnung/Factur-X/FatturaPA/PEPPOL + FACe Spain B2G + TicketBAI Basque Country + KSeF Poland), vacation rentals, POS, banking, fiscal (Modelo 303/130/390/180/347/415/425/418, VeriFactu, TicketBAI, IS M200/M202), IGIC, AIEM, GL audit approval, white-label portal domain, VIES EU VAT lookup, bank rules, time tracking, recurring invoices, team management, gestoria. 157 tools. Remote endpoint at mcp.frihet.io (zero install). Works with Claude, Cursor, Windsurf, Cline.",
   "type": "module",
   "main": "./dist/index.js",

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/Frihet-io/frihet-mcp",
     "source": "github"
   },
-  "version": "1.14.2",
+  "version": "1.14.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@frihet/mcp-server",
-      "version": "1.14.2",
+      "version": "1.14.3",
       "transport": {
         "type": "stdio"
       }

--- a/src/__tests__/einvoice-day4-tools.test.ts
+++ b/src/__tests__/einvoice-day4-tools.test.ts
@@ -196,26 +196,17 @@ describe("Day 4 E-Invoice Tools — Registration", () => {
 
 // ── einvoice_export tests ─────────────────────────────────────────────────────
 
-describe("einvoice_export — 404-fallback stub", () => {
-  test("404 → stub with _stub=true, xmlUrl and filename set", async () => {
+describe("einvoice_export — 404 returns honest unavailable (no fabrication)", () => {
+  test("404 → isError + _unavailable, NO _stub, NO fabricated xmlUrl", async () => {
     const server = await makeServer(make404Client());
     const tool = server.tools.get("einvoice_export")!;
     const result = await tool.handler({ invoiceId: "inv_001", format: "facturae", signed: true });
+    assert.equal((result as Record<string, unknown>)["isError"], true);
     const sc = result.structuredContent!;
-    assert.equal(sc["_stub"], true);
-    assert.equal(sc["_note"], "CF endpoint pending deploy");
-    assert.ok(typeof sc["xmlUrl"] === "string");
-    assert.ok(typeof sc["filename"] === "string");
-    assert.equal(sc["format"], "facturae");
-    assert.equal(sc["signed"], true);
-  });
-
-  test("signed defaults to false when omitted", async () => {
-    const server = await makeServer(make404Client());
-    const tool = server.tools.get("einvoice_export")!;
-    const result = await tool.handler({ invoiceId: "inv_002", format: "xrechnung-cii" });
-    const sc = result.structuredContent!;
-    assert.equal(sc["signed"], false);
+    assert.equal(sc["_unavailable"], true);
+    assert.equal(sc["_stub"], undefined);
+    assert.equal(sc["xmlUrl"], undefined, "must not fabricate a download URL");
+    assert.equal(sc["tool"], "einvoice_export");
   });
 
   test("403 error returns isError response (not stub)", async () => {
@@ -243,34 +234,17 @@ describe("einvoice_export — live client", () => {
 
 // ── face_submit tests ─────────────────────────────────────────────────────────
 
-describe("face_submit — 404-fallback stub", () => {
-  test("404 → stub with _stub=true, registroFACe and status set", async () => {
+describe("face_submit — 404 returns honest unavailable (no fabrication)", () => {
+  test("404 → isError + _unavailable, NO _stub, NO fabricated registroFACe", async () => {
     const server = await makeServer(make404Client());
     const tool = server.tools.get("face_submit")!;
     const result = await tool.handler({ invoiceId: "inv_face_001", mode: "production" });
+    assert.equal((result as Record<string, unknown>)["isError"], true);
     const sc = result.structuredContent!;
-    assert.equal(sc["_stub"], true);
-    assert.equal(sc["_note"], "CF endpoint pending deploy");
-    assert.ok(typeof sc["registroFACe"] === "string");
-    assert.equal(sc["status"], "submitted");
-    assert.ok(typeof sc["submittedAt"] === "string");
-    assert.equal(sc["mode"], "production");
-  });
-
-  test("mode defaults to production when omitted", async () => {
-    const server = await makeServer(make404Client());
-    const tool = server.tools.get("face_submit")!;
-    const result = await tool.handler({ invoiceId: "inv_face_002" });
-    const sc = result.structuredContent!;
-    assert.equal(sc["mode"], "production");
-  });
-
-  test("sandbox mode accepted", async () => {
-    const server = await makeServer(make404Client());
-    const tool = server.tools.get("face_submit")!;
-    const result = await tool.handler({ invoiceId: "inv_face_003", mode: "sandbox" });
-    const sc = result.structuredContent!;
-    assert.equal(sc["mode"], "sandbox");
+    assert.equal(sc["_unavailable"], true);
+    assert.equal(sc["_stub"], undefined);
+    assert.equal(sc["registroFACe"], undefined, "must not fabricate a FACe registro");
+    assert.equal(sc["status"], undefined);
   });
 
   test("403 error returns isError response (not stub)", async () => {
@@ -295,16 +269,16 @@ describe("face_submit — live client", () => {
 
 // ── face_status tests ─────────────────────────────────────────────────────────
 
-describe("face_status — 404-fallback stub", () => {
-  test("404 → stub with statusCode '1200' (Registrada)", async () => {
+describe("face_status — 404 returns honest unavailable (no fabrication)", () => {
+  test("404 → isError + _unavailable, NO fabricated 1200/Registrada", async () => {
     const server = await makeServer(make404Client());
     const tool = server.tools.get("face_status")!;
     const result = await tool.handler({ invoiceId: "inv_face_001" });
+    assert.equal((result as Record<string, unknown>)["isError"], true);
     const sc = result.structuredContent!;
-    assert.equal(sc["_stub"], true);
-    assert.equal(sc["statusCode"], "1200");
-    assert.equal(sc["statusDescription"], "Registrada");
-    assert.ok(typeof sc["registroFACe"] === "string");
+    assert.equal(sc["_unavailable"], true);
+    assert.equal(sc["statusCode"], undefined, "must not fabricate a FACe status code");
+    assert.equal(sc["registroFACe"], undefined);
   });
 
   test("403 error returns isError response (not stub)", async () => {
@@ -329,34 +303,17 @@ describe("face_status — live client", () => {
 
 // ── ticketbai_submit tests ────────────────────────────────────────────────────
 
-describe("ticketbai_submit — 404-fallback stub", () => {
-  test("404 → stub with tbaiId, territory=bizkaia, status=submitted", async () => {
+describe("ticketbai_submit — 404 returns honest unavailable (no fabrication)", () => {
+  test("404 → isError + _unavailable, NO fabricated tbaiId / qrUrl", async () => {
     const server = await makeServer(make404Client());
     const tool = server.tools.get("ticketbai_submit")!;
     const result = await tool.handler({ invoiceId: "inv_tbai_001" });
+    assert.equal((result as Record<string, unknown>)["isError"], true);
     const sc = result.structuredContent!;
-    assert.equal(sc["_stub"], true);
-    assert.ok(typeof sc["tbaiId"] === "string");
-    assert.equal(sc["territory"], "bizkaia");
-    assert.equal(sc["status"], "submitted");
-    assert.equal(sc["sandbox"], false);
-    assert.ok(typeof sc["qrUrl"] === "string");
-  });
-
-  test("sandbox=true is reflected in stub", async () => {
-    const server = await makeServer(make404Client());
-    const tool = server.tools.get("ticketbai_submit")!;
-    const result = await tool.handler({ invoiceId: "inv_tbai_002", sandbox: true });
-    const sc = result.structuredContent!;
-    assert.equal(sc["sandbox"], true);
-  });
-
-  test("sandbox defaults to false when omitted", async () => {
-    const server = await makeServer(make404Client());
-    const tool = server.tools.get("ticketbai_submit")!;
-    const result = await tool.handler({ invoiceId: "inv_tbai_003" });
-    const sc = result.structuredContent!;
-    assert.equal(sc["sandbox"], false);
+    assert.equal(sc["_unavailable"], true);
+    assert.equal(sc["tbaiId"], undefined, "must not fabricate a TBAI identifier");
+    assert.equal(sc["qrUrl"], undefined, "must not fabricate a QR url");
+    assert.equal(sc["status"], undefined);
   });
 
   test("403 error returns isError response (not stub)", async () => {
@@ -382,18 +339,16 @@ describe("ticketbai_submit — live client", () => {
 
 // ── ticketbai_status tests ────────────────────────────────────────────────────
 
-describe("ticketbai_status — 404-fallback stub", () => {
-  test("404 → stub with tbaiId, territory, status=accepted", async () => {
+describe("ticketbai_status — 404 returns honest unavailable (no fabrication)", () => {
+  test("404 → isError + _unavailable, NO fabricated accepted status", async () => {
     const server = await makeServer(make404Client());
     const tool = server.tools.get("ticketbai_status")!;
     const result = await tool.handler({ invoiceId: "inv_tbai_001" });
+    assert.equal((result as Record<string, unknown>)["isError"], true);
     const sc = result.structuredContent!;
-    assert.equal(sc["_stub"], true);
-    assert.ok(typeof sc["tbaiId"] === "string");
-    assert.equal(sc["territory"], "bizkaia");
-    assert.equal(sc["status"], "accepted");
-    assert.equal(sc["rejectionReason"], undefined);
-    assert.equal(sc["error"], undefined);
+    assert.equal(sc["_unavailable"], true);
+    assert.equal(sc["status"], undefined, "must not fabricate an accepted status");
+    assert.equal(sc["tbaiId"], undefined);
   });
 
   test("403 error returns isError response (not stub)", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,27 @@
  * Transport: stdio (designed for CLI tools like Claude Code, Cursor, Windsurf).
  */
 
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 
 import { FrihetClient } from "./client.js";
+
+// Single source of truth for the server version: package.json (read at runtime
+// from dist/../package.json). Hardcoding it here caused repeated version drift
+// (server.json/index.ts/console out of sync → audit:mcp-refs gate failure).
+// Reading it once means a `npm version` bump is the ONLY place version lives.
+const PKG_VERSION: string = (() => {
+  try {
+    const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "..", "package.json");
+    return JSON.parse(readFileSync(pkgPath, "utf8")).version as string;
+  } catch {
+    return "0.0.0";
+  }
+})();
 import { registerAllTools } from "./tools/register-all.js";
 import { registerAllResources } from "./resources/register-all.js";
 import { registerAllPrompts } from "./prompts/register-all.js";
@@ -79,7 +96,7 @@ function main(): void {
 
   const server = new McpServer({
     name: "frihet-erp",
-    version: "1.14.1",
+    version: PKG_VERSION,
     description:
       "AI-native MCP server for Frihet ERP — invoices, expenses, clients, products, quotes, webhooks, and deposits. " +
       "Provides 157 tools (including business context, monthly summaries, quarterly taxes, invoice duplication, CRM subcollections, and deposit management), " +
@@ -146,12 +163,12 @@ function main(): void {
   // Connect via stdio transport
   const transport = new StdioServerTransport();
   server.connect(transport).then(() => {
-    console.error("[frihet-mcp] v1.14.2 | 157 tools | https://github.com/Frihet-io/frihet-mcp");
+    console.error(`[frihet-mcp] v${PKG_VERSION} | 157 tools | https://github.com/Frihet-io/frihet-mcp`);
     log({
       level: "info",
       message: "Frihet MCP server running on stdio",
       operation: "startup",
-      metadata: { version: "1.14.1", transport: "stdio" },
+      metadata: { version: PKG_VERSION, transport: "stdio" },
     });
   }).catch((error: unknown) => {
     log({

--- a/src/tools/einvoice.ts
+++ b/src/tools/einvoice.ts
@@ -277,7 +277,7 @@ export function registerEInvoiceTools(server: McpServer, _client: IFrihetClient)
         "  • peppol — transmit via PEPPOL access point (peppol-bis-3 only)\n" +
         "  • download — generate and return a signed download URL only\n" +
         "\n" +
-        "NOTE: Stub response — real CF endpoint https://api.frihet.io/v1/einvoice/send wired in transport Wave. " +
+        "If the dispatch backend is not deployed for this workspace, returns an honest 'unavailable' response — never fabricated workflow data. " +
         "/ Envia una factura electronica al destinatario mediante el canal de transporte seleccionado. " +
         "Devuelve de forma asincrona — consultar get_einvoice_status para seguimiento.",
       annotations: CREATE_ANNOTATIONS,
@@ -344,7 +344,7 @@ export function registerEInvoiceTools(server: McpServer, _client: IFrihetClient)
         "Returns current step, ack ID (network confirmation), and download URLs once complete. " +
         "Poll every 5–10 seconds until status is 'succeeded', 'failed', or 'cancelled'. " +
         "\n\n" +
-        "NOTE: Stub response — real CF endpoint https://api.frihet.io/v1/einvoice/status wired in transport Wave. " +
+        "If the status backend is not deployed for this workspace, returns an honest 'unavailable' response — never a fabricated status. " +
         "/ Consulta el estado de un flujo de envio de factura electronica.",
       annotations: READ_ONLY_ANNOTATIONS,
       inputSchema: {
@@ -400,7 +400,7 @@ export function registerEInvoiceTools(server: McpServer, _client: IFrihetClient)
         "Use before dispatch to catch errors early without incurring network transmission costs. " +
         "A valid=true response means the document passes all schema + business rule checks. " +
         "\n\n" +
-        "NOTE: Stub response — real CF endpoint https://api.frihet.io/v1/einvoice/validate wired in transport Wave. " +
+        "If the validation backend is not deployed for this workspace, returns an honest 'unavailable' response — never a fabricated valid=true. " +
         "/ Valida un documento XML de factura electronica contra el esquema y reglas schematron del formato especificado.",
       annotations: READ_ONLY_ANNOTATIONS,
       inputSchema: {
@@ -465,7 +465,7 @@ export function registerEInvoiceTools(server: McpServer, _client: IFrihetClient)
         "Output encoding is always CP1252 per DATEV EXTF specification. " +
         "Date range: both periodStart and periodEnd must be ISO 8601 dates (YYYY-MM-DD). " +
         "\n\n" +
-        "NOTE: Stub response — real CF endpoint https://api.frihet.io/v1/datev/export wired in transport Wave. " +
+        "If the DATEV export backend is not deployed for this workspace, returns an honest 'unavailable' response — never a fabricated file URL. " +
         "/ Exporta datos contables en formato DATEV EXTF para importacion en DATEV o sistemas compatibles.",
       annotations: READ_ONLY_ANNOTATIONS,
       inputSchema: {
@@ -570,28 +570,13 @@ export function registerEInvoiceTools(server: McpServer, _client: IFrihetClient)
           };
         } catch (err: unknown) {
           if (isNotFoundError(err)) {
-            const stubResult = {
-              xmlUrl: `https://storage.frihet.io/stub/einvoice/${invoiceId}-${format}.xml`,
-              filename: `${invoiceId}-${format}.xml`,
-              format,
-              signed: signed ?? false,
-              _stub: true,
-              _note: "CF endpoint pending deploy",
-              _plannedEndpoint: plannedEndpoint,
-            };
-            return {
-              content: [
-                getContent(
-                  `E-invoice export ready (stub — CF pending deploy):\n` +
-                  `  Invoice: ${invoiceId}\n` +
-                  `  Format: ${format}\n` +
-                  `  Signed: ${stubResult.signed}\n` +
-                  `  Filename: ${stubResult.filename}\n` +
-                  `  Download URL: ${stubResult.xmlUrl}`,
-                ),
-              ],
-              structuredContent: stubResult as unknown as Record<string, unknown>,
-            };
+            // HONEST unavailable — the export CF is genuinely absent. Do NOT
+            // fabricate a download URL pointing at a non-existent stub file.
+            return unavailableResult({
+              tool: "einvoice_export",
+              plannedEndpoint,
+              what: "E-invoice XML export",
+            });
           }
           throw err;
         }
@@ -648,28 +633,15 @@ export function registerEInvoiceTools(server: McpServer, _client: IFrihetClient)
           };
         } catch (err: unknown) {
           if (isNotFoundError(err)) {
-            const stubResult = {
-              registroFACe: `RCF_stub_${Date.now()}`,
-              status: "submitted" as const,
-              submittedAt: new Date().toISOString(),
-              mode: resolvedMode,
-              _stub: true,
-              _note: "CF endpoint pending deploy",
-              _plannedEndpoint: plannedEndpoint,
-            };
-            return {
-              content: [
-                mutateContent(
-                  `FACe submission queued (stub — CF pending deploy):\n` +
-                  `  Invoice: ${invoiceId}\n` +
-                  `  Mode: ${resolvedMode}\n` +
-                  `  Registro: ${stubResult.registroFACe}\n` +
-                  `  Status: ${stubResult.status}\n\n` +
-                  `Use face_status with invoiceId to poll the portal for confirmation.`,
-                ),
-              ],
-              structuredContent: stubResult as unknown as Record<string, unknown>,
-            };
+            // HONEST unavailable — the FACe submit CF is genuinely absent. Do
+            // NOT fabricate a registro: a fake "submitted" B2G reference would
+            // make an agent report a filing that never happened.
+            return unavailableResult({
+              tool: "face_submit",
+              plannedEndpoint,
+              what: "FACe (Spain B2G) submission",
+              workaround: "No registro was created — do not treat this as an accepted submission.",
+            });
           }
           throw err;
         }
@@ -720,27 +692,13 @@ export function registerEInvoiceTools(server: McpServer, _client: IFrihetClient)
           };
         } catch (err: unknown) {
           if (isNotFoundError(err)) {
-            const stubResult = {
-              registroFACe: `RCF_stub_${invoiceId.slice(-8)}`,
-              statusCode: "1200",
-              statusDescription: "Registrada",
-              rejectionReason: undefined,
-              _stub: true,
-              _note: "CF endpoint pending deploy",
-              _plannedEndpoint: plannedEndpoint,
-            };
-            return {
-              content: [
-                getContent(
-                  `FACe status (stub — CF pending deploy):\n` +
-                  `  Invoice: ${invoiceId}\n` +
-                  `  Registro: ${stubResult.registroFACe}\n` +
-                  `  Status code: ${stubResult.statusCode}\n` +
-                  `  Description: ${stubResult.statusDescription}`,
-                ),
-              ],
-              structuredContent: stubResult as unknown as Record<string, unknown>,
-            };
+            // HONEST unavailable — do NOT fabricate a "Registrada" (1200) state
+            // for a submission that was never made.
+            return unavailableResult({
+              tool: "face_status",
+              plannedEndpoint,
+              what: "FACe submission status",
+            });
           }
           throw err;
         }
@@ -796,30 +754,14 @@ export function registerEInvoiceTools(server: McpServer, _client: IFrihetClient)
           };
         } catch (err: unknown) {
           if (isNotFoundError(err)) {
-            const stubResult = {
-              tbaiId: `TBAI-stub-${Date.now()}`,
-              territory: "bizkaia" as const,
-              status: "submitted" as const,
-              sandbox: isSandbox,
-              qrUrl: `https://batuz.eus/QRTBAI/?id=TBAI-stub`,
-              _stub: true,
-              _note: "CF endpoint pending deploy",
-              _plannedEndpoint: plannedEndpoint,
-            };
-            return {
-              content: [
-                mutateContent(
-                  `TicketBAI submitted (stub — CF pending deploy):\n` +
-                  `  Invoice: ${invoiceId}\n` +
-                  `  Territory: ${stubResult.territory}\n` +
-                  `  TBAI ID: ${stubResult.tbaiId}\n` +
-                  `  Sandbox: ${isSandbox}\n` +
-                  `  QR URL: ${stubResult.qrUrl}\n\n` +
-                  `Use ticketbai_status with invoiceId to poll for hacienda acknowledgement.`,
-                ),
-              ],
-              structuredContent: stubResult as unknown as Record<string, unknown>,
-            };
+            // HONEST unavailable — do NOT fabricate a TBAI identifier + QR URL.
+            // A fake TicketBAI id printed on an invoice is a fiscal forgery.
+            return unavailableResult({
+              tool: "ticketbai_submit",
+              plannedEndpoint,
+              what: "TicketBAI (Basque Country) submission",
+              workaround: "No TBAI identifier was issued — do not print a QR or treat this as filed.",
+            });
           }
           throw err;
         }
@@ -871,28 +813,13 @@ export function registerEInvoiceTools(server: McpServer, _client: IFrihetClient)
           };
         } catch (err: unknown) {
           if (isNotFoundError(err)) {
-            const stubResult = {
-              tbaiId: `TBAI-stub-${invoiceId.slice(-8)}`,
-              territory: "bizkaia" as const,
-              status: "accepted" as const,
-              rejectionReason: undefined,
-              error: undefined,
-              _stub: true,
-              _note: "CF endpoint pending deploy",
-              _plannedEndpoint: plannedEndpoint,
-            };
-            return {
-              content: [
-                getContent(
-                  `TicketBAI status (stub — CF pending deploy):\n` +
-                  `  Invoice: ${invoiceId}\n` +
-                  `  TBAI ID: ${stubResult.tbaiId}\n` +
-                  `  Territory: ${stubResult.territory}\n` +
-                  `  Status: ${stubResult.status}`,
-                ),
-              ],
-              structuredContent: stubResult as unknown as Record<string, unknown>,
-            };
+            // HONEST unavailable — do NOT fabricate an "accepted" hacienda
+            // acknowledgement for a TicketBAI that was never submitted.
+            return unavailableResult({
+              tool: "ticketbai_status",
+              plannedEndpoint,
+              what: "TicketBAI submission status",
+            });
           }
           throw err;
         }

--- a/src/tools/einvoice.ts
+++ b/src/tools/einvoice.ts
@@ -125,31 +125,6 @@ export const eInvoiceFormatSchema = z.enum([
 
 export type EInvoiceFormat = z.infer<typeof eInvoiceFormatSchema>;
 
-/**
- * Map the MCP lowercase format value to the API-facing format name accepted by
- * POST /v1/invoices/:id/einvoice/export (Frihet-ERP publicApi.ts
- * EINVOICE_EXPORT_FORMATS). The CF rejects any other value with a 400 validation
- * error, so this mapping is REQUIRED — passing the raw MCP value would fail.
- *
- * The CF accepts 8 formats: Facturae, XRechnung-CII, XRechnung-UBL, Factur-X,
- * FatturaPA, PEPPOL-BIS-3, UBL, CII. The four Factur-X sub-profiles
- * (en16931/extended/basic/minimum) all map to the CF's single "Factur-X" entry;
- * the CF resolves the concrete profile internally.
- */
-const EINVOICE_EXPORT_FORMAT_MAP: Record<EInvoiceFormat, string> = {
-  "facturae": "Facturae",
-  "xrechnung-cii": "XRechnung-CII",
-  "xrechnung-ubl": "XRechnung-UBL",
-  "facturx-en16931": "Factur-X",
-  "facturx-extended": "Factur-X",
-  "facturx-basic": "Factur-X",
-  "facturx-minimum": "Factur-X",
-  "fatturapa": "FatturaPA",
-  "peppol-bis-3": "PEPPOL-BIS-3",
-  "ubl": "UBL",
-  "cii": "CII",
-};
-
 /* ------------------------------------------------------------------ */
 /*  Output schemas                                                      */
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
**Security/honesty — Trust Area compliance.** Part of the API/MCP 10/10 honesty pass.

## Problem (verified in code)
5 e-invoice tools fabricated **fake compliance identifiers** on a backend 404, while 4 sibling tools already returned honest `unavailableResult`. An AI agent could receive a fabricated `"accepted"` TicketBAI id, FACe registro, or download URL and **report a fiscal filing that never happened** — the most dangerous stub class.

| Tool | Fabricated (before) |
|---|---|
| einvoice_export | `xmlUrl: storage.frihet.io/stub/...` `_stub:true` |
| face_submit | `registroFACe: RCF_stub_${Date.now()}` |
| face_status | `RCF_stub_*` + `statusCode "1200" Registrada` |
| ticketbai_submit | `tbaiId: TBAI-stub-*` + `qrUrl batuz.eus?id=TBAI-stub` |
| ticketbai_status | `tbaiId: TBAI-stub-*` + `status:"accepted"` |

## Fix
Each 404 branch now returns `unavailableResult({...})` → `isError + _unavailable` (no `_stub`, no fabricated id) — the exact contract the 4 correct siblings (send/status/validate/datev) already use. **Happy path unchanged** (CFs are live; the 404 branch is latent). Also fixed 4 stale `"NOTE: Stub response"` descriptions whose copy lied about already-honest code.

## Tests
The 5 `"404 → stub with _stub=true"` assertions **encoded the bug** — flipped to assert `404 → isError + _unavailable + no fabricated identifier`. Full suite **336/336 green**. v1.14.2 → v1.14.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)