### PR TITLE
fix(openai): harden ChatGPT submission metadata

### DIFF
--- a/docs/openai-resubmission-guide.md
+++ b/docs/openai-resubmission-guide.md
@@ -10,7 +10,7 @@
 | 2 | openWorldHint wrong | **DONE** | 4 tools corrected + justifications |
 | 3 | Test cases failing | **READY** | 15 test cases documented |
 | 4 | Privacy policy gaps | **DONE** | Section 10 added (11 sections, 17 langs) |
-| 5 | Sensitive data collection | **DONE** | OpenAI allowlist enforced: 53 reviewed tools, prompts hidden, restricted fields redacted |
+| 5 | Sensitive data collection | **DONE** | OpenAI allowlist enforced: 53 reviewed business tools + 3 read-only discovery meta-tools, prompts hidden, restricted fields redacted |
 
 ---
 
@@ -81,7 +81,7 @@ Justifications are embedded in tool descriptions as `[openWorldHint: true — ..
 
 ### OpenAI-visible tool surface
 
-OpenAI mode now enforces an explicit allowlist of 53 reviewed tools. The full MCP server can keep growing for Claude, Cursor, Windsurf, Cline, Codex, and direct MCP clients without automatically broadening the ChatGPT submission surface.
+OpenAI mode now enforces an explicit allowlist of 53 reviewed business tools. The live grouped ChatGPT surface also includes 3 read-only discovery meta-tools (`list_tool_groups`, `search_tools`, `describe_tool`) whose catalog is pinned to that same 53-tool allowlist. The full MCP server can keep growing for Claude, Cursor, Windsurf, Cline, Codex, and direct MCP clients without automatically broadening the ChatGPT submission surface.
 
 Hidden from OpenAI mode:
 - Payroll, HR, stay/PMS, POS, banking, e-invoicing XML, VIES lookup, VeriFactu/FACe/TicketBAI/KSeF submission, time tracking, recurring invoices, gestoria bulk-send, permissions, onboarding, and period-close tools.
@@ -102,13 +102,14 @@ Hidden from OpenAI mode:
 | `secret` | structuredContent + display text |
 | `idDocument` / `passport` / `dni` / `nationalId` | structuredContent + display text |
 | `apiKey` / tokens / password-like fields | structuredContent + display text |
+| `requestId` / `traceId` / `sessionId` / `userId` / `verifactuHash` | structuredContent + display text |
 
 Deep recursive redaction ensures nested objects and paginated arrays are clean.
 
 ### Regression test
 
 `npm test` now includes `dist/__tests__/openai-profile.test.js`, which asserts:
-- OpenAI mode exposes exactly 53 tools.
+- OpenAI mode exposes 56 total tools: 53 reviewed business tools + 3 read-only discovery meta-tools.
 - OpenAI mode exposes 0 prompts.
 - Sensitive/newer full-server tools are not visible.
 - Only `send_invoice`, `send_quote`, `create_webhook`, and `update_webhook` have `openWorldHint: true`.
@@ -192,7 +193,8 @@ curl -s https://www.frihet.io/en/privacy | grep -c "AI, API, and Developer"
 │  │ mcp.frihet.io│  │openai-mcp.     │   │
 │  │ (full)       │  │frihet.io       │   │
 │  │              │  │(OpenAI-safe)   │   │
-│  │ Full surface │  │ 53 tools       │   │
+│  │ Full surface │  │ 53 business    │   │
+│  │              │  │ + 3 discovery  │   │
 │  │ All fields   │  │ No taxId       │   │
 │  │ All data     │  │ No secret      │   │
 │  │              │  │ No quarterly   │   │
@@ -206,6 +208,6 @@ curl -s https://www.frihet.io/en/privacy | grep -c "AI, API, and Developer"
 │                                         │
 │  Same codebase, same Worker, same DO    │
 │  Difference: FRIHET_OPENAI_MODE=true    │
-│  + explicit 53-tool allowlist           │
+│  + explicit 53-tool business allowlist  │
 └─────────────────────────────────────────┘
 ```

--- a/docs/openai-test-cases.md
+++ b/docs/openai-test-cases.md
@@ -6,7 +6,7 @@
 ## Prerequisites
 
 - Deploy `openai-mcp.frihet.io` with `FRIHET_OPENAI_MODE=true`
-- Verify OpenAI mode exposes exactly 53 tools and 0 prompts
+- Verify OpenAI mode exposes 53 reviewed business tools + 3 read-only discovery meta-tools and 0 prompts
 - Demo API key with sample data: invoices, expenses, clients, vendors, products, quotes
 - Demo account must NOT require MFA or additional signup
 
@@ -208,7 +208,9 @@
 - `invite_team_member`
 - All MCP prompts
 
-**Verification:** Use `list_tools` / `list_prompts` or check the MCP session. OpenAI mode must expose exactly 53 tools and 0 prompts.
+**Expected PRESENT discovery tools:** `list_tool_groups`, `search_tools`, `describe_tool`.
+
+**Verification:** Use `list_tools` / `list_prompts` or check the MCP session. OpenAI mode must expose 56 total tools: 53 reviewed business tools + the 3 read-only discovery meta-tools above, and 0 prompts.
 
 ---
 
@@ -243,4 +245,4 @@
 | 14 | Excluded tools | Quarterly taxes + e-invoice absent |
 | 15 | Search | Pagination + text search |
 
-**Total: 53 tools available, 0 prompts, full-server tools hidden by allowlist, 0 government IDs in I/O, 0 credentials leaked.**
+**Total: 56 tools available (53 reviewed business tools + 3 read-only discovery meta-tools), 0 prompts, full-server tools hidden by allowlist, 0 government IDs in I/O, 0 credentials leaked.**

--- a/docs/openai-tool-justifications.md
+++ b/docs/openai-tool-justifications.md
@@ -1,6 +1,6 @@
 # OpenAI Tool Justifications — Copy-Paste Reference
 
-53 tools, 3 justifications each. Copy the text for each tool.
+53 reviewed business tools, 3 justifications each. The live ChatGPT surface also includes 3 read-only discovery meta-tools (`list_tool_groups`, `search_tools`, `describe_tool`) whose catalog is pinned to these 53 tools.
 
 ---
 
@@ -92,9 +92,9 @@ All these share the same justifications:
 
 ## EXCLUDED / HIDDEN TOOLS
 
-OpenAI mode uses an explicit allowlist of the 53 tools above. Everything else in the full MCP server is hidden from the ChatGPT app submission surface, including payroll, HR, stay/PMS, POS, banking, e-invoicing XML, VIES lookup, VeriFactu/FACe/TicketBAI/KSeF submission, time tracking, recurring invoices, gestoria bulk-send, permissions, onboarding, period-close tools, and all MCP prompts.
+OpenAI mode uses an explicit allowlist of the 53 business tools above. Everything else in the full MCP server is hidden from the ChatGPT app submission surface, including payroll, HR, lodging/POS, banking, e-invoicing, regulated filing/export workflows, time tracking, recurring invoices, gestoría bulk-send, permissions, onboarding, period-close tools, and all MCP prompts.
 
 Explicit defense-in-depth exclusions:
 
 - `get_quarterly_taxes` — returns tax filing data with government identifiers
