### PR TITLE
fix(remote-mcp): provision OAuth API key against CF origin, not api.frihet.io (522 worker→worker)

### DIFF
--- a/workers/remote-mcp/package.json
+++ b/workers/remote-mcp/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --experimental-strip-types --test 'src/__tests__/*.test.ts'"
   },
   "dependencies": {
     "@cloudflare/workers-oauth-provider": "^0.3.0",

--- a/workers/remote-mcp/src/__tests__/oauth-url.test.ts
+++ b/workers/remote-mcp/src/__tests__/oauth-url.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Regression test for the OAuth API-key provisioning URL derivation.
+ *
+ * Bug (26-jun-2026): auth-handler used `${FRIHET_API_BASE}/oauth/api-key` raw.
+ * With FRIHET_API_BASE = "https://api.frihet.io/v1" (the form the main client
+ * also accepts), this produced "https://api.frihet.io/v1/oauth/api-key", which
+ * does NOT match the provisioning route → the Firebase Bearer token is rejected
+ * as an invalid API key (401) → worker returns 500 "Failed to provision API key"
+ * for EVERY remote-OAuth connection. resolveOAuthApiKeyUrl strips the trailing
+ * /v1 so the call always lands on the API origin root.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveOAuthApiKeyUrl } from "../api-url.ts";
+
+const EXPECTED = "https://api.frihet.io/oauth/api-key";
+
+test("resolveOAuthApiKeyUrl strips /v1 suffix (the production bug)", () => {
+  assert.equal(resolveOAuthApiKeyUrl("https://api.frihet.io/v1"), EXPECTED);
+});
+
+test("resolveOAuthApiKeyUrl accepts origin form", () => {
+  assert.equal(resolveOAuthApiKeyUrl("https://api.frihet.io"), EXPECTED);
+});
+
+test("resolveOAuthApiKeyUrl tolerates trailing slashes", () => {
+  assert.equal(resolveOAuthApiKeyUrl("https://api.frihet.io/v1/"), EXPECTED);
+  assert.equal(resolveOAuthApiKeyUrl("https://api.frihet.io/"), EXPECTED);
+});
+
+test("resolveOAuthApiKeyUrl falls back to the CF origin (NOT api.frihet.io) when unset", () => {
+  // The fallback must be the direct Cloud Function origin: a worker→api.frihet.io
+  // subrequest (same Cloudflare zone) returns 522, breaking provisioning.
+  const cfFallback =
+    "https://europe-west1-gen-lang-client-0335716041.cloudfunctions.net/publicApi/api/oauth/api-key";
+  assert.equal(resolveOAuthApiKeyUrl(undefined), cfFallback);
+  assert.equal(resolveOAuthApiKeyUrl(""), cfFallback);
+  // api.frihet.io must never be the resolved origin (the 522 trap)
+  assert.ok(!resolveOAuthApiKeyUrl(undefined).includes("api.frihet.io"));
+});
+
+test("resolveOAuthApiKeyUrl only strips a /v1 SEGMENT, not substrings", () => {
+  // a host literally containing v1 must not be mangled
+  assert.equal(
+    resolveOAuthApiKeyUrl("https://api-v1.frihet.io"),
+    "https://api-v1.frihet.io/oauth/api-key",
+  );
+});

