### PR TITLE
fix(openai): strip sensitive OpenAPI schema variants

### DIFF
--- a/workers/remote-mcp/public-openai/openapi.json
+++ b/workers/remote-mcp/public-openai/openapi.json
@@ -15,7 +15,8 @@
     },
     "x-logo": {
       "url": "https://frihet.io/logos/frihet-logo.svg"
-    }
+    },
+    "x-frihet-openai-profile": "chatgpt-reviewed-v2"
   },
   "servers": [
     {
@@ -3705,11 +3706,6 @@
             "description": "Client name (snapshot field — frozen at create)",
             "example": "Acme Corp"
           },
-          "clientTaxId": {
-            "type": "string",
-            "description": "Client regulated identifiers / regulated identifier / tax (snapshot field — frozen at create).\nAuto-populated from clientId reference if not provided.\n",
-            "example": "B12345678"
-          },
           "clientAddress": {
             "type": "string",
             "description": "Client billing address — single-line or structured. Snapshot\nfield, frozen at create.\n",
@@ -4684,10 +4680,6 @@
               "updatedAt": {
                 "type": "string",
                 "format": "date-time"
-              },
-              "hasSecret": {
-                "type": "boolean",
-                "description": "True if an HMAC secret is configured. The secret value itself is never returned by read endpoints."
               }
             }
           },

--- a/workers/remote-mcp/scripts/scope-openai-openapi.mjs
+++ b/workers/remote-mcp/scripts/scope-openai-openapi.mjs
@@ -84,10 +84,10 @@ const TAG_DESCRIPTIONS = {
   Notes: "Manage notes attached to a client.",
 };
 const STRIP_PROPS = [
-  "taxId", "tax_id", "nif", "cif", "vatNumber", "vat_number", "vatId", "vat_id",
+  "taxId", "tax_id", "clientTaxId", "client_tax_id", "nif", "cif", "vatNumber", "vat_number", "vatId", "vat_id",
   "documentType", "documentNumber", "signatureCaptured", "passport", "passportNumber",
   "dni", "nationalId", "national_id", "iban", "bankAccount", "bank_account", "accountNumber",
-  "secret", "apiKey", "api_key", "ssn", "socialSecurityNumber", "social_security_number",
+  "secret", "hasSecret", "has_secret", "apiKey", "api_key", "ssn", "socialSecurityNumber", "social_security_number",
   "requestId", "request_id", "traceId", "trace_id", "sessionId", "session_id",
   "userId", "user_id", "verifactuHash", "verifactu_hash", "meta", "security",
 ];
@@ -203,6 +203,7 @@ if (spec.info) {
     "Frihet ERP API — ChatGPT connector reviewed surface (invoicing, expenses, clients/CRM, " +
     "products, quotes, vendors, webhooks, and monthly summaries). Regulated identifiers, " +
     "banking identifiers, credentials, diagnostic metadata, and hidden product modules are excluded.";
+  spec.info["x-frihet-openai-profile"] = "chatgpt-reviewed-v2";
 }
 spec.servers = [{ url: "https://api.frihet.io", description: "Frihet API" }];
 sanitizeDescriptionsDeep(spec);
@@ -248,7 +249,7 @@ if (existsSync(join(SRC, "releases.json"))) {
 
 const blob = JSON.stringify(spec) + extraAssetText;
 const sensitive = [
-  "\"taxId\"", "requestId", "traceId", "sessionId", "\"userId\"", "ApiKeyAuth", "\"apiKey\"",
+  "\"taxId\"", "\"clientTaxId\"", "\"hasSecret\"", "HMAC secret", "requestId", "traceId", "sessionId", "\"userId\"", "ApiKeyAuth", "\"apiKey\"",
   "verifactuHash", "documentType", "signatureCaptured", "passport", "\"dni\"", "\"iban\"",
   "\"secret\"", "/guests", "/reservations", "/quarterly", "/properties", "Reservations",
   "Guests", "Channels", "VeriFactu", "Facturae", "TicketBAI", "KSeF",

--- a/workers/remote-mcp/src/index.ts
+++ b/workers/remote-mcp/src/index.ts
@@ -782,10 +782,10 @@ const OPENAI_TAG_DESCRIPTIONS: Record<string, string> = {
   Notes: "Manage notes attached to a client.",
 };
 const OPENAI_STRIP_PROPS = [
-  "taxId", "tax_id", "nif", "cif", "vatNumber", "vat_number", "vatId", "vat_id",
+  "taxId", "tax_id", "clientTaxId", "client_tax_id", "nif", "cif", "vatNumber", "vat_number", "vatId", "vat_id",
   "documentType", "documentNumber", "signatureCaptured", "passport", "passportNumber",
   "dni", "nationalId", "national_id", "iban", "bankAccount", "bank_account", "accountNumber",
-  "secret", "apiKey", "api_key", "ssn", "socialSecurityNumber", "social_security_number",
+  "secret", "hasSecret", "has_secret", "apiKey", "api_key", "ssn", "socialSecurityNumber", "social_security_number",
   "requestId", "request_id", "traceId", "trace_id", "sessionId", "session_id",
   "userId", "user_id", "verifactuHash", "verifactu_hash", "meta", "security",
 ];
@@ -920,8 +920,9 @@ function scopeOpenApiForOpenAI(specText: string): string {
   pruneUnusedOpenAIComponents(spec);
   if (spec.info) {
     spec.info.description =
-      "Frihet ERP API — ChatGPT connector reviewed surface (invoicing, expenses, clients/CRM, products, quotes, vendors, webhooks). " +
+      "Frihet ERP API — ChatGPT connector reviewed surface (invoicing, expenses, clients/CRM, products, quotes, vendors, webhooks, and monthly summaries). " +
       "Regulated identifiers, banking identifiers, credentials, diagnostic metadata, and hidden product modules are excluded.";
+    spec.info["x-frihet-openai-profile"] = "chatgpt-reviewed-v2";
   }
   spec.servers = [{ url: "https://api.frihet.io", description: "Frihet API" }];
   sanitizeOpenAIDescriptionsDeep(spec);


### PR DESCRIPTION
## Summary
- strip compound sensitive OpenAPI schema fields (`clientTaxId`, `hasSecret`) from the ChatGPT scoped spec
- align the Worker runtime OpenAPI scoper with the asset generator
- add a stable OpenAI profile extension so `/openapi.json` asset bytes change and deploy cleanly

## Validation
- npm test
- npm run typecheck (workers/remote-mcp)
- PATH=/Users/brthls/.nvm/versions/node/v22.22.3/bin:$PATH npm test (workers/remote-mcp)
- node workers/remote-mcp/scripts/scope-openai-openapi.mjs
- npm run audit:mcp-refs -- --repo frihet-mcp
- git diff --check
- PATH=/Users/brthls/.nvm/versions/node/v22.22.3/bin:$PATH npx wrangler deploy --env openai --dry-run