-- `get_invoice_einvoice` — returns e-invoice XML with NIF/CIF
+- `get_invoice_einvoice` — returns e-invoice XML with regulated identifiers

--- a/marketplace/openai/SUBMISSION.md
+++ b/marketplace/openai/SUBMISSION.md
@@ -42,7 +42,9 @@ Frihet connects ChatGPT directly to your business workspace.
 
 Create invoices by describing what you sold. Log expenses in plain language. Look up clients, products, vendors, quotes, and monthly business summaries. Keep routine admin moving from inside ChatGPT without switching tabs.
 
-The ChatGPT app exposes a reviewed 53-tool OpenAI-safe surface: invoices, expenses, clients, CRM contacts/activities/notes, products, quotes, vendors, monthly summaries, and webhook management. Government IDs, webhook secrets, recipient override emails, payroll, HR, stay/PMS, e-invoicing XML, VIES lookup, and quarterly filing tools are not exposed in this OpenAI profile.
+The ChatGPT app exposes a reviewed OpenAI-safe surface for invoices, expenses, clients, CRM contacts/activities/notes, products, quotes, vendors, monthly summaries, and webhook management. It includes 53 reviewed business tools plus 3 read-only discovery tools (`list_tool_groups`, `search_tools`, `describe_tool`) that help ChatGPT select the right capability without exposing hidden product modules.
+
+Regulated identifiers, banking identifiers, webhook signing secrets, recipient override emails, payroll/HR, lodging/POS, banking, and regulated filing/export workflows are outside the ChatGPT surface.
 
 Connect via OAuth 2.0 in seconds. No API key required.
 
@@ -160,7 +162,7 @@ Before submitting:
 
 - [ ] `https://openai-mcp.frihet.io/mcp` is reachable with valid MCP response
 - [ ] OAuth metadata at `https://openai-mcp.frihet.io/.well-known/oauth-authorization-server` includes `code_challenge_methods_supported: ["S256"]`
-- [ ] `FRIHET_OPENAI_MODE=true` is active and exposes exactly 53 tools
+- [ ] `FRIHET_OPENAI_MODE=true` is active and exposes 53 reviewed business tools + 3 read-only discovery meta-tools
 - [ ] MCP prompts are hidden in OpenAI mode
 - [ ] `/.well-known/openai-apps-challenge` route added to Worker (deploy BEFORE submitting)
 - [ ] OpenAI redirect URI added to OAuth allowlist (exact URI provided by OpenAI during submission)

--- a/src/redaction.ts
+++ b/src/redaction.ts
@@ -3,7 +3,8 @@
  *
  * Single source of truth for the set of field names that must never leave the
  * process in cleartext — government IDs (NIF/CIF/VAT), banking identifiers,
- * identity documents, webhook signing secrets, and auth tokens.
+ * identity documents, internal trace/user identifiers, webhook signing secrets,
+ * and auth tokens.
  *
  * Two consumers:
  *   - openai-profile.ts — strips these from tool I/O in OpenAI-safe mode
@@ -37,6 +38,9 @@ export const SENSITIVE_FIELD_NAMES: readonly string[] = [
   "apiKey", "api_key",
   "accessToken", "access_token", "refreshToken", "refresh_token",
   "password", "mfa", "otp",
+  "requestId", "request_id", "traceId", "trace_id",
+  "sessionId", "session_id", "userId", "user_id",
+  "verifactuHash", "verifactu_hash",
 ];
 
 /** Recursively removes named fields from an object/array tree, IN PLACE. */

--- a/workers/remote-mcp/public-openai/openapi.json
+++ b/workers/remote-mcp/public-openai/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Frihet API",
     "version": "2026-03-18",
-    "description": "Frihet ERP API — ChatGPT connector reviewed surface (invoicing, expenses, clients/CRM, products, quotes, vendors, webhooks). Government tax identifiers, banking identifiers, and credentials are excluded.",
+    "description": "Frihet ERP API — ChatGPT connector reviewed surface (invoicing, expenses, clients/CRM, products, quotes, vendors, webhooks, and monthly summaries). Regulated identifiers, banking identifiers, credentials, diagnostic metadata, and hidden product modules are excluded.",
     "contact": {
       "name": "Frihet API Support",
       "url": "https://docs.frihet.io/desarrolladores/api-rest",
@@ -23,35 +23,30 @@
       "description": "Frihet API"
     }
   ],
-  "security": [
-    {
-      "ApiKeyAuth": []
-    }
-  ],
   "tags": [
     {
       "name": "Invoices",
-      "description": "Create, read, update, and delete invoices. Includes PDF generation, email sending, and payment tracking."
+      "description": "Create, read, update, send, and manage invoice records."
     },
     {
       "name": "Expenses",
-      "description": "Manage business expenses with categories, tax deductions, and receipt attachments."
+      "description": "Record and manage business expenses."
     },
     {
       "name": "Clients",
-      "description": "Manage your client database with contact details, tax IDs, and addresses."
+      "description": "Manage client records with contact details and addresses."
     },
     {
       "name": "Products",
-      "description": "Product and service catalog with pricing, tax rates, and SKUs."
+      "description": "Manage product and service catalogue records with pricing."
     },
     {
       "name": "Quotes",
-      "description": "Create and manage quotes with PDF generation and email delivery. Convert accepted quotes to invoices."
+      "description": "Create, read, update, send, and manage quotes."
     },
     {
       "name": "Vendors",
-      "description": "Manage your vendor database with contact details, tax IDs, and addresses."
+      "description": "Manage vendor records with contact details and addresses."
     },
     {
       "name": "Summary",
@@ -59,47 +54,23 @@
     },
     {
       "name": "Intelligence",
-      "description": "AI-optimized endpoints providing business context, monthly P&L, and quarterly tax figures in a single call."
+      "description": "Business context and monthly financial summaries."
     },
     {
       "name": "Webhooks",
-      "description": "CRUD endpoints for managing webhook subscriptions that receive real-time event notifications."
+      "description": "Manage webhook subscriptions for Frihet business events."
     },
     {
       "name": "Contacts",
-      "description": "Contact persons associated with a client. Manage multiple contacts per client for CRM."
+      "description": "Manage contact persons associated with a client."
     },
     {
       "name": "Activities",
-      "description": "Immutable activity timeline for a client. System activities are auto-generated; manual activities can be created via API."
+      "description": "Manage client activity timeline entries."
     },
     {
       "name": "Notes",
-      "description": "Free-form notes attached to a client."
-    },
-    {
-      "name": "Deposits",
-      "description": "Manage client deposits and prepayments. Apply deposits against invoices or process refunds."
-    },
-    {
-      "name": "Batch",
-      "description": "Batch creation of resources (up to 50 items per request)."
-    },
-    {
-      "name": "Reservations",
-      "description": "Frihet Stay: Manage vacation rental reservations with guest info, dates, and compliance tracking."
-    },
-    {
-      "name": "Properties",
-      "description": "Frihet Stay: Manage rental properties with owner info, capacity, and licensing."
-    },
-    {
-      "name": "Guests",
-      "description": "Frihet Stay: Read compliance records for guest check-in (document verification, police reports)."
-    },
-    {
-      "name": "Channels",
-      "description": "Frihet Stay: Manage channel connections (iCal feeds) for calendar sync with OTAs."
+      "description": "Manage notes attached to a client."
     }
   ],
   "paths": {
@@ -375,7 +346,7 @@
       "delete": {
         "operationId": "deleteInvoice",
         "summary": "Delete an invoice",
-        "description": "Delete an invoice. Draft invoices are permanently deleted (204).\nNon-draft invoices are soft-deleted (cancelled) to preserve VeriFactu\nSHA-256 hash chain integrity (RD 1007/2023 compliance), returning 200\nwith the cancelled document body.\n",
+        "description": "Delete an invoice. Draft invoices are permanently deleted (204).\nNon-draft invoices are soft-deleted (cancelled) to preserve internal compliance metadata\naudit history, returning 200\nwith the cancelled document body.\n",
         "tags": [
           "Invoices"
         ],
@@ -405,18 +376,6 @@
                         "cancelledVia": {
                           "type": "string",
                           "example": "api"
-                        }
-                      }
-                    },
-                    "meta": {
-                      "type": "object",
-                      "properties": {
-                        "requestId": {
-                          "type": "string"
-                        },
-                        "timestamp": {
-                          "type": "string",
-                          "format": "date-time"
                         }
                       }
                     }
