### PR TITLE
feat(invoices,quotes): expose ES fiscal fields the API already accepts (irpfRate etc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `@frihet/mcp-server` are documented here.
 
+## [1.14.5] — 2026-06-23
+
+### Added
+
+- **`create_invoice` / `update_invoice` expose the full ES fiscal field set the API already accepts.** The schemas previously only allowed `clientName/items/issueDate/dueDate/status/notes/taxRate`, so agents could not set `irpfRate` (retención IRPF — critical for Spanish autónomos), `equivalenceSurchargeRate`, `clientId`, `clientTaxId`, `clientAddress`, `clientLocation`, `prepayment`, `discountRate`, `seriesId`, `documentNumber`, `poNumber`, or `operationType`. The backend accepted all of these — the MCP Zod was just too narrow. No client/transport change (the HTTP client already passes fields through).
+- **`create_quote` / `update_quote` gain `clientId`, `clientTaxId`, `clientAddress`, `issueDate`, `dueDate`, `taxRate`, `irpfRate`, `equivalenceSurchargeRate`, `clientLocation`** for parity with the invoice subset the API supports on quotes.
+
 ## [1.14.4] — 2026-06-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 | **ChatGPT Apps** | Coming soon | [chatgpt.com](https://chatgpt.com) |
 | **Anthropic Claude Directory** | Coming soon | [claude.ai/settings/connectors](https://claude.ai/settings/connectors) |
 
-> **Tool count:** npm `latest` (1.14.4) ships all 157 tools, same as the remote endpoint (`mcp.frihet.io`).
+> **Tool count:** npm `latest` (1.14.5) ships all 157 tools, same as the remote endpoint (`mcp.frihet.io`).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frihet/mcp-server",
-  "version": "1.14.4",
+  "version": "1.14.5",
   "description": "AI-native MCP server for business management — invoices, expenses, deposits, clients, products, quotes, webhooks, CRM, e-invoicing (Facturae/XRechnung/Factur-X/FatturaPA/PEPPOL + FACe Spain B2G + TicketBAI Basque Country + KSeF Poland), vacation rentals, POS, banking, fiscal (Modelo 303/130/390/180/347/415/425/418, VeriFactu, TicketBAI, IS M200/M202), IGIC, AIEM, GL audit approval, white-label portal domain, VIES EU VAT lookup, bank rules, time tracking, recurring invoices, team management, gestoria. 157 tools. Remote endpoint at mcp.frihet.io (zero install). Works with Claude, Cursor, Windsurf, Cline.",
   "type": "module",
   "main": "./dist/index.js",

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/Frihet-io/frihet-mcp",
     "source": "github"
   },
-  "version": "1.14.4",
+  "version": "1.14.5",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@frihet/mcp-server",
-      "version": "1.14.4",
+      "version": "1.14.5",
       "transport": {
         "type": "stdio"
       }

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -13,6 +13,74 @@ const invoiceItemSchema = z.object({
   unitPrice: z.number().describe("Unit price in EUR / Precio unitario en EUR"),
 });
 
+// Optional client-identity fields the Frihet API accepts on invoice/quote
+// create+update. When clientId is supplied the server back-fills taxId/address
+// from the stored client; clientTaxId/clientAddress override per-document.
+const clientIdentityFields = {
+  clientId: z
+    .string()
+    .optional()
+    .describe("Existing client ID — server back-fills taxId/address / ID de cliente existente"),
+  clientTaxId: z
+    .string()
+    .optional()
+    .describe("Client tax ID (NIF/CIF/VAT) shown on the invoice / NIF/CIF del cliente"),
+  clientAddress: z
+    .string()
+    .optional()
+    .describe("Client billing address shown on the invoice / Direccion fiscal del cliente"),
+};
+
+// Optional Spanish fiscal fields the Frihet API accepts on invoice create+update.
+// irpfRate is the freelancer withholding (retencion IRPF) — critical for ES
+// autonomos; equivalenceSurchargeRate is recargo de equivalencia.
+const invoiceFiscalFields = {
+  irpfRate: z
+    .number()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe("IRPF withholding % (retencion autonomo ES, e.g. 15 or 7) / Retencion IRPF %"),
+  equivalenceSurchargeRate: z
+    .number()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe("Recargo de equivalencia % (ES retail regime) / Recargo de equivalencia %"),
+  clientLocation: z
+    .enum(["peninsula", "canarias", "ceuta_melilla", "eu", "world"])
+    .optional()
+    .describe("Fiscal zone driving IVA vs IGIC vs exempt / Zona fiscal (IVA/IGIC/exento)"),
+  prepayment: z
+    .number()
+    .min(0)
+    .optional()
+    .describe("Prepaid/advance amount already collected in EUR / Anticipo cobrado en EUR"),
+  discountRate: z
+    .number()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe("Global discount % applied to the invoice / Descuento global %"),
+  seriesId: z
+    .string()
+    .optional()
+    .describe("Invoice numbering series ID / ID de serie de numeracion"),
+  documentNumber: z
+    .string()
+    .max(50)
+    .optional()
+    .describe("Externally-issued number for import (honored verbatim) / Numero externo para importacion"),
+  poNumber: z
+    .string()
+    .optional()
+    .describe("Client purchase-order reference / Numero de pedido del cliente"),
+  operationType: z
+    .enum(["service", "goods"])
+    .optional()
+    .describe("Operation type (service or goods) / Tipo de operacion"),
+};
+
 export function registerInvoiceTools(server: McpServer, client: IFrihetClient): void {
   // -- list_invoices --
 
@@ -116,12 +184,14 @@ export function registerInvoiceTools(server: McpServer, client: IFrihetClient): 
       description:
         "Create a new invoice. Requires client name and at least one line item. " +
         "The invoice number is auto-generated. Defaults to draft status and today's date. " +
-        "Example: clientName='Acme Corp', items=[{description:'Consulting', quantity:10, unitPrice:150}], taxRate=21 " +
+        "Example: clientName='Acme Corp', items=[{description:'Consulting', quantity:10, unitPrice:150}], taxRate=21, irpfRate=15 " +
         "/ Crea una nueva factura. Requiere nombre del cliente y al menos un concepto. " +
-        "El numero se genera automaticamente. Por defecto estado borrador y fecha de hoy.",
+        "El numero se genera automaticamente. Por defecto estado borrador y fecha de hoy. " +
+        "Soporta retencion IRPF (autonomos ES), recargo de equivalencia, serie, anticipo y descuento global.",
       annotations: CREATE_ANNOTATIONS,
       inputSchema: {
         clientName: z.string().describe("Client/customer name / Nombre del cliente"),
+        ...clientIdentityFields,
         items: z
           .array(invoiceItemSchema)
           .min(1)
@@ -148,6 +218,7 @@ export function registerInvoiceTools(server: McpServer, client: IFrihetClient): 
           .max(100)
           .optional()
           .describe("Tax rate percentage (e.g. 21 for 21% IVA, 7 for IGIC) / Porcentaje de impuesto"),
+        ...invoiceFiscalFields,
       },
       outputSchema: invoiceItemOutput,
     },
@@ -175,6 +246,7 @@ export function registerInvoiceTools(server: McpServer, client: IFrihetClient): 
       inputSchema: {
         id: z.string().describe("Invoice ID / ID de la factura"),
         clientName: z.string().optional().describe("Client name / Nombre del cliente"),
+        ...clientIdentityFields,
         items: z
           .array(invoiceItemSchema)
           .min(1)
@@ -188,6 +260,7 @@ export function registerInvoiceTools(server: McpServer, client: IFrihetClient): 
           .describe("Invoice status / Estado"),
         notes: z.string().optional().describe("Notes / Notas"),
         taxRate: z.number().min(0).max(100).optional().describe("Tax rate % / IVA %"),
+        ...invoiceFiscalFields,
       },
       outputSchema: invoiceItemOutput,
     },

