### PR TITLE
security: Codex audit P0/P1 — PII redaction, output-schema strip, OAuth log fingerprint, metadata single-source

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "npm run build && node --test dist/__tests__/openai-profile.test.js dist/__tests__/tool-exposure.test.js dist/__tests__/einvoice-tools.test.js dist/__tests__/einvoice-day4-tools.test.js dist/__tests__/stay-tools.test.js dist/__tests__/pos-tools.test.js dist/__tests__/kitchen-tools.test.js dist/__tests__/banking-tools.test.js dist/__tests__/banking-client-contract.test.js dist/__tests__/fiscal-tools.test.js dist/__tests__/time-tools.test.js dist/__tests__/recurring-tools.test.js dist/__tests__/team-tools.test.js dist/__tests__/d4b-hr-payroll-onboarding-tools.test.js dist/__tests__/audit-server-version.test.js dist/__tests__/openai-grouped-compose.test.js dist/__tests__/contract.test.js",
+    "test": "npm run build && node --test dist/__tests__/openai-profile.test.js dist/__tests__/tool-exposure.test.js dist/__tests__/einvoice-tools.test.js dist/__tests__/einvoice-day4-tools.test.js dist/__tests__/stay-tools.test.js dist/__tests__/pos-tools.test.js dist/__tests__/kitchen-tools.test.js dist/__tests__/banking-tools.test.js dist/__tests__/banking-client-contract.test.js dist/__tests__/fiscal-tools.test.js dist/__tests__/time-tools.test.js dist/__tests__/recurring-tools.test.js dist/__tests__/team-tools.test.js dist/__tests__/d4b-hr-payroll-onboarding-tools.test.js dist/__tests__/audit-server-version.test.js dist/__tests__/openai-grouped-compose.test.js dist/__tests__/contract.test.js dist/__tests__/observability-redaction.test.js",
     "start": "node dist/index.js",
     "postinstall": "node scripts/postinstall.js || true",
     "prepublishOnly": "npm run build && npm run audit:mcp-refs -- --repo frihet-mcp",

--- a/scripts/audit-mcp-refs.mjs
+++ b/scripts/audit-mcp-refs.mjs
@@ -68,6 +68,7 @@ const REPOS = {
       'skill/SKILL.md',
       'src/index.ts',
       'workers/remote-mcp/src/index.ts',
+      'workers/remote-mcp/src/auth-handler.ts',
       'workers/remote-mcp/public/releases.json',
     ],
   },

--- a/src/__tests__/observability-redaction.test.ts
+++ b/src/__tests__/observability-redaction.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Trust test — no government ID, credential, or banking identifier may ever
+ * reach the external Langfuse observability service.
+ *
+ * Regression guard for the P0 finding (Codex audit 2026-06-22): the Langfuse
+ * tracer captured the RAW tool output BEFORE the OpenAI profile redaction
+ * wrapper ran, so taxId/secret/IBAN leaked into traces in every profile mode.
+ * The fix moved redaction INTO buildTracePayload, so the trace copy is redacted
+ * unconditionally. This test fails if any sensitive value survives into the
+ * serialized ingestion batch.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildTracePayload } from "../observability.js";
+import { redactClone, SENSITIVE_FIELD_NAMES } from "../redaction.js";
+
+const SECRETS = {
+  taxId: "B12345678",
+  nif: "12345678Z",
+  secret: "whsec_live_DEADBEEFCAFE",
+  iban: "ES9121000418450200051332",
+  passport: "PAX9988776",
+  apiKey: "fri_live_TOPSECRET",
+  accessToken: "ya29.A0ARrdaM-TOKEN",
+  password: "hunter2",
+};
+const SECRET_VALUES = Object.values(SECRETS);
+
+/** A realistic MCP tool result: structuredContent + a serialized JSON text block. */
+function mcpResultWithSecrets() {
+  return {
+    content: [{ type: "text", text: JSON.stringify({ id: "cli_1", ...SECRETS }) }],
+    structuredContent: {
+      client: { id: "cli_1", name: "Acme", ...SECRETS },
+      webhooks: [{ id: "wh_1", url: "https://x.test", secret: SECRETS.secret }],
+    },
+  };
+}
+
+function assertNoSecrets(serialized: string): void {
+  for (const v of SECRET_VALUES) {
+    assert.ok(
+      !serialized.includes(v),
+      `sensitive value leaked into trace payload: ${v}`,
+    );
+  }
+}
+
+describe("observability redaction", () => {
+  test("buildTracePayload strips PII/credentials from output (success path)", () => {
+    const now = new Date("2026-06-22T10:00:00.000Z");
+    const batch = buildTracePayload({
+      toolName: "get_client",
+      input: { id: "cli_1", taxId: SECRETS.taxId },
+      output: mcpResultWithSecrets(),
+      isError: false,
+      startTime: now,
+      endTime: now,
+      traceId: "trace_1",
+      spanId: "span_1",
+      stub: null,
+    });
+    assertNoSecrets(JSON.stringify(batch));
+  });
+
+  test("buildTracePayload strips PII from input args even on the error path", () => {
+    const now = new Date("2026-06-22T10:00:00.000Z");
+    const batch = buildTracePayload({
+      toolName: "create_client",
+      input: { name: "Acme", ...SECRETS },
+      output: undefined,
+      isError: true,
+      // an error message that echoes the request body must not leak either
+      errorMessage: `Backend rejected payload: {"taxId":"${SECRETS.taxId}","secret":"${SECRETS.secret}"}`,
+      startTime: now,
+      endTime: now,
+      traceId: "trace_2",
+      spanId: "span_2",
+      stub: null,
+    });
+    assertNoSecrets(JSON.stringify(batch));
+  });
+
+  test("redactClone never mutates its argument", () => {
+    const original = mcpResultWithSecrets();
+    const before = JSON.stringify(original);
+    redactClone(original);
+    assert.equal(JSON.stringify(original), before, "redactClone must not mutate input");
+  });
+
+  test("redactClone preserves non-sensitive fields", () => {
+    const cloned = redactClone({ id: "cli_1", name: "Acme", total: 100, taxId: SECRETS.taxId }) as Record<string, unknown>;
+    assert.equal(cloned.id, "cli_1");
+    assert.equal(cloned.name, "Acme");
+    assert.equal(cloned.total, 100);
+    assert.notEqual(cloned.taxId, SECRETS.taxId);
+  });
+
+  test("the sensitive field set covers the critical Trust fields", () => {
+    for (const f of ["taxId", "secret", "iban", "apiKey", "accessToken", "password"]) {
+      assert.ok(SENSITIVE_FIELD_NAMES.includes(f), `missing critical sensitive field: ${f}`);
+    }
+  });
+});