@@ -994,7 +953,7 @@
       "post": {
         "operationId": "createClient",
         "summary": "Create a client",
-        "description": "Add a new client to your database.",
+        "description": "Add a new client to your database.\n\nIf `regulated identifier` is provided and another client in your workspace already has the\nsame regulated identifier (normalized: case-insensitive, ignoring separators like dots and\nhyphens), the request is rejected with `409 CLIENT_regulated identifier_EXISTS` and the\nexisting client's id is returned in `existingClientId`.\n",
         "tags": [
           "Clients"
         ],
@@ -1024,6 +983,30 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          },
+          "409": {
+            "description": "A client with this regulated identifier already exists in your workspace.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "CLIENT_regulated identifier_EXISTS"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Client with this regulated identifier already exists"
+                    },
+                    "existingClientId": {
+                      "type": "string",
+                      "description": "Document id of the existing client with the same regulated identifier."
+                    }
+                  }
+                }
+              }
+            }
           },
           "429": {
             "$ref": "#/components/responses/RateLimited"
@@ -1078,7 +1061,7 @@
       "put": {
         "operationId": "updateClient",
         "summary": "Full update a client",
-        "description": "Replace all fields on an existing client.",
+        "description": "Replace all fields on an existing client. Returns `409 CLIENT_regulated identifier_EXISTS`\nif the new `regulated identifier` is already in use by another client in your workspace.\n",
         "tags": [
           "Clients"
         ],
@@ -1116,6 +1099,25 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "description": "Another client with this regulated identifier already exists in your workspace.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "CLIENT_regulated identifier_EXISTS"
+                    },
+                    "existingClientId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           },
           "429": {
             "$ref": "#/components/responses/RateLimited"
@@ -1128,7 +1130,7 @@
       "patch": {
         "operationId": "patchClient",
         "summary": "Partial update a client",
-        "description": "Update only the provided fields on an existing client.",
+        "description": "Update only the provided fields on an existing client. Returns\n`409 CLIENT_regulated identifier_EXISTS` if the new `regulated identifier` is already in use by\nanother client in your workspace.\n",
         "tags": [
           "Clients"
         ],
@@ -1166,6 +1168,25 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "description": "Another client with this regulated identifier already exists in your workspace.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "CLIENT_regulated identifier_EXISTS"
+                    },
+                    "existingClientId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           },
           "429": {
             "$ref": "#/components/responses/RateLimited"
@@ -2356,7 +2377,7 @@
       "delete": {
         "operationId": "deleteQuote",
         "summary": "Delete a quote",
-        "description": "Delete a quote. Draft quotes are permanently deleted (204).\nNon-draft quotes are soft-deleted (cancelled) to preserve VeriFactu\nhash chain integrity, returning 200 with the cancelled document body.\n",
+        "description": "Delete a quote. Draft quotes are permanently deleted (204).\nNon-draft quotes are soft-deleted (cancelled) to preserve internal compliance metadata\nhash chain integrity, returning 200 with the cancelled document body.\n",
         "tags": [
           "Quotes"
         ],
@@ -2386,18 +2407,6 @@
                         "cancelledVia": {
                           "type": "string",
                           "example": "api"
-                        }
-                      }
-                    },
-                    "meta": {
-                      "type": "object",
-                      "properties": {
-                        "requestId": {
-                          "type": "string"
-                        },
-                        "timestamp": {
-                          "type": "string",
-                          "format": "date-time"
                         }
                       }
                     }
@@ -2859,7 +2868,7 @@
       "get": {
         "operationId": "getMonthlySummary",
         "summary": "Monthly P&L",
-        "description": "Monthly financial summary with revenue breakdown (tax base, tax, IRPF),\nexpense breakdown (deductible, tax), profit (gross/net), invoice status\ncounts, top clients, expenses by category, and estimated tax liability\n(Modelo 303).\n",
+        "description": "Monthly financial summary with revenue breakdown (tax base, tax, IRPF),\nexpense breakdown (deductible, tax), profit (gross/net), invoice status\ncounts, top clients, expenses by category, and estimated tax liability\n(estimated tax total).\n",
         "tags": [
           "Intelligence"
         ],
@@ -3178,7 +3187,7 @@
       "post": {
         "operationId": "createCreditNote",
         "summary": "Create a credit note",
-        "description": "Create a rectificative invoice (credit note) for an existing invoice.\nThe original invoice must not be in `draft` or `cancelled` status.\nThe credit note is created with `sent` status and negative line item amounts.\nThe `rectificativa` field is populated according to Spanish Facturae R-type codes.\n",
+        "description": "Create a rectificative invoice (credit note) for an existing invoice.\nThe original invoice must not be in `draft` or `cancelled` status.\nThe credit note is created with `sent` status and negative line item amounts.\nThe `rectificativa` field is populated according to Spanish credit-note metadata.\n",
         "tags": [
           "Invoices"
         ],
@@ -3373,14 +3382,6 @@
     }
   },
   "components": {
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "X-API-Key",
-        "description": "API key for authentication. Keys start with `fri_` prefix.\nGenerate keys from Settings > API Keys in the Frihet app.\n"
-      }
-    },
     "parameters": {
       "Limit": {
         "name": "limit",
@@ -3514,15 +3515,6 @@
           "type": "string"
         }
       },
-      "DepositId": {
-        "name": "depositId",
-        "in": "path",
-        "required": true,
-        "description": "Deposit unique identifier",
-        "schema": {
-          "type": "string"
-        }
-      },
       "Search": {
         "name": "q",
         "in": "query",
@@ -3608,58 +3600,9 @@
           ],
           "example": "active"
         }
