### PR TITLE
feat(cursor): add Cursor plugin marketplace manifest

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "frihet",
+  "owner": {
+    "name": "Frihet",
+    "email": "support@frihet.io"
+  },
+  "metadata": {
+    "description": "AI-native ERP for Spain & the EU — invoicing, CRM, banking and fiscal compliance through natural language.",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "frihet-erp",
+      "source": "./plugins/frihet-erp",
+      "description": "Connect Cursor to your Frihet ERP — 157 tools for invoicing, expenses, CRM, banking and Spanish/EU fiscal compliance (VeriFactu, TicketBAI, Facturae)."
+    }
+  ]
+}

--- a/plugins/frihet-erp/.cursor-plugin/plugin.json
+++ b/plugins/frihet-erp/.cursor-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "frihet-erp",
+  "displayName": "Frihet ERP",
+  "version": "1.0.0",
+  "description": "AI-native ERP for Spain & the EU. Talk to your business from Cursor: create invoices, log expenses, manage clients, check cash flow and prepare quarterly taxes — 157 tools over the Frihet MCP server, with native VeriFactu / TicketBAI / Facturae compliance.",
+  "author": {
+    "name": "Frihet",
+    "email": "support@frihet.io"
+  },
+  "license": "MIT",
+  "keywords": [
+    "erp",
+    "invoicing",
+    "accounting",
+    "spain",
+    "fiscal",
+    "verifactu",
+    "ticketbai",
+    "facturae",
+    "mcp",
+    "finance",
+    "tax"
+  ],
+  "logo": "assets/logo.svg"
+}

--- a/plugins/frihet-erp/README.md
+++ b/plugins/frihet-erp/README.md
@@ -1,0 +1,48 @@
+# Frihet ERP — Cursor plugin
+
+Talk to your business from inside Cursor. Create invoices, log expenses, manage
+clients, check cash flow and prepare quarterly taxes in natural language — backed
+by the [Frihet](https://frihet.io) AI-native ERP.
+
+## Included
+
+- `mcp.json` — the Frihet MCP server (157 tools: invoicing, expenses, CRM, products,
+  quotes, deposits, banking, fiscal compliance, e-invoicing, POS, stay/PMS, HR/payroll).
+- `rules/frihet-fiscal.mdc` — Spanish & EU fiscal context so the agent picks the right
+  VAT/IGIC rate, IRPF retención and tax model.
+- `assets/logo.svg` — marketplace logo.
+
+## Setup
+
+1. Get an API key: log into [app.frihet.io](https://app.frihet.io) → **Settings → API → Create API key** (starts with `fri_`).
+2. Set `FRIHET_API_KEY` in your environment. The bundled `mcp.json` reads it via `${FRIHET_API_KEY}`.
+
+That's it — `npx @frihet/mcp-server` runs locally over stdio.
+
+### Remote (zero install)
+
+Prefer no local process? Point at the hosted endpoint instead of the npx command:
+
+```json
+{
+  "mcpServers": {
+    "frihet": {
+      "type": "streamable-http",
+      "url": "https://mcp.frihet.io/mcp",
+      "headers": { "Authorization": "Bearer fri_your_key_here" }
+    }
+  }
+}
+```
+
+Clients that support OAuth 2.1 + PKCE (browser login, no key) can connect to
+`https://mcp.frihet.io/mcp` directly.
+
+## Links
+
+- Product: <https://frihet.io>
+- Docs: <https://docs.frihet.io/desarrolladores/mcp-server>
+- npm: [`@frihet/mcp-server`](https://www.npmjs.com/package/@frihet/mcp-server)
+- Source: <https://github.com/Frihet-io/frihet-mcp>
+
+MIT licensed.

--- a/plugins/frihet-erp/assets/logo.svg
+++ b/plugins/frihet-erp/assets/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" role="img" aria-label="Frihet">
+  <rect width="500" height="500" fill="#ffffff"/>
+  <circle cx="250" cy="250" r="172" fill="#171717"/>
+</svg>

--- a/plugins/frihet-erp/mcp.json
+++ b/plugins/frihet-erp/mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "frihet": {
+      "command": "npx",
+      "args": ["-y", "@frihet/mcp-server"],
+      "env": {
+        "FRIHET_API_KEY": "${FRIHET_API_KEY}"
+      }
+    }
+  }
+}

--- a/plugins/frihet-erp/rules/frihet-fiscal.mdc
+++ b/plugins/frihet-erp/rules/frihet-fiscal.mdc
@@ -1,0 +1,14 @@
+---
+description: Spanish & EU fiscal context for operating the Frihet ERP MCP tools correctly
+alwaysApply: false
+---
+
+Apply this when using the Frihet MCP tools for invoicing, expenses or tax.
+
+- **VAT (IVA):** mainland Spain uses 21% (general), 10% (reduced), 4% (super-reduced). Pick the rate per line item, not per invoice.
+- **Canary Islands:** use **IGIC** (general 7%), not IVA. Ceuta & Melilla use IPSI. Frihet applies the right zone rate automatically — set the client's region.
+- **IRPF retención:** Spanish freelancers may apply professional withholding (15%, or 7% for newly registered). Do not add it for non-Spanish clients.
+- **EU B2B:** reverse-charge / intra-community supplies need a VAT number validated via VIES (`frihet_tax_id_vies_lookup`). Never invent a NIF/CIF/IBAN — ask or look it up.
+- **Compliance is automatic:** VeriFactu (state), TicketBAI (Basque Country) and Facturae/FACe (B2G) are handled by Frihet on issue. Don't fabricate fiscal identifiers or submission acks — read the real status with the `verifactu_status` / `ticketbai_status` / `face_status` tools.
+- **Tax models:** Modelo 303 (quarterly IVA), 130 (quarterly IRPF), 390 (annual IVA), 347 (third parties > €3,005). Use the `get_modelo_*_summary` tools rather than computing by hand.
+- **Confirm before destructive actions** (delete, refund, mark-paid). These mutate real business records.


### PR DESCRIPTION
## What
Adds the [Cursor plugin-template](https://github.com/cursor/plugin-template) structure so this repo is submittable to the **Cursor plugin marketplace**. The publisher/org application was sent 2026-06-23 (pending review at marketplace-publishing@cursor.com); this is the per-plugin structure their review expects.

## Files
```
.cursor-plugin/marketplace.json              # marketplace listing (owner: Frihet)
plugins/frihet-erp/
  .cursor-plugin/plugin.json                 # plugin manifest (name, logo, keywords)
  mcp.json                                    # Frihet MCP server — npx stdio + ${FRIHET_API_KEY}
  rules/frihet-fiscal.mdc                     # ES/EU fiscal context (IVA/IGIC/IRPF, VeriFactu…)
  assets/logo.svg                             # white-plate brand mark
  README.md                                   # setup + remote (mcp.frihet.io) option
```

## Validation
Passes Cursor's own `scripts/validate-template.mjs` → **Validation passed** (only the benign "no hooks/hooks.json" optional warning).

Additive only — no existing files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)