--- a/src/__tests__/openai-profile.test.ts
+++ b/src/__tests__/openai-profile.test.ts
@@ -11,6 +11,7 @@ import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 
 import { applyOpenAIProfile } from "../openai-profile.js";
+import { SENSITIVE_FIELD_NAMES } from "../redaction.js";
 import { registerAllTools } from "../tools/register-all.js";
 import { registerAllPrompts } from "../prompts/register-all.js";
 import type { IFrihetClient } from "../client-interface.js";
@@ -184,5 +185,41 @@ describe("OpenAI profile", () => {
     assert.equal(serialized.includes("B12345678"), false);
     assert.equal(serialized.includes("secret"), false);
     assert.equal(serialized.includes("should-not-leak"), false);
+  });
+
+  test("no reviewed tool DECLARES a sensitive field in its outputSchema", () => {
+    const server = makeOpenAIServer();
+
+    // Recursively collect every object key declared by a Zod output schema.
+    const collectKeys = (schema: unknown, acc: Set<string>): Set<string> => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const def = (schema as any)?._def;
+      const typeName: string | undefined = def?.typeName;
+      if (typeName === "ZodObject") {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        for (const [key, value] of Object.entries((schema as any).shape as Record<string, unknown>)) {
+          acc.add(key);
+          collectKeys(value, acc);
+        }
+      } else if (typeName === "ZodArray") {
+        collectKeys(def.type, acc);
+      } else if (typeName === "ZodOptional" || typeName === "ZodNullable") {
+        collectKeys(def.innerType, acc);
+      }
+      return acc;
+    };
+
+    for (const tool of server.tools.values()) {
+      const out = tool.config.outputSchema;
+      if (!out) continue;
+      const keys = collectKeys(out, new Set<string>());
+      for (const field of SENSITIVE_FIELD_NAMES) {
+        assert.equal(
+          keys.has(field),
+          false,
+          `${tool.name} outputSchema must not declare sensitive field "${field}"`,
+        );
+      }
+    }
   });
 });

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -19,6 +19,8 @@
  * Docs: https://langfuse.com/docs/api/reference/overview
  */
 
+import { redactClone, redactText } from "./redaction.js";
+
 // Declared to avoid TS errors in Workers environment where `process` is not typed
 declare const process: { env?: Record<string, string | undefined> } | undefined;
 
@@ -232,6 +234,115 @@ export function setTraceContext(ctx: TraceContext): void {
   _sessionContext = { ..._sessionContext, ...ctx };
 }
 