--- a/src/tools/quotes.ts
+++ b/src/tools/quotes.ts
@@ -13,6 +13,53 @@ const quoteItemSchema = z.object({
   unitPrice: z.number().describe("Unit price in EUR / Precio unitario en EUR"),
 });
 
+// Optional client-identity + ES fiscal fields the Frihet API accepts on quote
+// create+update (mirrors the invoice subset the backend supports for quotes).
+const quoteOptionalFields = {
+  clientId: z
+    .string()
+    .optional()
+    .describe("Existing client ID — server back-fills taxId/address / ID de cliente existente"),
+  clientTaxId: z
+    .string()
+    .optional()
+    .describe("Client tax ID (NIF/CIF/VAT) / NIF/CIF del cliente"),
+  clientAddress: z
+    .string()
+    .optional()
+    .describe("Client billing address / Direccion fiscal del cliente"),
+  issueDate: z
+    .string()
+    .optional()
+    .describe("Issue date in ISO 8601 (YYYY-MM-DD), defaults to today / Fecha de emision"),
+  dueDate: z
+    .string()
+    .optional()
+    .describe("Due date in ISO 8601 (YYYY-MM-DD) / Fecha de vencimiento"),
+  taxRate: z
+    .number()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe("Tax rate % (e.g. 21 IVA, 7 IGIC) / Porcentaje de impuesto"),
+  irpfRate: z
+    .number()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe("IRPF withholding % (retencion autonomo ES) / Retencion IRPF %"),
+  equivalenceSurchargeRate: z
+    .number()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe("Recargo de equivalencia % / Recargo de equivalencia %"),
+  clientLocation: z
+    .enum(["peninsula", "canarias", "ceuta_melilla", "eu", "world"])
+    .optional()
+    .describe("Fiscal zone driving IVA vs IGIC vs exempt / Zona fiscal"),
+};
+
 export function registerQuoteTools(server: McpServer, client: IFrihetClient): void {
   // -- list_quotes --
 
@@ -110,6 +157,7 @@ export function registerQuoteTools(server: McpServer, client: IFrihetClient): vo
       annotations: CREATE_ANNOTATIONS,
       inputSchema: {
         clientName: z.string().describe("Client name / Nombre del cliente"),
+        ...quoteOptionalFields,
         items: z
           .array(quoteItemSchema)
           .min(1)
@@ -150,6 +198,7 @@ export function registerQuoteTools(server: McpServer, client: IFrihetClient): vo
       inputSchema: {
         id: z.string().describe("Quote ID / ID del presupuesto"),
         clientName: z.string().optional().describe("Client name / Nombre del cliente"),
+        ...quoteOptionalFields,
         items: z.array(quoteItemSchema).min(1).optional().describe("Line items / Conceptos"),
         validUntil: z.string().optional().describe("Expiry date (YYYY-MM-DD) / Fecha de validez"),
         notes: z.string().optional().describe("Notes / Notas"),


### PR DESCRIPTION
## Fase 0.4 — MCP schema widen

The create/update invoice + quote Zod schemas only allowed a thin subset (\`clientName/items/dates/status/notes/taxRate\`), so agents could not set fields the Frihet API has long accepted — most importantly **\`irpfRate\`** (retención IRPF, critical for Spanish autónomos like the owner), plus \`equivalenceSurchargeRate\`, \`clientId/clientTaxId/clientAddress\`, \`clientLocation\`, \`prepayment\`, \`discountRate\`, \`seriesId\`, \`documentNumber\`, \`poNumber\`, \`operationType\`.

Same root cause as the recent backend "schema too narrow" fix — the MCP layer was the gate. The HTTP client passes \`Record<string,unknown>\` through, so **no client or transport change**, only the input Zod widens. Shared field consts keep create/update in sync.

Quotes get the subset the API supports on quotes (client identity + dates + taxRate + irpfRate + equivalenceSurchargeRate + clientLocation).

Bump 1.14.4 → 1.14.5. Build clean, 344/344 tests pass. Republish npm + worker redeploy gated on owner order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)