-      },
-      "IdempotencyKey": {
-        "name": "Idempotency-Key",
-        "in": "header",
-        "required": false,
-        "description": "Unique key to prevent duplicate resource creation from network retries.\nIf the same key is sent within 24 hours, the original response is returned\nwith an X-Idempotent-Replayed: true header. Max 64 characters. UUID v4 recommended.\n",
-        "schema": {
-          "type": "string",
-          "maxLength": 64,
-          "example": "550e8400-e29b-41d4-a716-446655440000"
-        }
       }
     },
-    "headers": {
-      "X-RateLimit-Limit": {
-        "description": "Maximum number of requests allowed per window",
-        "schema": {
-          "type": "integer",
-          "example": 100
-        }
-      },
-      "X-RateLimit-Remaining": {
-        "description": "Number of requests remaining in the current window",
-        "schema": {
-          "type": "integer",
-          "example": 87
-        }
-      },
-      "X-RateLimit-Reset": {
-        "description": "Unix timestamp (seconds) when the rate limit window resets",
-        "schema": {
-          "type": "integer",
-          "example": 1742310060
-        }
-      },
-      "X-API-Version": {
-        "description": "Current API version date. Monitor for breaking changes.",
-        "schema": {
-          "type": "string",
-          "example": "2026-03-18"
-        }
-      },
-      "X-Idempotent-Replayed": {
-        "description": "Present and set to \"true\" when returning a cached idempotent response",
-        "schema": {
-          "type": "string",
-          "enum": [
-            "true"
-          ]
-        }
-      }
-    },
+    "headers": {},
     "schemas": {
       "InvoiceStatus": {
         "type": "string",
@@ -3752,10 +3695,42 @@
           "items"
         ],
         "properties": {
+          "clientId": {
+            "type": "string",
+            "description": "Client document ID. When provided, the API auto-snapshots\n`client identifier`, `clientAddress`, `clientLocation`, `clientName`,\nand `clientEmail` from the referenced client at create time\n(immutable post-create — internal compliance metadata. Caller-provided\nvalues for those fields override the snapshot.\n",
+            "example": "client_abc123"
+          },
           "clientName": {
             "type": "string",
-            "description": "Client name",
+            "description": "Client name (snapshot field — frozen at create)",
             "example": "Acme Corp"
+          },
+          "clientTaxId": {
+            "type": "string",
+            "description": "Client regulated identifiers / regulated identifier / tax (snapshot field — frozen at create).\nAuto-populated from clientId reference if not provided.\n",
+            "example": "B12345678"
+          },
+          "clientAddress": {
+            "type": "string",
+            "description": "Client billing address — single-line or structured. Snapshot\nfield, frozen at create.\n",
+            "example": "Calle Mayor 12, 38001 Santa Cruz de Tenerife"
+          },
+          "clientLocation": {
+            "type": "string",
+            "enum": [
+              "peninsula",
+              "canarias",
+              "ceuta_melilla",
+              "eu",
+              "world"
+            ],
+            "description": "Fiscal zone — drives tax label rendering on PDF + tax math\n(IVA/IGIC/IPSI/Reverse charge/Exempt). Snapshot field, frozen\nat create. Auto-populated from clientId reference if absent.\n",
+            "example": "canarias"
+          },
+          "clientEmail": {
+            "type": "string",
+            "format": "email",
+            "description": "Client email (snapshot field — frozen at create)."
           },
           "items": {
             "type": "array",
@@ -3788,8 +3763,22 @@
             "type": "number",
             "minimum": 0,
             "maximum": 100,
-            "description": "Tax rate percentage",
+            "description": "Tax rate percentage. Combined with `clientLocation` to produce\nthe label (IGIC for canarias, IPSI for ceuta_melilla, etc.).\n",
             "example": 21
+          },
+          "irpfRate": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "IRPF withholding rate percentage (Spain).",
+            "example": 15
+          },
+          "discountRate": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Invoice-level discount percentage.",
+            "example": 10
           },
           "recurring": {
             "$ref": "#/components/schemas/InvoiceRecurringConfig"
@@ -3843,10 +3832,6 @@
                 "type": "string",
                 "description": "Currency code",
                 "example": "EUR"
-              },
-              "verifactuHash": {
-                "type": "string",
-                "description": "VeriFactu SHA-256 hash (Spanish tax compliance)"
               }
             }
           }
@@ -4541,6 +4526,11 @@
             "type": "string",
             "description": "Cursor for fetching the next page of results. Only present when there\nare more results available. Pass this value as the `cursor` query parameter\nin the next request. Base64url-encoded.\n",
             "example": "eyJpc3N1ZURhdGUiOiIyMDI2LTAzLTIwIiwiX19pZCI6ImFiYzEyMyJ9"
+          },
+          "truncated": {
+            "type": "boolean",
+            "description": "Only present (and `true`) when the underlying search query\nsaturated the internal 500-document cap. `total` therefore reports\nthe size of the first 500 matches, not the full match count.\nNarrow the search query (regulated identifier / fiscal id, exact email) to ensure\nyou see every result.\n",
+            "example": true
           }
         }
       },
@@ -4695,8 +4685,9 @@
                 "type": "string",
                 "format": "date-time"
               },
-              "userId": {
-                "type": "string"
+              "hasSecret": {
+                "type": "boolean",
+                "description": "True if an HMAC secret is configured. The secret value itself is never returned by read endpoints."
               }
             }
           },
@@ -4893,18 +4884,6 @@
                 }
               }
             }
-          },
-          "meta": {
-            "type": "object",
-            "properties": {
-              "requestId": {
-                "type": "string"
-              },
-              "timestamp": {
-                "type": "string",
-                "format": "date-time"
-              }
-            }
           }
         }
       },
@@ -5006,7 +4985,7 @@
                 "properties": {
                   "vatPayable": {
                     "type": "number",
-                    "description": "Net VAT payable (output - input)"
+                    "description": "Net tax payable (output - input)"
                   },
                   "irpfRetained": {
                     "type": "number"
@@ -5015,18 +4994,6 @@
                     "type": "number"
                   }
                 }
-              }
-            }
-          },
-          "meta": {
-            "type": "object",
-            "properties": {
-              "requestId": {
-                "type": "string"
-              },
-              "timestamp": {
-                "type": "string",
-                "format": "date-time"
               }
             }
           }
@@ -5062,15 +5029,6 @@
                 }
               }
             }
-          },
-          "meta": {
-            "type": "object",
-            "properties": {
-              "requestId": {
-                "type": "string",
-                "description": "Unique request identifier for tracing"
-              }
-            }
           }
         }
       }
@@ -5093,10 +5051,7 @@
                     "clientName"
                   ]
                 }
-              ],
-              "meta": {
-                "requestId": "550e8400-e29b-41d4-a716-446655440000"
-              }
+              ]
             }
           }
         }