+// ── Trace payload builder (pure, redacted) ───────────────────────────────────
+
+interface TracePayloadParams {
+  toolName: string;
+  /** Raw tool input args (redacted before serialization). */
+  input: unknown;
+  /** Raw tool output (redacted before serialization); ignored when isError. */
+  output: unknown;
+  isError: boolean;
+  errorMessage?: string;
+  startTime: Date;
+  endTime: Date;
+  traceId: string;
+  spanId: string;
+  /** Already-hashed user id, or undefined. */
+  userIdHashed?: string;
+  clientName?: string;
+  mcpVersion?: string;
+  /** Fabricated-stub marker, or null on a genuine result. */
+  stub: StubMarker | null;
+}
+
+/**
+ * Builds the Langfuse trace+span ingestion batch for a single tool call.
+ *
+ * CRITICAL (Trust): `input` and `output` are passed through {@link redactClone}
+ * before they enter the payload, so government IDs (taxId/NIF/CIF), banking
+ * identifiers (IBAN), webhook signing secrets, and auth tokens NEVER reach the
+ * external Langfuse service — in ANY profile mode. The tool-call output handed
+ * to the user is redacted later (OpenAI mode only); this redacts the trace copy
+ * unconditionally. Exported so a test can assert no sensitive value survives.
+ */
+export function buildTracePayload(p: TracePayloadParams): IngestionBatch {
+  const {
+    toolName, input, output, isError, errorMessage,
+    startTime, endTime, traceId, spanId, userIdHashed, clientName, mcpVersion, stub,
+  } = p;
+
+  const stubbed = stub !== null;
+  // success: false whenever the call threw OR returned a fabricated stub body.
+  const success = !isError && !stubbed;
+  const stubNote =
+    stub?.note ??
+    (stub?.plannedEndpoint
+      ? `Backend endpoint not yet available: ${stub.plannedEndpoint}`
+      : undefined);
+
+  // ── Redact BEFORE the payload is built (never mutates the live response) ──
+  const safeArgs = redactClone(input);
+  const safeError = errorMessage ? redactText(errorMessage) : errorMessage;
+  const safeOutput = isError ? { error: safeError } : redactClone(output);
+
+  const traceBody: LangfuseTraceBody = {
+    id: traceId,
+    name: "mcp_request",
+    timestamp: startTime.toISOString(),
+    input: { tool: toolName, args: safeArgs },
+    output: safeOutput,
+    metadata: {
+      tool: toolName,
+      clientName,
+      mcpVersion,
+      // FALSE on a thrown error AND on a fabricated-stub fallback.
+      success,
+      ...(stubbed
+        ? {
+            stub: true,
+            ...(stub?.plannedEndpoint ? { plannedEndpoint: stub.plannedEndpoint } : {}),
+            ...(stubNote ? { note: stubNote } : {}),
+          }
+        : {}),
+    },
+    tags: [`mcp.tool.${toolName}`, ...(stubbed ? ["mcp.stub"] : [])],
+    ...(userIdHashed ? { userId: userIdHashed } : {}),
+  };
+
+  const spanBody: LangfuseSpanBody = {
+    id: spanId,
+    traceId,
+    name: `tool.${toolName}`,
+    startTime: startTime.toISOString(),
+    endTime: endTime.toISOString(),
+    input: safeArgs,
+    output: safeOutput,
+    metadata: {
+      durationMs: endTime.getTime() - startTime.getTime(),
+      clientName,
+      mcpVersion,
+      ...(stubbed ? { stub: true } : {}),
+    },
+    // ERROR on a thrown error; WARNING on a fabricated-stub fallback (the call
+    // "succeeded" mechanically but returned no real backend data); DEFAULT only
+    // on a genuine success.
+    level: isError ? "ERROR" : stubbed ? "WARNING" : "DEFAULT",
+    ...(isError && safeError
+      ? { statusMessage: safeError }
+      : stubbed && stubNote
+        ? { statusMessage: stubNote }
+        : {}),
+  };
+
+  return {
+    batch: [
+      { type: "trace-create", id: newId(), timestamp: startTime.toISOString(), body: traceBody },
+      { type: "span-create", id: newId(), timestamp: startTime.toISOString(), body: spanBody },
+    ],
+  };
+}
+
 /**
  * Wraps a tool handler fn and sends a Langfuse trace+span for the call.
  *
@@ -285,14 +396,6 @@ export async function traceMCPTool<T>(
     // success. This is the central fix: it covers every stub branch regardless of
     // which tool produced it, because the stub path never reaches the catch above.
     const stub = isError ? null : inspectStubMarker(output);
-    const stubbed = stub !== null;
-    // success: false whenever the call threw OR returned a fabricated stub body.
-    const success = !isError && !stubbed;
-    const stubNote =
-      stub?.note ??
-      (stub?.plannedEndpoint
-        ? `Backend endpoint not yet available: ${stub.plannedEndpoint}`
-        : undefined);
 
     // Fire-and-forget — build and send async, never awaited
     void (async () => {
@@ -301,71 +404,23 @@ export async function traceMCPTool<T>(
         const userIdRaw = _sessionContext.userId;
         const userIdHashed = userIdRaw ? await hashPii(userIdRaw) : undefined;
 
-        const traceBody: LangfuseTraceBody = {
-          id: traceId,
-          name: "mcp_request",
-          timestamp: startTime.toISOString(),
-          input: { tool: toolName, args: input },
-          output: isError ? { error: errorMessage } : output,
-          metadata: {
-            tool: toolName,
-            clientName: _sessionContext.clientName,
-            mcpVersion: _sessionContext.mcpVersion,
-            // FALSE on a thrown error AND on a fabricated-stub fallback.
-            success,
-            ...(stubbed
-              ? {
-                  stub: true,
-                  ...(stub?.plannedEndpoint ? { plannedEndpoint: stub.plannedEndpoint } : {}),
-                  ...(stubNote ? { note: stubNote } : {}),
-                }
-              : {}),
-          },
-          tags: [`mcp.tool.${toolName}`, ...(stubbed ? ["mcp.stub"] : [])],
-          ...(userIdHashed ? { userId: userIdHashed } : {}),
-        };
-
-        const spanBody: LangfuseSpanBody = {
-          id: spanId,
-          traceId,
-          name: `tool.${toolName}`,
-          startTime: startTime.toISOString(),
-          endTime: endTime.toISOString(),
+        // buildTracePayload redacts input/output (taxId/secret/IBAN/tokens) so
+        // the external Langfuse service never stores cleartext PII or credentials.
+        const batch = buildTracePayload({
+          toolName,
           input,
-          output: isError ? { error: errorMessage } : output,
-          metadata: {
-            durationMs: endTime.getTime() - startTime.getTime(),
-            clientName: _sessionContext.clientName,
-            mcpVersion: _sessionContext.mcpVersion,
-            ...(stubbed ? { stub: true } : {}),
-          },
-          // ERROR on a thrown error; WARNING on a fabricated-stub fallback (the
-          // call "succeeded" mechanically but returned no real backend data);
-          // DEFAULT only on a genuine success.
-          level: isError ? "ERROR" : stubbed ? "WARNING" : "DEFAULT",
-          ...(isError && errorMessage
-            ? { statusMessage: errorMessage }
-            : stubbed && stubNote
-              ? { statusMessage: stubNote }
-              : {}),
-        };
-
-        const batch: IngestionBatch = {
-          batch: [
-            {
-              type: "trace-create",
-              id: newId(),
-              timestamp: startTime.toISOString(),
-              body: traceBody,
-            },
-            {
-              type: "span-create",
-              id: newId(),
-              timestamp: startTime.toISOString(),
-              body: spanBody,
-            },
-          ],
-        };
+          output,
+          isError,
+          errorMessage,
+          startTime,
+          endTime,
+          traceId,
+          spanId,
+          userIdHashed,
+          clientName: _sessionContext.clientName,
+          mcpVersion: _sessionContext.mcpVersion,
+          stub,
+        });
 
         await sendBatch(config, batch);
       } catch (langfuseErr) {

--- a/src/openai-profile.ts
+++ b/src/openai-profile.ts
@@ -22,6 +22,7 @@
  */
 
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { SENSITIVE_FIELD_NAMES, deepRedact, redactText } from "./redaction.js";
 
 /* ------------------------------------------------------------------ */
 /*  Profile definition                                                 */