--- a/workers/remote-mcp/src/api-url.ts
+++ b/workers/remote-mcp/src/api-url.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure URL-derivation helpers for the Frihet API base.
+ *
+ * Dependency-free on purpose: both the request client (src/client.ts) and the
+ * OAuth auth handler (src/auth-handler.ts) consume these, and the regression
+ * test imports them directly via `node --test` without pulling in the full
+ * base-client chain.
+ *
+ * ⚠️ FRIHET_API_BASE MUST point at the Cloud Function origin directly
+ * (`https://<region>-<project>.cloudfunctions.net/publicApi/api`), NOT at
+ * `https://api.frihet.io`. Both this worker (mcp.frihet.io) and the API proxy
+ * (api.frihet.io) live on the SAME Cloudflare zone — a Worker→same-zone-Worker
+ * subrequest returns HTTP 522 (connection refused, ~140ms), so every API call
+ * (tool calls AND OAuth provisioning) fails when the base is api.frihet.io.
+ * The api proxy's own upstream (workers/api-proxy/wrangler.toml
+ * FRIHET_UPSTREAM_URL) is the canonical value. Verified live 26-jun-2026.
+ */
+
+/**
+ * Cloud Function origin — fallback when FRIHET_API_BASE is unset. Mirrors
+ * workers/api-proxy FRIHET_UPSTREAM_URL. NOT api.frihet.io (see header note).
+ */
+const DEFAULT_API_BASE =
+  "https://europe-west1-gen-lang-client-0335716041.cloudfunctions.net/publicApi/api";
+
+/**
+ * Normalize FRIHET_API_BASE into the /v1 base URL the request client expects.
+ * Accepts both the origin form ("https://api.frihet.io") and the full
+ * form ("https://api.frihet.io/v1"); trailing slashes are stripped.
+ * Returns undefined for empty/missing input so the root default applies.
+ */
+export function resolveApiBaseUrl(apiBase?: string): string | undefined {
+  if (!apiBase) return undefined;
+  const trimmed = apiBase.replace(/\/+$/, "");
+  if (trimmed === "") return undefined;
+  return trimmed.endsWith("/v1") ? trimmed : `${trimmed}/v1`;
+}
+
+/**
+ * Build the OAuth API-key provisioning URL from FRIHET_API_BASE.
+ *
+ * The provisioning endpoint lives at the API ORIGIN ROOT
+ * (`https://api.frihet.io/oauth/api-key`), NOT under `/v1`. FRIHET_API_BASE
+ * may be configured in either the origin form ("https://api.frihet.io") or
+ * the full form ("https://api.frihet.io/v1"); the auth handler must strip a
+ * trailing `/v1` segment before appending `/oauth/api-key`, otherwise it hits
+ * `/v1/oauth/api-key` which does NOT match the provisioning route and the
+ * Firebase Bearer token is rejected as an invalid API key (HTTP 401) →
+ * "Failed to provision API key" for every OAuth connection.
+ *
+ * Falls back to the production origin when the env var is absent.
+ */
+export function resolveOAuthApiKeyUrl(apiBase?: string): string {
+  const trimmed = (apiBase || DEFAULT_API_BASE).replace(/\/+$/, "");
+  const origin = trimmed.replace(/\/v1$/, "");
+  return `${origin}/oauth/api-key`;
+}

--- a/workers/remote-mcp/src/auth-handler.ts
+++ b/workers/remote-mcp/src/auth-handler.ts
@@ -10,6 +10,7 @@
 
 import type { AuthRequest, OAuthHelpers } from "@cloudflare/workers-oauth-provider";
 import { Hono } from "hono";
+import { resolveOAuthApiKeyUrl } from "./api-url.js";
 import { getLoginPage } from "./login-page.js";
 import { log } from "../../../src/logger.js";
 import { MCP_SERVER_VERSION, FULL_TOOL_COUNT } from "./server-meta.js";
