### PR TITLE
release(mcp): 1.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `@frihet/mcp-server` are documented here.
 
+## [1.14.4] — 2026-06-22
+
+### Fixed
+
+- **`duplicate_invoice` no longer 400s on paid/sent invoices** (#47): it fetched the full raw stored invoice and spread it into the strict create schema, which rejects unknown keys (`payments`, `verifactu`, `operationType`, `poNumber`, …). Now it allowlist-picks only writable fields. Every paid/sent/cancelled/e-invoiced invoice was affected; a fresh draft duplicated fine.
+
+### Security (Trust)
+
+- **Langfuse traces no longer leak PII/credentials** (#46): the tracer captured raw tool output before the OpenAI redaction wrapper ran, so `taxId`/NIF/CIF, IBAN, webhook secrets, and auth tokens reached the external Langfuse service in every profile mode. Redaction now happens inside observability (shared `src/redaction.ts`) before the trace is built.
+- **OpenAI `outputSchema` no longer declares `taxId`/`secret`** (#46): the descriptor advertised government IDs/credentials even though runtime redacted the values; now stripped at every depth.
+- **OAuth callback fingerprints uid/email in logs** (#46), honoring "No PII logged".
+- **Worker version + tool count single-sourced** from `package.json` (#46) so root/health/metadata surfaces can no longer drift apart; `audit:mcp-refs` now scans `auth-handler.ts`.
+
 ## [1.14.3] — 2026-06-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 | **ChatGPT Apps** | Coming soon | [chatgpt.com](https://chatgpt.com) |
 | **Anthropic Claude Directory** | Coming soon | [claude.ai/settings/connectors](https://claude.ai/settings/connectors) |
 
-> **Tool count:** npm `latest` (1.14.3) ships all 157 tools, same as the remote endpoint (`mcp.frihet.io`).
+> **Tool count:** npm `latest` (1.14.4) ships all 157 tools, same as the remote endpoint (`mcp.frihet.io`).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@frihet/mcp-server",
-  "version": "1.14.3",
+  "version": "1.14.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@frihet/mcp-server",
-      "version": "1.14.3",
+      "version": "1.14.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frihet/mcp-server",
-  "version": "1.14.3",
+  "version": "1.14.4",
   "description": "AI-native MCP server for business management — invoices, expenses, deposits, clients, products, quotes, webhooks, CRM, e-invoicing (Facturae/XRechnung/Factur-X/FatturaPA/PEPPOL + FACe Spain B2G + TicketBAI Basque Country + KSeF Poland), vacation rentals, POS, banking, fiscal (Modelo 303/130/390/180/347/415/425/418, VeriFactu, TicketBAI, IS M200/M202), IGIC, AIEM, GL audit approval, white-label portal domain, VIES EU VAT lookup, bank rules, time tracking, recurring invoices, team management, gestoria. 157 tools. Remote endpoint at mcp.frihet.io (zero install). Works with Claude, Cursor, Windsurf, Cline.",
   "type": "module",
   "main": "./dist/index.js",

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/Frihet-io/frihet-mcp",
     "source": "github"
   },
-  "version": "1.14.3",
+  "version": "1.14.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@frihet/mcp-server",
-      "version": "1.14.3",
+      "version": "1.14.4",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Version bump + CHANGELOG for merged Trust + duplicate_invoice fixes (#46, #47). audit:mcp-refs OK, 344 tests. Publishing npm + deploying Workers after merge.