@@ -5109,26 +5064,7 @@
               "$ref": "#/components/schemas/Error"
             },
             "example": {
-              "error": "Invalid or expired API key",
-              "meta": {
-                "requestId": "550e8400-e29b-41d4-a716-446655440000"
-              }
-            }
-          }
-        }
-      },
-      "Forbidden": {
-        "description": "Insufficient permissions",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Error"
-            },
-            "example": {
-              "error": "Insufficient permissions",
-              "meta": {
-                "requestId": "550e8400-e29b-41d4-a716-446655440000"
-              }
+              "error": "Invalid or expired API key"
             }
           }
         }
@@ -5141,10 +5077,7 @@
               "$ref": "#/components/schemas/Error"
             },
             "example": {
-              "error": "Resource not found",
-              "meta": {
-                "requestId": "550e8400-e29b-41d4-a716-446655440000"
-              }
+              "error": "Resource not found"
             }
           }
         }
@@ -5168,14 +5101,6 @@
                   "type": "integer",
                   "description": "Seconds until rate limit resets",
                   "example": 60
-                },
-                "meta": {
-                  "type": "object",
-                  "properties": {
-                    "requestId": {
-                      "type": "string"
-                    }
-                  }
                 }
               }
             }
@@ -5190,10 +5115,7 @@
               "$ref": "#/components/schemas/Error"
             },
             "example": {
-              "error": "Internal server error",
-              "meta": {
-                "requestId": "550e8400-e29b-41d4-a716-446655440000"
-              }
+              "error": "Internal server error"
             }
           }
         }

--- a/workers/remote-mcp/public-openai/releases.json
+++ b/workers/remote-mcp/public-openai/releases.json
@@ -1,32 +1,25 @@
 {
-  "integrationCount": 0,
-  "languageCount": 17,
-  "lastEmit": "2026-06-01T00:10:38.257Z",
-  "manifestChecksum": "a227aaf46c65a3c3db81a3eeea7e9d07c484b33ddc4864bca8336c349192435c",
-  "mcpToolCount": 0,
+  "version": "1.14.5",
+  "releasedAt": "2026-06-22",
+  "surface": "openai-chatgpt",
+  "mcpToolCount": 56,
+  "reviewedBusinessToolCount": 53,
+  "discoveryMetaToolCount": 3,
+  "promptsCount": 0,
+  "notes": "ChatGPT connector metadata is scoped to reviewed invoices, expenses, clients/CRM, products, quotes, vendors, webhooks, and monthly summaries. Hidden product modules, regulated identifiers, credentials, and diagnostic metadata are excluded.",
   "products": {
-    "app": {
-      "status": "live",
-      "version": "0.1.0"
-    },
-    "cli": {
-      "install": "npm install -g @frihet/cli",
-      "npm": "@frihet/cli",
-      "status": "live",
-      "version": "0.1.0"
-    },
     "mcp_server": {
-      "install": "npm install @frihet/mcp-server",
-      "npm": "@frihet/mcp-server",
       "status": "live",
-      "version": "1.0.0"
-    },
-    "sdk": {
-      "install": "npm install @frihet/sdk",
-      "npm": "@frihet/sdk",
-      "status": "live",
-      "version": "0.1.0"
+      "version": "1.14.5"
     }
   },
-  "version": "0.1.0"
+  "releases": [
+    {
+      "version": "1.14.5",
+      "releasedAt": "2026-06-22",
+      "mcpToolCount": 56,
+      "delta": "OpenAI ChatGPT scoped connector surface",
+      "notes": "OpenAI mode exposes 53 reviewed business tools plus 3 read-only discovery meta-tools. Prompts and hidden full-server modules are not part of this surface."
+    }
+  ]
 }

--- a/workers/remote-mcp/scripts/scope-openai-openapi.mjs
+++ b/workers/remote-mcp/scripts/scope-openai-openapi.mjs
@@ -11,7 +11,7 @@
  * Mirrors scopeOpenApiForOpenAI() in src/index.ts. Run before `wrangler deploy --env openai`.
  *   node scripts/scope-openai-openapi.mjs
  */
