### PR TITLE
fix(openai): hide MCP resources from ChatGPT profile

### DIFF
--- a/docs/openai-resubmission-guide.md
+++ b/docs/openai-resubmission-guide.md
@@ -10,7 +10,7 @@
 | 2 | openWorldHint wrong | **DONE** | 4 tools corrected + justifications |
 | 3 | Test cases failing | **READY** | 15 test cases documented |
 | 4 | Privacy policy gaps | **DONE** | Section 10 added (11 sections, 17 langs) |
-| 5 | Sensitive data collection | **DONE** | OpenAI allowlist enforced: 53 reviewed business tools + 3 read-only discovery meta-tools, prompts hidden, restricted fields redacted |
+| 5 | Sensitive data collection | **DONE** | OpenAI allowlist enforced: 53 reviewed business tools + 3 read-only discovery meta-tools, prompts/resources hidden, restricted fields redacted |
 
 ---
 
@@ -85,7 +85,7 @@ OpenAI mode now enforces an explicit allowlist of 53 reviewed business tools. Th
 
 Hidden from OpenAI mode:
 - Payroll, HR, stay/PMS, POS, banking, e-invoicing XML, VIES lookup, VeriFactu/FACe/TicketBAI/KSeF submission, time tracking, recurring invoices, gestoria bulk-send, permissions, onboarding, and period-close tools.
-- All MCP prompts, because several prompt templates reference tools or fields that are intentionally hidden from OpenAI mode.
+- All MCP prompts and resources, because several prompt/resource templates reference tools, fields, or modules that are intentionally hidden from OpenAI mode.
 - `get_quarterly_taxes` and `get_invoice_einvoice`, retained as explicit exclusions for defense in depth.
 
 ### Input fields removed (8 tools)
@@ -110,7 +110,7 @@ Deep recursive redaction ensures nested objects and paginated arrays are clean.
 
 `npm test` now includes `dist/__tests__/openai-profile.test.js`, which asserts:
 - OpenAI mode exposes 56 total tools: 53 reviewed business tools + 3 read-only discovery meta-tools.
-- OpenAI mode exposes 0 prompts.
+- OpenAI mode exposes 0 prompts and 0 resources.
 - Sensitive/newer full-server tools are not visible.
 - Only `send_invoice`, `send_quote`, `create_webhook`, and `update_webhook` have `openWorldHint: true`.
 - Restricted input/output fields are stripped/redacted.

--- a/docs/openai-test-cases.md
+++ b/docs/openai-test-cases.md
@@ -6,7 +6,7 @@
 ## Prerequisites
 
 - Deploy `openai-mcp.frihet.io` with `FRIHET_OPENAI_MODE=true`
-- Verify OpenAI mode exposes 53 reviewed business tools + 3 read-only discovery meta-tools and 0 prompts
+- Verify OpenAI mode exposes 53 reviewed business tools + 3 read-only discovery meta-tools, 0 prompts, and 0 resources
 - Demo API key with sample data: invoices, expenses, clients, vendors, products, quotes
 - Demo account must NOT require MFA or additional signup
 
@@ -206,11 +206,11 @@
 - `create_reservation`
 - `payroll_export`
 - `invite_team_member`
-- All MCP prompts
+- All MCP prompts and resources
 
 **Expected PRESENT discovery tools:** `list_tool_groups`, `search_tools`, `describe_tool`.
 
-**Verification:** Use `list_tools` / `list_prompts` or check the MCP session. OpenAI mode must expose 56 total tools: 53 reviewed business tools + the 3 read-only discovery meta-tools above, and 0 prompts.
+**Verification:** Use `list_tools` / `list_prompts` / `list_resources` or check the MCP session. OpenAI mode must expose 56 total tools: 53 reviewed business tools + the 3 read-only discovery meta-tools above, 0 prompts, and 0 resources.
 
 ---
 
@@ -245,4 +245,4 @@
 | 14 | Excluded tools | Quarterly taxes + e-invoice absent |
 | 15 | Search | Pagination + text search |
 
-**Total: 56 tools available (53 reviewed business tools + 3 read-only discovery meta-tools), 0 prompts, full-server tools hidden by allowlist, 0 government IDs in I/O, 0 credentials leaked.**
+**Total: 56 tools available (53 reviewed business tools + 3 read-only discovery meta-tools), 0 prompts, 0 resources, full-server tools hidden by allowlist, 0 government IDs in I/O, 0 credentials leaked.**