@@ -41,7 +42,7 @@ interface OpenAIProfile {
   /** Per-tool input fields to remove from schema */
   stripInputFields: Record<string, string[]>;
   /** Field names to redact from ALL tool outputs */
-  redactOutputFields: string[];
+  redactOutputFields: readonly string[];
 }
 
 const PROFILE: OpenAIProfile = {
@@ -223,62 +224,17 @@ const PROFILE: OpenAIProfile = {
 
   // ── Output fields redacted ─────────────────────────────────────────
   // Stripped from structuredContent and text in ALL tool responses.
-  // Includes synonyms that the Frihet API may return via .passthrough() schemas.
-  redactOutputFields: [
-    "taxId", "tax_id",             // Primary field name + snake_case variant
-    "nif", "cif", "vatNumber",     // Spanish/EU synonyms for government tax ID
-    "vat_number", "vatId", "vat_id",
-    "secret",                      // Webhook signing credential
-    "iban", "bankAccount",         // Banking identifiers (if exposed via passthrough)
-    "bank_account", "accountNumber",
-    "idDocument", "documentNumber", // Guest/customer government document fields
-    "passport", "passportNumber",
-    "dni", "nationalId", "national_id",
-    "ssn", "socialSecurityNumber", "social_security_number",
-    "apiKey", "api_key",
-    "accessToken", "access_token", "refreshToken", "refresh_token",
-    "password", "mfa", "otp",
-  ],
+  // Single source of truth lives in redaction.ts (shared with observability.ts
+  // so Langfuse traces redact the EXACT same field set).
+  redactOutputFields: SENSITIVE_FIELD_NAMES,
 };
 
 /* ------------------------------------------------------------------ */
-/*  Deep field redaction                                                */
+/*  Deep field redaction — shared policy in redaction.ts               */
 /* ------------------------------------------------------------------ */
-
-/** Recursively removes named fields from an object/array tree. */
-function deepRedact(obj: unknown, fields: string[]): void {
-  if (obj === null || typeof obj !== "object") return;
-
-  if (Array.isArray(obj)) {
-    for (const item of obj) deepRedact(item, fields);
-    return;
-  }
-
-  const record = obj as Record<string, unknown>;
-  for (const field of fields) {
-    if (field in record) delete record[field];
-  }
-  for (const value of Object.values(record)) {
-    deepRedact(value, fields);
-  }
-}
-
-/** Best-effort redaction of JSON field patterns from display text. */
-function redactText(text: string, fields: string[]): string {
-  let result = text;
-  for (const field of fields) {
-    // Remove "field": "value", or "field": value patterns
-    result = result.replace(
-      new RegExp(
-        `\\s*"${field}"\\s*:\\s*(?:"[^"]*"|null|true|false|\\d+(?:\\.\\d+)?)\\s*,?`,
-        "g",
-      ),
-      "",
-    );
-  }
-  // Clean up trailing commas before } or ] left by removals
-  return result.replace(/,(\s*[}\]])/g, "$1");
-}
+//
+// deepRedact (in-place DELETE) + redactText (regex) now live in ./redaction.ts
+// so observability.ts redacts the SAME field set before tracing to Langfuse.
 
 /* ------------------------------------------------------------------ */
 /*  Resources excluded / redacted in OpenAI mode                       */