@@ -171,9 +172,13 @@ app.post("/callback", async (c) => {
     return c.json({ error: "Invalid Firebase token" }, 401);
   }
 
-  // Provision an API key for this user via the Frihet Cloud Function
+  // Provision an API key for this user via the Frihet Cloud Function.
+  // The provisioning endpoint lives at the API ORIGIN ROOT, never under /v1 —
+  // resolveOAuthApiKeyUrl strips a trailing /v1 so a FRIHET_API_BASE configured
+  // in either form (origin or /v1) resolves correctly. Passing the raw env var
+  // with a /v1 suffix produced /v1/oauth/api-key → 401 → 500 for every OAuth grant.
   const apiKeyResponse = await fetch(
-    `${c.env.FRIHET_API_BASE}/oauth/api-key`,
+    resolveOAuthApiKeyUrl(c.env.FRIHET_API_BASE),
     {
       method: "POST",
       headers: {

--- a/workers/remote-mcp/src/client.ts
+++ b/workers/remote-mcp/src/client.ts
@@ -21,25 +21,14 @@ import {
   FrihetClient as BaseFrihetClient,
   FrihetApiError,
 } from "../../../src/client.js";
+import { resolveApiBaseUrl } from "./api-url.js";
 
 export { FrihetApiError };
+export { resolveApiBaseUrl, resolveOAuthApiKeyUrl } from "./api-url.js";
 export type { PaginatedResponse, ApiError } from "../../../src/types.js";
 
 /** Workers have a ~30s wall-clock limit — keep requests under it. */
 const WORKER_REQUEST_TIMEOUT_MS = 25000;
-
-/**
- * Normalize FRIHET_API_BASE into the /v1 base URL the client expects.
- * Accepts both the origin form ("https://api.frihet.io") and the full
- * form ("https://api.frihet.io/v1"); trailing slashes are stripped.
- * Returns undefined for empty/missing input so the root default applies.
- */
-export function resolveApiBaseUrl(apiBase?: string): string | undefined {
-  if (!apiBase) return undefined;
-  const trimmed = apiBase.replace(/\/+$/, "");
-  if (trimmed === "") return undefined;
-  return trimmed.endsWith("/v1") ? trimmed : `${trimmed}/v1`;
-}
 
 export class FrihetClient extends BaseFrihetClient {
   constructor(apiKey: string, baseUrl?: string) {

--- a/workers/remote-mcp/tsconfig.json
+++ b/workers/remote-mcp/tsconfig.json
@@ -24,5 +24,5 @@
     "../../src/logger.ts",
     "../../src/metrics.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/__tests__/**"]
 }


### PR DESCRIPTION
## Problem

Connecting Claude via the **remote MCP OAuth flow** (`mcp.frihet.io`) failed for **every** user with *"Failed to provision API key"* / *"Firebase authentication expired"*. Reported by a customer (Google-SSO account, so "reset password" was a red herring — they have no password).

## Root cause (both verified live 26-jun-2026)

1. **Worker→same-zone-worker subrequest returns HTTP 522.** `mcp.frihet.io` and `api.frihet.io` are both Cloudflare Workers on the same zone. A `fetch()` from one to the other 522s (~140ms). `FRIHET_API_BASE` was an `api.frihet.io` form, so **both tool calls and OAuth provisioning** (`auth-handler.ts` POST to `${FRIHET_API_BASE}/oauth/api-key`) 522'd. `wrangler tail` showed `API key provisioning returned 522`. **External `curl` returns 200 — only the worker→worker hop fails**, which masks the bug.
2. The provisioning endpoint lives at the **API origin root** (`/oauth/api-key`), never under `/v1` (CF matches `req.path === '/api/oauth/api-key'`). The handler used the raw env var → a `/v1`-suffixed base produced `/v1/oauth/api-key` → 401.

## Prod fix (already applied, no code deploy)

`FRIHET_API_BASE` secret on `frihet-remote-mcp` flipped to the direct CF origin (`…cloudfunctions.net/publicApi/api`, == the api-proxy's own `FRIHET_UPSTREAM_URL`), bypassing the 522 hop. Secrets propagate without redeploy.

## This PR — durable hardening

- Extract `resolveApiBaseUrl` + new **`resolveOAuthApiKeyUrl`** into dependency-free `api-url.ts`. `resolveOAuthApiKeyUrl` strips a trailing `/v1` segment and appends `/oauth/api-key`; its fallback is the CF origin, **never `api.frihet.io`**.
- `auth-handler.ts` derives the provisioning URL via the helper.
- Regression test (`npm test`, `node --test`, 5 cases incl. the `/v1` trap + the 522 fallback). Typecheck clean.

## Verified live E2E

`register → /authorize → /callback 200 → /token 200 → MCP initialize 200 → tools/call list_clients 200 ("Found 55 clients")`.

## Follow-ups (not in this PR)

- ⚠️ **Twin worker** `frihet-openai-mcp` (`openai-mcp.frihet.io`) shares this source but has its **own** `FRIHET_API_BASE` secret — needs the same flip if deployed (audit in progress).
- `MAX_ACTIVE_KEYS_PER_USER=5`: each OAuth grant mints a new key; repeated reconnects → 429 → opaque 500. Consider reuse/prune or higher cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)