--- a/marketplace/openai/SUBMISSION.md
+++ b/marketplace/openai/SUBMISSION.md
@@ -163,7 +163,7 @@ Before submitting:
 - [ ] `https://openai-mcp.frihet.io/mcp` is reachable with valid MCP response
 - [ ] OAuth metadata at `https://openai-mcp.frihet.io/.well-known/oauth-authorization-server` includes `code_challenge_methods_supported: ["S256"]`
 - [ ] `FRIHET_OPENAI_MODE=true` is active and exposes 53 reviewed business tools + 3 read-only discovery meta-tools
-- [ ] MCP prompts are hidden in OpenAI mode
+- [ ] MCP prompts and resources are hidden in OpenAI mode
 - [ ] `/.well-known/openai-apps-challenge` route added to Worker (deploy BEFORE submitting)
 - [ ] OpenAI redirect URI added to OAuth allowlist (exact URI provided by OpenAI during submission)
 - [ ] OAuth state parameter handler accepts strings of 400+ chars (no truncation)

--- a/src/__tests__/openai-grouped-compose.test.ts
+++ b/src/__tests__/openai-grouped-compose.test.ts
@@ -34,6 +34,7 @@ import {
 import { applyToolExposureProfile, GROUPED_META_TOOL_COUNT } from "../tool-exposure.js";
 import { registerAllTools } from "../tools/register-all.js";
 import { registerAllPrompts } from "../prompts/register-all.js";
+import { registerAllResources } from "../resources/register-all.js";
 import type { IFrihetClient } from "../client-interface.js";
 
 interface ToolConfig {
@@ -110,6 +111,7 @@ function makeComposedServer(): StubMcpServer {
   // 2. OpenAI SECOND (outermost) — gate/redact/annotate, then collapse.
   applyOpenAIProfile(asMcp(server));
   registerAllTools(asMcp(server), makeClient());
+  registerAllResources(asMcp(server));
   registerAllPrompts(asMcp(server));
   return server;
 }
@@ -143,6 +145,9 @@ describe("openai × grouped composition: invariant (1) — meta-tools present, 5
 
     // Prompts still hidden in OpenAI mode.
     assert.equal(server.prompts.length, 0);
+    // Resources are hidden too: full-server static fiscal/compliance resources
+    // are outside the reviewed ChatGPT app surface.
+    assert.equal(server.resources.length, 0);
   });
 
   test("all 3 discovery meta-tools materialise by name despite the OpenAI allow-list", () => {

--- a/src/__tests__/openai-profile.test.ts
+++ b/src/__tests__/openai-profile.test.ts
@@ -14,6 +14,7 @@ import { applyOpenAIProfile } from "../openai-profile.js";
 import { SENSITIVE_FIELD_NAMES } from "../redaction.js";
 import { registerAllTools } from "../tools/register-all.js";
 import { registerAllPrompts } from "../prompts/register-all.js";
+import { registerAllResources } from "../resources/register-all.js";
 import type { IFrihetClient } from "../client-interface.js";
 
 interface ToolConfig {
@@ -84,6 +85,7 @@ function makeOpenAIServer(): StubMcpServer {
     server as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer,
     makeClient(),
   );
+  registerAllResources(server as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer);
   registerAllPrompts(server as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer);
   return server;
 }
@@ -94,6 +96,7 @@ describe("OpenAI profile", () => {
 
     assert.equal(server.tools.size, 53);
     assert.equal(server.prompts.length, 0);
+    assert.equal(server.resources.length, 0);
 
     for (const hiddenTool of [
       "get_quarterly_taxes",

--- a/src/openai-profile.ts
+++ b/src/openai-profile.ts
@@ -12,10 +12,10 @@
  * 4. Redacts sensitive fields from all tool outputs
  * 5. Updates descriptions to reflect modified behavior + openWorldHint justifications
  *
- * The full MCP server (55 tools) remains available for Claude, Cursor,
+ * The full MCP server (157 business tools + MCP extras) remains available for Claude, Cursor,
  * Windsurf, Cline, Codex, and all other MCP clients.
  *
- * OpenAI-safe mode: 53 reviewed tools, 0 prompts, 0 government IDs in I/O.
+ * OpenAI-safe mode: 53 reviewed business tools, 0 prompts, 0 resources, 0 government IDs in I/O.
  * The full MCP surface remains available outside FRIHET_OPENAI_MODE.
  *
  * @see https://developers.openai.com/apps-sdk/app-submission-guidelines
@@ -23,6 +23,7 @@
 
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
+import { MCP_RESOURCE_COUNT } from "./resources/register-all.js";
 import { SENSITIVE_FIELD_NAMES, deepRedact, redactText } from "./redaction.js";
 
 /* ------------------------------------------------------------------ */
@@ -36,6 +37,8 @@ interface OpenAIProfile {
   excludeTools: Set<string>;
   /** Hide MCP prompt templates in OpenAI mode */
   excludePrompts: boolean;
+  /** Hide MCP resources in OpenAI mode */
+  excludeResources: boolean;
   /** Per-tool annotation overrides (merged with existing) */
   annotationOverrides: Record<string, Partial<ToolAnnotations>>;
   /** Per-tool description replacements */
@@ -125,10 +128,12 @@ const PROFILE: OpenAIProfile = {
     "get_invoice_einvoice", // EN16931 XML mandatorily contains seller+buyer NIF/CIF
   ]),
 
-  // MCP prompts can reference tools/fields that are intentionally hidden from
-  // OpenAI mode (for example tax IDs and fiscal filing tools). ChatGPT Apps do
+  // MCP prompts/resources can reference tools/fields/modules that are
+  // intentionally hidden from OpenAI mode (for example tax IDs, fiscal filing
+  // tools, and broad Spanish compliance reference material). ChatGPT Apps do
   // not need them for the public app surface, so remove them from this profile.
   excludePrompts: true,
+  excludeResources: true,
 
   // ── Annotation corrections ──────────────────────────────────────────
   // openWorldHint MUST be true for tools that cause external side effects.
@@ -450,6 +455,11 @@ export function applyOpenAIProfile(server: any): void {
   // registerResource(name, uri, config, handler) — 4 args
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   server.registerResource = (name: string, ...rest: any[]) => {
+    // Public ChatGPT Apps do not need MCP resources. Several full-server
+    // resources contain broad fiscal/compliance reference material or raw
+    // workspace lists that are outside the reviewed 53-tool business surface.
+    if (PROFILE.excludeResources) return;
+
     // Skip resources that expose too much raw PII
     if (EXCLUDE_RESOURCES.has(name)) return;
 
@@ -517,4 +527,6 @@ export const OPENAI_REVIEWED_TOOL_ALLOWLIST: ReadonlySet<string> =
   PROFILE.includeTools;
 
 /** Number of resources excluded in OpenAI mode (for logging). */
-export const OPENAI_EXCLUDED_RESOURCE_COUNT = EXCLUDE_RESOURCES.size;
+export const OPENAI_EXCLUDED_RESOURCE_COUNT = PROFILE.excludeResources
+  ? MCP_RESOURCE_COUNT
+  : EXCLUDE_RESOURCES.size;

--- a/src/resources/register-all.ts
+++ b/src/resources/register-all.ts
@@ -12,6 +12,10 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { IFrihetClient } from "../client-interface.js";
 
+export const MCP_STATIC_RESOURCE_COUNT = 7;
+export const MCP_DYNAMIC_RESOURCE_COUNT = 4;
+export const MCP_RESOURCE_COUNT = MCP_STATIC_RESOURCE_COUNT + MCP_DYNAMIC_RESOURCE_COUNT;
+
 /* ------------------------------------------------------------------ */
 /*  Static data                                                        */
 /* ------------------------------------------------------------------ */

--- a/workers/remote-mcp/public-openai/releases.json
+++ b/workers/remote-mcp/public-openai/releases.json
@@ -6,6 +6,7 @@
   "reviewedBusinessToolCount": 53,
   "discoveryMetaToolCount": 3,
   "promptsCount": 0,
+  "resourcesCount": 0,
   "notes": "ChatGPT connector metadata is scoped to reviewed invoices, expenses, clients/CRM, products, quotes, vendors, webhooks, and monthly summaries. Hidden product modules, regulated identifiers, credentials, and diagnostic metadata are excluded.",
   "products": {
     "mcp_server": {
@@ -18,6 +19,8 @@
       "version": "1.14.5",
       "releasedAt": "2026-06-22",
       "mcpToolCount": 56,
+      "resourcesCount": 0,
+      "promptsCount": 0,
       "delta": "OpenAI ChatGPT scoped connector surface",
       "notes": "OpenAI mode exposes 53 reviewed business tools plus 3 read-only discovery meta-tools. Prompts and hidden full-server modules are not part of this surface."
     }

--- a/workers/remote-mcp/scripts/scope-openai-openapi.mjs
+++ b/workers/remote-mcp/scripts/scope-openai-openapi.mjs
@@ -220,6 +220,7 @@ if (existsSync(join(SRC, "releases.json"))) {
     reviewedBusinessToolCount: 53,
     discoveryMetaToolCount: 3,
     promptsCount: 0,
+    resourcesCount: 0,
     notes:
       "ChatGPT connector metadata is scoped to reviewed invoices, expenses, clients/CRM, products, quotes, vendors, webhooks, and monthly summaries. Hidden product modules, regulated identifiers, credentials, and diagnostic metadata are excluded.",
     products: {
@@ -233,6 +234,8 @@ if (existsSync(join(SRC, "releases.json"))) {
         version: sourceReleases.version,
         releasedAt: sourceReleases.releasedAt,
         mcpToolCount: 56,
+        resourcesCount: 0,
+        promptsCount: 0,
         delta: "OpenAI ChatGPT scoped connector surface",
         notes:
           "OpenAI mode exposes 53 reviewed business tools plus 3 read-only discovery meta-tools. Prompts and hidden full-server modules are not part of this surface.",

--- a/workers/remote-mcp/src/index.ts
+++ b/workers/remote-mcp/src/index.ts
@@ -540,6 +540,7 @@ const WELL_KNOWN_MCP = JSON.stringify({
 // ===========================================================================
 
 const OPENAI_HOST = "https://openai-mcp.frihet.io";
+const OPENAI_LIVE_TOOL_COUNT = OPENAI_ALLOWED_TOOL_COUNT + GROUPED_META_TOOL_COUNT;
 const OPENAI_SCOPED_DESC =
   `AI-native ERP MCP connector — ${OPENAI_ALLOWED_TOOL_COUNT} reviewed tools for invoicing, expenses, ` +
   `clients/CRM, products, quotes, vendors, and webhooks.`;
@@ -576,7 +577,7 @@ at https://app.frihet.io.
 - **Founded:** February 13, 2026. Live product.
 - **Built by:** Viktor Berthelius — indie bootstrapped.
 - **HQ:** Tenerife, Spain (EU)
-- **Connector tools:** ${OPENAI_ALLOWED_TOOL_COUNT} reviewed tools via @frihet/mcp-server
+- **Connector tools:** ${OPENAI_ALLOWED_TOOL_COUNT} reviewed business tools + ${GROUPED_META_TOOL_COUNT} read-only discovery tools via @frihet/mcp-server
 - **OpenAPI spec:** ${OPENAI_HOST}/openapi.json
 
 ---
@@ -636,8 +637,10 @@ const OPENAI_MCP_DESCRIPTOR = {
   docs: "https://docs.frihet.io/desarrolladores/mcp-server",
   npm: "@frihet/mcp-server",
   install_local: "npx @frihet/mcp-server",
-  tools_count: OPENAI_ALLOWED_TOOL_COUNT,
-  resources_count: 11,
+  tools_count: OPENAI_LIVE_TOOL_COUNT,
+  reviewed_business_tools_count: OPENAI_ALLOWED_TOOL_COUNT,
+  discovery_meta_tools_count: GROUPED_META_TOOL_COUNT,
+  resources_count: 0,
   prompts_count: 0,
   registry: [
     "https://smithery.ai/server/frihet/frihet-mcp",


### PR DESCRIPTION
## Summary
- hide all MCP resources from the OpenAI/ChatGPT profile, matching the already-hidden prompts
- align OpenAI metadata and release docs to advertise 56 tools, 0 prompts, 0 resources
- add regression coverage so resource registration stays suppressed in OpenAI mode

## Validation
- npm test
- npm run typecheck (workers/remote-mcp)
- PATH=/Users/brthls/.nvm/versions/node/v22.22.3/bin:$PATH npm test (workers/remote-mcp)
- npm run audit:mcp-refs -- --repo frihet-mcp
- node workers/remote-mcp/scripts/scope-openai-openapi.mjs
- git diff --check