--- a/src/openai-profile.ts
+++ b/src/openai-profile.ts
@@ -22,6 +22,7 @@
  */
 
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
 import { SENSITIVE_FIELD_NAMES, deepRedact, redactText } from "./redaction.js";
 
 /* ------------------------------------------------------------------ */
@@ -237,6 +238,76 @@ const PROFILE: OpenAIProfile = {
 // so observability.ts redacts the SAME field set before tracing to Langfuse.
 
 /* ------------------------------------------------------------------ */
+/*  Output SCHEMA stripping (descriptor-level)                          */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Returns a Zod output schema with sensitive fields removed at EVERY depth.
+ *
+ * Runtime output redaction (deepRedact in the handler wrapper) hides the
+ * VALUES, but the advertised `outputSchema` descriptor still DECLARES taxId /
+ * secret etc. at tools/list — which OpenAI's submission review auto-detects as
+ * exposed government IDs / credentials. This strips them from the descriptor too.
+ *
+ * Surgical: only the object/array nodes on the path to a sensitive field are
+ * rebuilt; untouched branches are returned BY REFERENCE so their `.describe()`
+ * metadata and `.passthrough()` behavior are preserved. A schema with no
+ * sensitive field anywhere is returned unchanged (identity).
+ */
+function stripSensitiveOutputSchema(
+  schema: unknown,
+  fields: readonly string[],
+): unknown {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const def = (schema as any)?._def;
+  const typeName: string | undefined = def?.typeName;
+
+  if (typeName === "ZodObject") {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const shape = (schema as any).shape as Record<string, unknown>;
+    const newShape: Record<string, unknown> = {};
+    let changed = false;
+    for (const [key, value] of Object.entries(shape)) {
+      if (fields.includes(key)) {
+        changed = true;
+        continue; // drop the sensitive field entirely from the descriptor
+      }
+      const stripped = stripSensitiveOutputSchema(value, fields);
+      if (stripped !== value) changed = true;
+      newShape[key] = stripped;
+    }
+    if (!changed) return schema;
+    let rebuilt: z.ZodTypeAny = z.object(newShape as z.ZodRawShape);
+    if (typeof def.description === "string") rebuilt = rebuilt.describe(def.description);
+    return rebuilt;
+  }
+
+  if (typeName === "ZodArray") {
+    const inner = def.type;
+    const stripped = stripSensitiveOutputSchema(inner, fields);
+    if (stripped === inner) return schema;
+    let rebuilt: z.ZodTypeAny = z.array(stripped as z.ZodTypeAny);
+    if (typeof def.description === "string") rebuilt = rebuilt.describe(def.description);
+    return rebuilt;
+  }
+
+  if (typeName === "ZodOptional") {
+    const inner = def.innerType;
+    const stripped = stripSensitiveOutputSchema(inner, fields);
+    return stripped === inner ? schema : z.optional(stripped as z.ZodTypeAny);
+  }
+
+  if (typeName === "ZodNullable") {
+    const inner = def.innerType;
+    const stripped = stripSensitiveOutputSchema(inner, fields);
+    return stripped === inner ? schema : z.nullable(stripped as z.ZodTypeAny);
+  }
+
+  // Primitives, unions, records, and anything else: leave untouched.
+  return schema;
+}
+
+/* ------------------------------------------------------------------ */
 /*  Resources excluded / redacted in OpenAI mode                       */
 /* ------------------------------------------------------------------ */
 
@@ -337,6 +408,14 @@ export function applyOpenAIProfile(server: any): void {
       for (const field of inputStrip) {
         delete config.inputSchema[field];
       }
+    }
+
+    // 4b. Strip sensitive fields from the OUTPUT schema descriptor too.
+    // The handler wrapper (step 5) redacts VALUES at runtime; this removes the
+    // field DECLARATIONS (taxId/secret/iban/…) from the outputSchema advertised
+    // at tools/list, so OpenAI review never sees a gov-ID/credential field.
+    if (config.outputSchema) {
+      config.outputSchema = stripSensitiveOutputSchema(config.outputSchema, fieldsToRedact);
     }
 
     // 5. Wrap handler to redact sensitive output fields

--- a/src/redaction.ts
+++ b/src/redaction.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared PII / credential redaction policy for the Frihet MCP server.
+ *
+ * Single source of truth for the set of field names that must never leave the
+ * process in cleartext — government IDs (NIF/CIF/VAT), banking identifiers,
+ * identity documents, webhook signing secrets, and auth tokens.
+ *
+ * Two consumers:
+ *   - openai-profile.ts — strips these from tool I/O in OpenAI-safe mode
+ *     (in-place DELETE of the live response the user receives).
+ *   - observability.ts  — redacts these from every Langfuse trace payload
+ *     (non-mutating CLONE) so an external observability service never stores a
+ *     taxId / secret / IBAN, regardless of profile mode.
+ *
+ * Zero runtime deps — safe in both Node.js (stdio) and Cloudflare Workers (edge).
+ */
+
+/** Sentinel left in place of a redacted value in cloned (tracing) payloads. */
+export const REDACTED = "[redacted]";
+
+/**
+ * Field names whose VALUES must never appear in logs, traces, or any surface
+ * outside the process boundary. Includes snake_case + locale synonyms because
+ * the Frihet API may return any of them via `.passthrough()` schemas.
+ */
+export const SENSITIVE_FIELD_NAMES: readonly string[] = [
+  "taxId", "tax_id",              // Primary field name + snake_case variant
+  "nif", "cif", "vatNumber",      // Spanish/EU synonyms for government tax ID
+  "vat_number", "vatId", "vat_id",
+  "secret",                       // Webhook signing credential
+  "iban", "bankAccount",          // Banking identifiers
+  "bank_account", "accountNumber",
+  "idDocument", "documentNumber", // Guest/customer government document fields
+  "passport", "passportNumber",
+  "dni", "nationalId", "national_id",
+  "ssn", "socialSecurityNumber", "social_security_number",
+  "apiKey", "api_key",
+  "accessToken", "access_token", "refreshToken", "refresh_token",
+  "password", "mfa", "otp",
+];
+
+/** Recursively removes named fields from an object/array tree, IN PLACE. */
+export function deepRedact(obj: unknown, fields: readonly string[] = SENSITIVE_FIELD_NAMES): void {
+  if (obj === null || typeof obj !== "object") return;
+
+  if (Array.isArray(obj)) {
+    for (const item of obj) deepRedact(item, fields);
+    return;
+  }
+
+  const record = obj as Record<string, unknown>;
+  for (const field of fields) {
+    if (field in record) delete record[field];
+  }
+  for (const value of Object.values(record)) {
+    deepRedact(value, fields);
+  }
+}
+
+/** Best-effort redaction of JSON field patterns from display / serialized text. */
+export function redactText(text: string, fields: readonly string[] = SENSITIVE_FIELD_NAMES): string {
+  let result = text;
+  for (const field of fields) {
+    // Remove "field": "value", or "field": value patterns
+    result = result.replace(
+      new RegExp(
+        `\\s*"${field}"\\s*:\\s*(?:"[^"]*"|null|true|false|\\d+(?:\\.\\d+)?)\\s*,?`,
+        "g",
+      ),
+      "",
+    );
+  }
+  // Clean up trailing commas before } or ] left by removals
+  return result.replace(/,(\s*[}\]])/g, "$1");
+}
+
+/**
+ * Returns a deep CLONE of `value` with sensitive field values replaced by the
+ * REDACTED sentinel (objects/arrays) and JSON field patterns stripped from any
+ * string leaf (covers the serialized MCP `content[].text` block).
+ *
+ * Unlike {@link deepRedact} this never mutates its argument — required for
+ * tracing, where the original object is the live response returned to the
+ * caller. A depth guard bounds pathological / cyclic structures.
+ */
+export function redactClone(
+  value: unknown,
+  fields: readonly string[] = SENSITIVE_FIELD_NAMES,
+  depth = 0,
+): unknown {
+  if (depth > 16) return REDACTED; // cycle / pathological-depth guard
+  if (typeof value === "string") return redactText(value, fields);
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map((v) => redactClone(v, fields, depth + 1));
+
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    out[k] = fields.includes(k) ? REDACTED : redactClone(v, fields, depth + 1);
+  }
+  return out;
+}