-import { readFileSync, writeFileSync, mkdirSync, existsSync, copyFileSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
@@ -29,21 +29,75 @@ const DROP_PATHS_EXACT = new Set([
   "/v1/quotes/{quoteId}/pdf",
   "/v1/{resource}/batch",
 ]);
+const KEEP_PATHS_EXACT = new Set([
+  "/v1/invoices",
+  "/v1/invoices/{invoiceId}",
+  "/v1/invoices/{invoiceId}/pdf",
+  "/v1/invoices/{invoiceId}/send",
+  "/v1/invoices/{invoiceId}/paid",
+  "/v1/expenses",
+  "/v1/expenses/{expenseId}",
+  "/v1/clients",
+  "/v1/clients/{clientId}",
+  "/v1/clients/{clientId}/contacts",
+  "/v1/clients/{clientId}/contacts/{contactId}",
+  "/v1/clients/{clientId}/activities",
+  "/v1/clients/{clientId}/activities/{activityId}",
+  "/v1/clients/{clientId}/notes",
+  "/v1/clients/{clientId}/notes/{noteId}",
+  "/v1/products",
+  "/v1/products/{productId}",
+  "/v1/quotes",
+  "/v1/quotes/{quoteId}",
+  "/v1/quotes/{quoteId}/send",
+  "/v1/summary",
+  "/v1/vendors",
+  "/v1/vendors/{vendorId}",
+  "/v1/context",
+  "/v1/monthly",
+  "/v1/webhooks",
+  "/v1/webhooks/{webhookId}",
+  "/v1/invoices/{invoiceId}/credit-note",
+  "/v1/invoices/{invoiceId}/late-fee",
+]);
 const DROP_SCHEMAS = new Set([
   "Channel", "ChannelCreate", "ChannelStatus", "Deposit", "DepositCreate", "DepositStatus",
   "Guest", "Property", "PropertyCreate", "PropertyStatus", "Reservation", "ReservationCreate",
   "ReservationStatus", "QuarterlySummary", "BatchResponse", "ReceiptQueueItem", "ResendInboundPayload",
 ]);
+const ALLOWED_TAGS = new Set([
+  "Invoices", "Expenses", "Clients", "Products", "Quotes", "Vendors",
+  "Summary", "Intelligence", "Webhooks", "Contacts", "Activities", "Notes",
+]);
+const TAG_DESCRIPTIONS = {
+  Invoices: "Create, read, update, send, and manage invoice records.",
+  Expenses: "Record and manage business expenses.",
+  Clients: "Manage client records with contact details and addresses.",
+  Products: "Manage product and service catalogue records with pricing.",
+  Quotes: "Create, read, update, send, and manage quotes.",
+  Vendors: "Manage vendor records with contact details and addresses.",
+  Summary: "Financial dashboard data including revenue, expenses, and profit aggregations.",
+  Intelligence: "Business context and monthly financial summaries.",
+  Webhooks: "Manage webhook subscriptions for Frihet business events.",
+  Contacts: "Manage contact persons associated with a client.",
+  Activities: "Manage client activity timeline entries.",
+  Notes: "Manage notes attached to a client.",
+};
 const STRIP_PROPS = [
   "taxId", "tax_id", "nif", "cif", "vatNumber", "vat_number", "vatId", "vat_id",
   "documentType", "documentNumber", "signatureCaptured", "passport", "passportNumber",
   "dni", "nationalId", "national_id", "iban", "bankAccount", "bank_account", "accountNumber",
   "secret", "apiKey", "api_key", "ssn", "socialSecurityNumber", "social_security_number",
+  "requestId", "request_id", "traceId", "trace_id", "sessionId", "session_id",
+  "userId", "user_id", "verifactuHash", "verifactu_hash", "meta", "security",
 ];
 
 function stripDeep(node) {
   if (!node || typeof node !== "object") return;
   if (Array.isArray(node)) { for (const x of node) stripDeep(x); return; }
+  for (const p of STRIP_PROPS) {
+    if (p in node) delete node[p];
+  }
   if (node.properties && typeof node.properties === "object") {
     for (const p of STRIP_PROPS) delete node.properties[p];
   }
@@ -53,31 +107,150 @@ function stripDeep(node) {
   for (const v of Object.values(node)) stripDeep(v);
 }
 
+function sanitizeReviewText(text) {
+  return text
+    .replace(/clientTaxId/gi, "client identifier")
+    .replace(/NIF\/CIF\/VAT/gi, "regulated identifiers")
+    .replace(/\bNIF\b|\bCIF\b/gi, "regulated identifier")
+    .replace(/\bVAT\b/gi, "tax")
+    .replace(/\bIBAN\b/gi, "banking identifier")
+    .replace(/VeriFactu[^.\n]*/gi, "internal compliance metadata")
+    .replace(/Facturae[^.\n]*/gi, "credit-note metadata")
+    .replace(/TicketBAI[^.\n]*/gi, "regional e-invoicing metadata")
+    .replace(/KSeF[^.\n]*/gi, "e-invoicing metadata")
+    .replace(/VIES[^.\n]*/gi, "external tax validation")
+    .replace(/Modelo 303/gi, "estimated tax total")
+    .replace(/taxId/gi, "regulated identifier")
+    .replace(/quarterly tax figures?/gi, "business figures")
+    .replace(/tax IDs?/gi, "regulated identifiers")
+    .replace(/SHA-256 hash chain integrity[^,.\n]*/gi, "audit history")
+    .replace(/Spanish tax compliance/gi, "internal compliance");
+}
+
+function addComponentRef(refs, queue, ref) {
+  const match = ref.match(/^#\/components\/([^/]+)\/([^/]+)$/);
+  if (!match) return;
+  const [, section, encodedName] = match;
+  const name = decodeURIComponent(encodedName);
+  const key = `${section}/${name}`;
+  if (!refs.has(key)) {
+    refs.set(key, { section, name });
+    queue.push({ section, name });
+  }
+}
+
+function collectComponentRefs(node, refs, queue) {
+  if (!node || typeof node !== "object") return;
+  if (Array.isArray(node)) { for (const x of node) collectComponentRefs(x, refs, queue); return; }
+  if (typeof node.$ref === "string") addComponentRef(refs, queue, node.$ref);
+  for (const v of Object.values(node)) collectComponentRefs(v, refs, queue);
+}
+
+function pruneUnusedComponents(spec) {
+  const refs = new Map();
+  const queue = [];
+  collectComponentRefs(spec.paths, refs, queue);
+  for (let i = 0; i < queue.length; i += 1) {
+    const { section, name } = queue[i];
+    const component = spec.components?.[section]?.[name];
+    collectComponentRefs(component, refs, queue);
+  }
+  for (const [section, entries] of Object.entries(spec.components ?? {})) {
+    if (!entries || typeof entries !== "object" || Array.isArray(entries)) continue;
+    for (const name of Object.keys(entries)) {
+      if (!refs.has(`${section}/${name}`)) delete entries[name];
+    }
+  }
+}
+
+function sanitizeDescriptionsDeep(node) {
+  if (!node || typeof node !== "object") return;
+  if (Array.isArray(node)) { for (const x of node) sanitizeDescriptionsDeep(x); return; }
+  for (const [key, value] of Object.entries(node)) {
+    if (typeof value === "string") {
+      node[key] = sanitizeReviewText(value);
+      continue;
+    }
+    sanitizeDescriptionsDeep(value);
+  }
+}
+
 const spec = JSON.parse(readFileSync(join(SRC, "openapi.json"), "utf8"));
 for (const p of Object.keys(spec.paths ?? {})) {
-  const drop = DROP_PATHS_EXACT.has(p) ||
+  const drop = !KEEP_PATHS_EXACT.has(p) ||
+    DROP_PATHS_EXACT.has(p) ||
     DROP_PATH_PREFIXES.some((pre) => p === pre || p.startsWith(pre + "/"));
   if (drop) delete spec.paths[p];
 }
 if (spec.components?.schemas) {
   for (const s of DROP_SCHEMAS) delete spec.components.schemas[s];
 }
+if (Array.isArray(spec.tags)) {
+  spec.tags = spec.tags
+    .filter((tag) => ALLOWED_TAGS.has(tag.name))
+    .map((tag) => ({
+      ...tag,
+      description: TAG_DESCRIPTIONS[tag.name] ?? sanitizeReviewText(tag.description ?? ""),
+    }));
+}
+delete spec.security;
+if (spec.components?.securitySchemes) delete spec.components.securitySchemes;
 stripDeep(spec.paths);
 stripDeep(spec.components);
+pruneUnusedComponents(spec);
 if (spec.info) {
   spec.info.description =
     "Frihet ERP API — ChatGPT connector reviewed surface (invoicing, expenses, clients/CRM, " +
-    "products, quotes, vendors, webhooks). Government tax identifiers, banking identifiers, " +
-    "and credentials are excluded.";
+    "products, quotes, vendors, webhooks, and monthly summaries). Regulated identifiers, " +
+    "banking identifiers, credentials, diagnostic metadata, and hidden product modules are excluded.";
 }
 spec.servers = [{ url: "https://api.frihet.io", description: "Frihet API" }];
+sanitizeDescriptionsDeep(spec);
 
 if (!existsSync(OUT)) mkdirSync(OUT, { recursive: true });
 writeFileSync(join(OUT, "openapi.json"), JSON.stringify(spec, null, 2));
-if (existsSync(join(SRC, "releases.json"))) copyFileSync(join(SRC, "releases.json"), join(OUT, "releases.json"));
+let extraAssetText = "";
+if (existsSync(join(SRC, "releases.json"))) {
+  const sourceReleases = JSON.parse(readFileSync(join(SRC, "releases.json"), "utf8"));
+  const openaiReleases = {
+    version: sourceReleases.version,
+    releasedAt: sourceReleases.releasedAt,
+    surface: "openai-chatgpt",
+    mcpToolCount: 56,
+    reviewedBusinessToolCount: 53,
+    discoveryMetaToolCount: 3,
+    promptsCount: 0,
+    notes:
+      "ChatGPT connector metadata is scoped to reviewed invoices, expenses, clients/CRM, products, quotes, vendors, webhooks, and monthly summaries. Hidden product modules, regulated identifiers, credentials, and diagnostic metadata are excluded.",
+    products: {
+      mcp_server: {
+        status: "live",
+        version: sourceReleases.products?.mcp_server?.version ?? sourceReleases.version,
+      },
+    },
+    releases: [
+      {
+        version: sourceReleases.version,
+        releasedAt: sourceReleases.releasedAt,
+        mcpToolCount: 56,
+        delta: "OpenAI ChatGPT scoped connector surface",
+        notes:
+          "OpenAI mode exposes 53 reviewed business tools plus 3 read-only discovery meta-tools. Prompts and hidden full-server modules are not part of this surface.",
+      },
+    ],
+  };
+  extraAssetText = JSON.stringify(openaiReleases);
+  writeFileSync(join(OUT, "releases.json"), `${JSON.stringify(openaiReleases, null, 2)}\n`);
+}
 
-const blob = JSON.stringify(spec);
-const sensitive = ["\"taxId\"", "documentType", "signatureCaptured", "/guests", "/reservations", "/quarterly", "/properties"]
+const blob = JSON.stringify(spec) + extraAssetText;
+const sensitive = [
+  "\"taxId\"", "requestId", "traceId", "sessionId", "\"userId\"", "ApiKeyAuth", "\"apiKey\"",
+  "verifactuHash", "documentType", "signatureCaptured", "passport", "\"dni\"", "\"iban\"",
+  "\"secret\"", "/guests", "/reservations", "/quarterly", "/properties", "Reservations",
+  "Guests", "Channels", "VeriFactu", "Facturae", "TicketBAI", "KSeF",
+  "VIES", "Modelo 303", "quarterly tax", "police reports",
+]
   .filter((t) => blob.includes(t));
 console.log(`scoped openapi.json: ${Object.keys(spec.paths).length} paths (from full spec)`);
 console.log(`sensitive/regulated leftovers: ${sensitive.length ? sensitive.join(", ") : "NONE"}`);

--- a/workers/remote-mcp/src/index.ts
+++ b/workers/remote-mcp/src/index.ts
@@ -565,9 +565,9 @@ This is the OpenAI/ChatGPT connector surface for Frihet. It exposes ${OPENAI_ALL
 - Vendors — supplier records
 - Webhooks — event subscriptions
 
-Government tax identifiers (NIF/CIF/VAT), banking identifiers (IBAN), and signing
-credentials are never collected or returned through this connector; manage them in
-the Frihet web app at https://app.frihet.io.
+Regulated identifiers, banking identifiers, and signing credentials are never
+collected or returned through this connector; manage them in the Frihet web app
+at https://app.frihet.io.
 
 ---
 
@@ -724,22 +724,76 @@ const OPENAI_DROP_PATHS_EXACT = new Set([
   "/v1/quotes/{quoteId}/pdf",
   "/v1/{resource}/batch",
 ]);
+const OPENAI_KEEP_PATHS_EXACT = new Set([
+  "/v1/invoices",
+  "/v1/invoices/{invoiceId}",
+  "/v1/invoices/{invoiceId}/pdf",
+  "/v1/invoices/{invoiceId}/send",
+  "/v1/invoices/{invoiceId}/paid",
+  "/v1/expenses",
+  "/v1/expenses/{expenseId}",
+  "/v1/clients",
+  "/v1/clients/{clientId}",
+  "/v1/clients/{clientId}/contacts",
+  "/v1/clients/{clientId}/contacts/{contactId}",
+  "/v1/clients/{clientId}/activities",
+  "/v1/clients/{clientId}/activities/{activityId}",
+  "/v1/clients/{clientId}/notes",
+  "/v1/clients/{clientId}/notes/{noteId}",
+  "/v1/products",
+  "/v1/products/{productId}",
+  "/v1/quotes",
+  "/v1/quotes/{quoteId}",
+  "/v1/quotes/{quoteId}/send",
+  "/v1/summary",
+  "/v1/vendors",
+  "/v1/vendors/{vendorId}",
+  "/v1/context",
+  "/v1/monthly",
+  "/v1/webhooks",
+  "/v1/webhooks/{webhookId}",
+  "/v1/invoices/{invoiceId}/credit-note",
+  "/v1/invoices/{invoiceId}/late-fee",
+]);
 const OPENAI_DROP_SCHEMAS = new Set([
   "Channel", "ChannelCreate", "ChannelStatus", "Deposit", "DepositCreate", "DepositStatus",
   "Guest", "Property", "PropertyCreate", "PropertyStatus", "Reservation", "ReservationCreate",
   "ReservationStatus", "QuarterlySummary", "BatchResponse", "ReceiptQueueItem", "ResendInboundPayload",
 ]);
+const OPENAI_ALLOWED_TAGS = new Set([
+  "Invoices", "Expenses", "Clients", "Products", "Quotes", "Vendors",
+  "Summary", "Intelligence", "Webhooks", "Contacts", "Activities", "Notes",
+]);
+const OPENAI_TAG_DESCRIPTIONS: Record<string, string> = {
+  Invoices: "Create, read, update, send, and manage invoice records.",
+  Expenses: "Record and manage business expenses.",
+  Clients: "Manage client records with contact details and addresses.",
+  Products: "Manage product and service catalogue records with pricing.",
+  Quotes: "Create, read, update, send, and manage quotes.",
+  Vendors: "Manage vendor records with contact details and addresses.",
+  Summary: "Financial dashboard data including revenue, expenses, and profit aggregations.",
+  Intelligence: "Business context and monthly financial summaries.",
+  Webhooks: "Manage webhook subscriptions for Frihet business events.",
+  Contacts: "Manage contact persons associated with a client.",
+  Activities: "Manage client activity timeline entries.",
+  Notes: "Manage notes attached to a client.",
+};
 const OPENAI_STRIP_PROPS = [
   "taxId", "tax_id", "nif", "cif", "vatNumber", "vat_number", "vatId", "vat_id",
   "documentType", "documentNumber", "signatureCaptured", "passport", "passportNumber",
   "dni", "nationalId", "national_id", "iban", "bankAccount", "bank_account", "accountNumber",
   "secret", "apiKey", "api_key", "ssn", "socialSecurityNumber", "social_security_number",
+  "requestId", "request_id", "traceId", "trace_id", "sessionId", "session_id",
+  "userId", "user_id", "verifactuHash", "verifactu_hash", "meta", "security",
 ];
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function stripSensitivePropsDeep(node: any): void {
   if (!node || typeof node !== "object") return;
   if (Array.isArray(node)) { for (const x of node) stripSensitivePropsDeep(x); return; }
+  for (const p of OPENAI_STRIP_PROPS) {
+    if (p in node) delete node[p];
+  }
   if (node.properties && typeof node.properties === "object") {
     for (const p of OPENAI_STRIP_PROPS) delete node.properties[p];
   }
@@ -749,13 +803,95 @@ function stripSensitivePropsDeep(node: any): void {
   for (const v of Object.values(node)) stripSensitivePropsDeep(v);
 }
 
+function sanitizeOpenAIReviewText(text: string): string {
+  return text
+    .replace(/clientTaxId/gi, "client identifier")
+    .replace(/NIF\/CIF\/VAT/gi, "regulated identifiers")
+    .replace(/\bNIF\b|\bCIF\b/gi, "regulated identifier")
+    .replace(/\bVAT\b/gi, "tax")
+    .replace(/\bIBAN\b/gi, "banking identifier")
+    .replace(/VeriFactu[^.\n]*/gi, "internal compliance metadata")
+    .replace(/Facturae[^.\n]*/gi, "credit-note metadata")
+    .replace(/TicketBAI[^.\n]*/gi, "regional e-invoicing metadata")
+    .replace(/KSeF[^.\n]*/gi, "e-invoicing metadata")
+    .replace(/VIES[^.\n]*/gi, "external tax validation")
+    .replace(/Modelo 303/gi, "estimated tax total")
+    .replace(/taxId/gi, "regulated identifier")
+    .replace(/quarterly tax figures?/gi, "business figures")
+    .replace(/tax IDs?/gi, "regulated identifiers")
+    .replace(/SHA-256 hash chain integrity[^,.\n]*/gi, "audit history")
+    .replace(/Spanish tax compliance/gi, "internal compliance");
+}
+
+function addOpenAIComponentRef(
+  refs: Map<string, { section: string; name: string }>,
+  queue: Array<{ section: string; name: string }>,
+  ref: string,
+): void {
+  const match = ref.match(/^#\/components\/([^/]+)\/([^/]+)$/);
+  if (!match) return;
+  const [, section, encodedName] = match;
+  const name = decodeURIComponent(encodedName);
+  const key = `${section}/${name}`;
+  if (!refs.has(key)) {
+    refs.set(key, { section, name });
+    queue.push({ section, name });
+  }
+}
+
+function collectOpenAIComponentRefs(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  node: any,
+  refs: Map<string, { section: string; name: string }>,
+  queue: Array<{ section: string; name: string }>,
+): void {
+  if (!node || typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    for (const item of node) collectOpenAIComponentRefs(item, refs, queue);
+    return;
+  }
+  if (typeof node.$ref === "string") addOpenAIComponentRef(refs, queue, node.$ref);
+  for (const value of Object.values(node)) collectOpenAIComponentRefs(value, refs, queue);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function pruneUnusedOpenAIComponents(spec: any): void {
+  const refs = new Map<string, { section: string; name: string }>();
+  const queue: Array<{ section: string; name: string }> = [];
+  collectOpenAIComponentRefs(spec.paths, refs, queue);
+  for (let i = 0; i < queue.length; i += 1) {
+    const { section, name } = queue[i];
+    collectOpenAIComponentRefs(spec.components?.[section]?.[name], refs, queue);
+  }
+  for (const [section, entries] of Object.entries(spec.components ?? {})) {
+    if (!entries || typeof entries !== "object" || Array.isArray(entries)) continue;
+    for (const name of Object.keys(entries as Record<string, unknown>)) {
+      if (!refs.has(`${section}/${name}`)) delete (entries as Record<string, unknown>)[name];
+    }
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function sanitizeOpenAIDescriptionsDeep(node: any): void {
+  if (!node || typeof node !== "object") return;
+  if (Array.isArray(node)) { for (const x of node) sanitizeOpenAIDescriptionsDeep(x); return; }
+  for (const [key, value] of Object.entries(node)) {
+    if (typeof value === "string") {
+      node[key] = sanitizeOpenAIReviewText(value);
+      continue;
+    }
+    sanitizeOpenAIDescriptionsDeep(value);
+  }
+}
+
 function scopeOpenApiForOpenAI(specText: string): string {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let spec: any;
   try { spec = JSON.parse(specText); } catch { return specText; }
   if (spec.paths && typeof spec.paths === "object") {
     for (const p of Object.keys(spec.paths)) {
-      const drop = OPENAI_DROP_PATHS_EXACT.has(p) ||
+      const drop = !OPENAI_KEEP_PATHS_EXACT.has(p) ||
+        OPENAI_DROP_PATHS_EXACT.has(p) ||
         OPENAI_DROP_PATH_PREFIXES.some((pre) => p === pre || p.startsWith(pre + "/"));
       if (drop) delete spec.paths[p];
     }
@@ -763,14 +899,29 @@ function scopeOpenApiForOpenAI(specText: string): string {
   if (spec.components?.schemas) {
     for (const s of OPENAI_DROP_SCHEMAS) delete spec.components.schemas[s];
   }
+  if (Array.isArray(spec.tags)) {
+    spec.tags = spec.tags
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .filter((tag: any) => OPENAI_ALLOWED_TAGS.has(tag.name))
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .map((tag: any) => ({
+        ...tag,
+        description: OPENAI_TAG_DESCRIPTIONS[tag.name] ??
+          sanitizeOpenAIReviewText(tag.description ?? ""),
+      }));
+  }
+  delete spec.security;
+  if (spec.components?.securitySchemes) delete spec.components.securitySchemes;
   stripSensitivePropsDeep(spec.paths);
   stripSensitivePropsDeep(spec.components);
+  pruneUnusedOpenAIComponents(spec);
   if (spec.info) {
     spec.info.description =
       "Frihet ERP API — ChatGPT connector reviewed surface (invoicing, expenses, clients/CRM, products, quotes, vendors, webhooks). " +
-      "Government tax identifiers, banking identifiers, and credentials are excluded.";
+      "Regulated identifiers, banking identifiers, credentials, diagnostic metadata, and hidden product modules are excluded.";
   }
   spec.servers = [{ url: "https://api.frihet.io", description: "Frihet API" }];
+  sanitizeOpenAIDescriptionsDeep(spec);
   return JSON.stringify(spec);
 }
 


### PR DESCRIPTION
## Summary
- Scope the OpenAI public OpenAPI asset with an allowlist of reviewed ChatGPT routes and prune unused components.
- Replace the OpenAI releases asset with a scoped ChatGPT-surface summary instead of the full MCP changelog.
- Extend OpenAI-mode redaction to diagnostic/internal identifiers and align submission docs with the live 53 business + 3 discovery tool surface.

## Validation
- npm test
- PATH=/Users/brthls/.nvm/versions/node/v22.22.3/bin:/Users/brthls/.nvm/versions/node/v20.19.6/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Applications/quarto/bin:/Users/brthls/.codex/tmp/arg0/codex-arg023Afxt:/Users/brthls/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/brthls/.mavis/bin:/Users/brthls/.opencode/bin:/Users/brthls/.claude/bin:/opt/homebrew/opt/node@22/bin:/Users/brthls/Library/Python/3.9/bin:/Users/brthls/.local/bin:/Users/brthls/.antigravity/antigravity/bin:/opt/homebrew/opt/openjdk@17/bin:/Users/brthls/.nvm/versions/node/v20.19.6/bin:/Users/brthls/.rokit/bin:/Users/brthls/.cargo/bin:/Users/brthls/.orbstack/bin:/Applications/Codex.app/Contents/Resources npm test (workers/remote-mcp)
- npm run typecheck (workers/remote-mcp)
- npm run audit:mcp-refs -- --repo frihet-mcp
- node workers/remote-mcp/scripts/scope-openai-openapi.mjs