--- a/workers/remote-mcp/public/releases.json
+++ b/workers/remote-mcp/public/releases.json
@@ -3,7 +3,7 @@
   "languageCount": 17,
   "lastEmit": "2026-06-15T00:00:00.000Z",
   "manifestChecksum": "659abd5b9923ef22c1f1a5f0c8d5af0dd0c957c3bd7c3227e02f15fff20c64f3",
-  "mcpToolCount": 151,
+  "mcpToolCount": 157,
   "products": {
     "app": {
       "status": "live",
@@ -19,7 +19,7 @@
       "install": "npm install @frihet/mcp-server",
       "npm": "@frihet/mcp-server",
       "status": "live",
-      "version": "1.13.0"
+      "version": "1.14.3"
     },
     "sdk": {
       "install": "npm install @frihet/sdk",
@@ -28,9 +28,16 @@
       "version": "0.1.0"
     }
   },
-  "releasedAt": "2026-06-15",
-  "version": "1.13.0",
+  "releasedAt": "2026-06-22",
+  "version": "1.14.3",
   "releases": [
+    {
+      "version": "1.14.3",
+      "releasedAt": "2026-06-22",
+      "mcpToolCount": 157,
+      "delta": "Trust hardening: Langfuse PII redaction + OpenAI output-schema strip + metadata single-source",
+      "notes": "Sensitive fields (taxId/NIF/CIF, IBAN, webhook secrets, auth tokens) are now redacted before Langfuse tracing in every profile mode; OpenAI-mode output schema no longer declares government IDs/credentials; OAuth logs fingerprint uid/email; Worker version + tool count now single-sourced from package.json so root/health/metadata surfaces can no longer drift apart."
+    },
     {
       "version": "1.13.0",
       "releasedAt": "2026-06-15",

--- a/workers/remote-mcp/src/auth-handler.ts
+++ b/workers/remote-mcp/src/auth-handler.ts
@@ -12,6 +12,7 @@ import type { AuthRequest, OAuthHelpers } from "@cloudflare/workers-oauth-provid
 import { Hono } from "hono";
 import { getLoginPage } from "./login-page.js";
 import { log } from "../../../src/logger.js";
+import { MCP_SERVER_VERSION, FULL_TOOL_COUNT } from "./server-meta.js";
 
 type AuthEnv = Env & { OAUTH_PROVIDER: OAuthHelpers };
 
@@ -46,7 +47,7 @@ async function fingerprintPii(value: string | undefined): Promise<string> {
 app.get("/", (c) => {
   return c.json({
     name: "Frihet MCP Server",
-    version: "1.5.2",
+    version: MCP_SERVER_VERSION,
     description:
       "AI-native business management — invoices, expenses, clients, products, quotes",
     docs: "https://docs.frihet.io/desarrolladores/mcp-server",
@@ -58,7 +59,7 @@ app.get("/", (c) => {
       authorization_server:
         "https://mcp.frihet.io/.well-known/oauth-authorization-server",
     },
-    tools: 52,
+    tools: FULL_TOOL_COUNT,
     resources: 11,
     prompts: 10,
   });

--- a/workers/remote-mcp/src/auth-handler.ts
+++ b/workers/remote-mcp/src/auth-handler.ts
@@ -17,6 +17,28 @@ type AuthEnv = Env & { OAUTH_PROVIDER: OAuthHelpers };
 
 const app = new Hono<{ Bindings: AuthEnv }>();
 
+/**
+ * One-way SHA-256 fingerprint (first 12 hex) of a PII value for LOG lines only.
+ *
+ * The submission claims "No PII logged" — so uid/email must never appear in
+ * cleartext in logs. The raw values still flow where the protocol needs them
+ * (API-key provisioning body, OAuth session props); this only guards log output.
+ * Returns "none" for an absent value and "hash-error" if WebCrypto is missing.
+ */
+async function fingerprintPii(value: string | undefined): Promise<string> {
+  if (!value) return "none";
+  try {
+    const data = new TextEncoder().encode(value);
+    const buf = await crypto.subtle.digest("SHA-256", data);
+    return Array.from(new Uint8Array(buf))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("")
+      .slice(0, 12);
+  } catch {
+    return "hash-error";
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Public endpoints
 // ---------------------------------------------------------------------------
@@ -164,7 +186,7 @@ app.post("/callback", async (c) => {
   if (!apiKeyResponse.ok) {
     log({
       level: "error",
-      message: `OAuth callback: failed to provision API key for ${decoded.uid}`,
+      message: `OAuth callback: failed to provision API key for uid:${await fingerprintPii(decoded.uid)}`,
       operation: "oauth_callback",
       error: { message: `API key provisioning returned ${apiKeyResponse.status}`, statusCode: apiKeyResponse.status },
     });
@@ -192,9 +214,12 @@ app.post("/callback", async (c) => {
 
   log({
     level: "info",
-    message: `OAuth callback: success for ${decoded.email ?? decoded.uid}`,
+    message: `OAuth callback: success for uid:${await fingerprintPii(decoded.uid)}`,
     operation: "oauth_callback",
-    metadata: { userId: decoded.uid, email: decoded.email },
+    metadata: {
+      userId: await fingerprintPii(decoded.uid),
+      email: await fingerprintPii(decoded.email),
+    },
   });
 
   return c.json({ redirectTo });

--- a/workers/remote-mcp/src/index.ts
+++ b/workers/remote-mcp/src/index.ts
@@ -34,8 +34,7 @@ import { log } from "../../../src/logger.js";
 import { initLangfuse, setTraceContext } from "../../../src/observability.js";
 import { FrihetClient } from "./client.js";
 import { authHandler } from "./auth-handler.js";
-
-const MCP_SERVER_VERSION = "1.13.0";
+import { MCP_SERVER_VERSION, FULL_TOOL_COUNT } from "./server-meta.js";
 
 // ---------------------------------------------------------------------------
 // Auth props — stored in OAuth token, available via this.props in McpAgent
@@ -413,7 +412,7 @@ const WELL_KNOWN_JSONLD = JSON.stringify([
       "MIT licensed npm package",
       "Cloudflare Worker remote endpoint"
     ],
-    "softwareVersion": "1.13.0",
+    "softwareVersion": MCP_SERVER_VERSION,
     "license": "https://opensource.org/licenses/MIT",
     "codeRepository": "https://github.com/Frihet-io/frihet-mcp",
     "offers": {
@@ -481,7 +480,7 @@ const MCP_JSON = JSON.stringify({
   docs: "https://docs.frihet.io/desarrolladores/mcp-server",
   npm: "@frihet/mcp-server",
   install_local: "npx @frihet/mcp-server",
-  tools_count: 151,
+  tools_count: FULL_TOOL_COUNT,
   resources_count: 11,
   prompts_count: 10,
   registry: [
@@ -520,7 +519,7 @@ const WELL_KNOWN_MCP = JSON.stringify({
   docs: "https://docs.frihet.io/desarrolladores/mcp-server",
   npm: "@frihet/mcp-server",
   install_local: "npx @frihet/mcp-server",
-  tools_count: 151,
+  tools_count: FULL_TOOL_COUNT,
   resources_count: 11,
   prompts_count: 10,
   registry: [

--- a/workers/remote-mcp/src/server-meta.ts
+++ b/workers/remote-mcp/src/server-meta.ts
@@ -1,0 +1,24 @@
+/**
+ * Single source of truth for the Worker's advertised server metadata.
+ *
+ * Historically the version + tool count were hardcoded across several Worker
+ * surfaces (root `/`, `/health`, JSON-LD, `.well-known/mcp`, releases.json),
+ * which drifted apart (root said 1.5.2/52 while /health said 1.13.0). These
+ * constants give every surface ONE place to read from.
+ *
+ * MCP_SERVER_VERSION is derived from the published package.json so a single
+ * `npm version` bump propagates everywhere — it can never re-drift.
+ *
+ * @see feedback-frihet-mcp-drift-multi-sot-coverage-gap (memory)
+ */
+
+import pkg from "../../../package.json";
+
+/** The published @frihet/mcp-server version (single source: root package.json). */
+export const MCP_SERVER_VERSION: string = (pkg as { version: string }).version;
+
+/**
+ * Full MCP surface size: 151 business tools + 6 grouped discovery meta-tools.
+ * Mirrors the audit:mcp-refs SoT (count of registerTool calls across src/tools).
+ */
+export const FULL_TOOL_COUNT = 157;


### PR DESCRIPTION
Fixes the 4 real security/honesty defects from the Codex OpenAI-Apps audit (2026-06-22), independent of the OpenAI submission itself. All are Trust Area. Source: `reference-frihet-external-audits-gemini-codex-2026-06-22`.

## P0 — Langfuse stored raw PII before redaction (`observability.ts`)
The Langfuse tracer wraps the tool callback **innermost**, so it captured the RAW output BEFORE the OpenAI profile's redaction wrapper ran → taxId/NIF/CIF, IBAN, webhook secrets, auth tokens leaked into external traces in **every** profile mode. Fix moves redaction into observability itself (`buildTracePayload` runs `redactClone`/`redactText` before building the batch). New `src/redaction.ts` = single source of truth for the sensitive field set, shared with `openai-profile.ts`. Test asserts no sensitive value survives into the serialized payload on success + error paths, and that `redactClone` never mutates the live response.

## P0/P1 — OpenAI output **schema** still declared taxId/secret (`openai-profile.ts`)
Runtime redaction hid the values but the advertised `outputSchema` descriptor still **declared** taxId (clients/vendors) + secret (webhooks) at tools/list. `stripSensitiveOutputSchema` removes those declarations at every depth (incl. the paginated `data: array(item)` envelope), surgically — untouched branches return by reference so `describe()` metadata survives. Test walks every reviewed tool's Zod output schema and asserts no sensitive field is declared.

## P1 — OAuth logged raw uid/email (`workers/remote-mcp/src/auth-handler.ts`)
Callback logged `decoded.uid`/`decoded.email` in cleartext, contradicting the "No PII logged" claim. Replaced with a one-way SHA-256 fingerprint in all 3 log sites. Raw values still flow where the protocol needs them (provisioning body, OAuth props/label).

## P1 — Worker metadata drift (`workers/remote-mcp/*`)
Surfaces disagreed: root `/` = 1.5.2/52, /health + JSON-LD = 1.13.0, releases.json = 1.13.0/151, while the package is 1.14.3/157. New `server-meta.ts` derives `MCP_SERVER_VERSION` from `package.json` (a `npm version` bump can't re-drift) + `FULL_TOOL_COUNT`. releases.json current pointers refreshed (+1.14.3 entry; history intact). `audit:mcp-refs` now also scans `auth-handler.ts` — the root `/` surface that drifted was never in the audit list.

## Verification
- `npm test` → 342 pass / 0 fail (+6 new tests)
- worker `npm run typecheck` clean
- `npm run audit:mcp-refs --repo frihet-mcp` → OK, 1.14.3 / 157

**Deploy/republish (Worker + npm) is gated** — this lands code only. The live Langfuse leak + OpenAI descriptor + stale metadata are not remediated on the wire until Distribution deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)