### PR TITLE
Expose agent-ready MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <a href="https://smithery.ai/server/frihet/frihet-mcp"><img src="https://smithery.ai/badge/frihet/frihet-mcp" alt="Smithery installs"></a>
   <a href="https://registry.modelcontextprotocol.io/?q=io.frihet"><img src="https://img.shields.io/badge/MCP_Registry-io.frihet%2Ferp-4A90D9?style=flat&logo=anthropic&logoColor=white" alt="MCP Registry"></a>
   <a href="https://github.com/Frihet-io/frihet-mcp/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-18181b?style=flat&labelColor=09090b" alt="license"></a>
-  <img src="https://img.shields.io/badge/tools-157-18181b?style=flat&labelColor=09090b" alt="157 tools">
+  <img src="https://img.shields.io/badge/tools-161-18181b?style=flat&labelColor=09090b" alt="161 tools">
   <img src="https://img.shields.io/badge/node-%3E%3D18-18181b?style=flat&labelColor=09090b" alt="node >=18">
   <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-18181b?style=flat&labelColor=09090b" alt="TypeScript"></a>
 </p>
@@ -39,7 +39,7 @@
 | **ChatGPT Apps** | Coming soon | [chatgpt.com](https://chatgpt.com) |
 | **Anthropic Claude Directory** | Coming soon | [claude.ai/settings/connectors](https://claude.ai/settings/connectors) |
 
-> **Tool count:** npm `latest` (1.14.5) ships all 157 tools, same as the remote endpoint (`mcp.frihet.io`).
+> **Tool count:** this source branch registers 161 tools. npm `latest` and `mcp.frihet.io` may report the previous release until this branch is published and deployed.
 
 ---
 
@@ -52,9 +52,9 @@ You:     "Create an invoice for TechStart SL, 40 hours of consulting at 75 EUR/h
 Claude:  Done. Invoice INV-2026-089 created. Total: 3,000.00 EUR + 21% IVA = 3,630.00 EUR.
 ```
 
-157 tools. 11 resources. 10 prompts. Structured output on every tool. Zero boilerplate.
+161 tools. 11 resources. 10 prompts. Structured output on every tool. Zero boilerplate.
 
-<!-- v1.12.0-beta.1 — D4-B megasprint: HR (9), payroll (2), onboarding (2), permissions (2), period close (3), webhook test (1) = +19 = 157 tools total -->
+<!-- v1.12.0-beta.1 — D4-B megasprint: HR (9), payroll (2), onboarding (2), permissions (2), period close (3), webhook test (1); Agent-readiness MCP wrapper adds global search (1), reconciliation suggestions (1), expense attachment reference flow (2) = 161 tools total -->
 
 ---
 
@@ -182,7 +182,7 @@ Talk to your ERP. These are real prompts, not marketing copy.
 
 ## What to expect
 
-This MCP is a **structured data interface** -- you describe what you want in natural language, and the AI creates, queries, or modifies business records in Frihet. All 157 tools are CRUD operations over the REST API.
+This MCP is a **structured data interface** -- you describe what you want in natural language, and the AI creates, queries, or modifies business records in Frihet. All 161 tools are structured operations over the REST API.
 
 **Works great:**
 
@@ -196,7 +196,7 @@ This MCP is a **structured data interface** -- you describe what you want in nat
 **Does not do:**
 
 - OCR or PDF scanning -- you cannot upload an invoice image and have it read
-- File upload or attachment handling
+- Local file reading, raw binary upload, or arbitrary path-based attachment handling
 - Image processing of any kind
 
 If you need to digitize paper invoices or receipts, extract the data first (e.g., Claude Vision API, a dedicated OCR service, or manual entry), then use the MCP to create the record:
@@ -209,7 +209,7 @@ If you need to digitize paper invoices or receipts, extract the data first (e.g.
 
 ---
 
-## Tools (157)
+## Tools (161)
 
 ### Invoices (12)
 
@@ -228,7 +228,7 @@ If you need to digitize paper invoices or receipts, extract the data first (e.g.
 | `create_credit_note` | Create a credit note linked to an existing invoice |
 | `apply_late_fee` | Apply a late payment fee to an overdue invoice |
 
-### Expenses (5)
+### Expenses (7)
 
 | Tool | What it does |
 |------|-------------|
@@ -237,6 +237,8 @@ If you need to digitize paper invoices or receipts, extract the data first (e.g.
 | `create_expense` | Record a new expense |
 | `update_expense` | Modify an expense |
 | `delete_expense` | Delete an expense |
+| `create_expense_attachment_upload` | Prepare a metadata-only attachment upload and file reference |
+| `attach_file_to_expense` | Attach a backend-issued file reference to an expense |
 
 ### Clients (5)
 
@@ -303,13 +305,14 @@ If you need to digitize paper invoices or receipts, extract the data first (e.g.
 | `delete_webhook` | Remove a webhook |
 | `test_webhook` | Send a test payload to a configured webhook endpoint |
 
-### Intelligence (4)
+### Intelligence (5)
 
 | Tool | What it does |
 |------|-------------|
 | `get_business_context` | Full snapshot: profile, plan, recent activity, top clients, current month |
 | `get_monthly_summary` | Monthly P&L: revenue, expenses, profit, tax liability, top clients by revenue |
 | `get_quarterly_taxes` | Quarterly tax prep: Modelo 303/130 fields, collected vs deductible, liability |
+| `search_global` | Read-only global search across Frihet resources |
 | `duplicate_invoice` | Clone an invoice for recurring billing (copies items/client/tax, starts as draft) |
 
 ### E-Invoicing (10)
@@ -438,7 +441,7 @@ If you need to digitize paper invoices or receipts, extract the data first (e.g.
 | `update_vendor` | Update vendor info |
 | `delete_vendor` | Remove a vendor |
 
-### Banking (5)
+### Banking (6)
 
 | Tool | What it does |
 |------|-------------|
@@ -446,6 +449,7 @@ If you need to digitize paper invoices or receipts, extract the data first (e.g.
 | `get_bank_account` | Get details for a bank account |
 | `list_transactions` | List bank transactions with filters |
 | `categorize_transaction` | Assign a category and expense/income type to a transaction |
+| `get_reconciliation_suggestions` | Read-only candidate matches and scoring for a bank transaction |
 | `match_transaction_to_invoice` | Link a bank transaction to an existing invoice |
 
 ### Fiscal — Spanish Tax Models (8)
@@ -523,7 +527,7 @@ If you need to digitize paper invoices or receipts, extract the data first (e.g.
 | `period_close` | Close an accounting period (gestor/admin only — TRUST AREA) |
 | `period_reopen` | Reopen a closed period with a mandatory reason (TRUST AREA) |
 
-All 157 tools return **structured output** via `outputSchema` -- typed JSON, not raw text. List tools return paginated results (`{ data, total, limit, offset }`).
+All 161 tools return **structured output** via `outputSchema` -- typed JSON, not raw text. List tools return paginated results (`{ data, total, limit, offset }`).
 
 ---
 
@@ -746,7 +750,7 @@ npm run build   # must pass before submitting
 
 | Package | What it is |
 |---------|-----------|
-| [`@frihet/mcp-server`](https://www.npmjs.com/package/@frihet/mcp-server) | This MCP server (157 tools, 11 resources, 10 prompts) |
+| [`@frihet/mcp-server`](https://www.npmjs.com/package/@frihet/mcp-server) | This MCP server (161 tools, 11 resources, 10 prompts) |
 | [`@frihet/sdk`](https://github.com/Frihet-io/frihet-sdk) | TypeScript SDK (`frihet.invoices.create()`) |
 | [`frihet`](https://www.npmjs.com/package/frihet) | CLI (`frihet invoices list --status overdue`) |
 | [`n8n-nodes-frihet`](https://www.npmjs.com/package/n8n-nodes-frihet) | n8n community node for workflow automation |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@frihet/mcp-server",
-  "version": "1.14.4",
+  "version": "1.14.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@frihet/mcp-server",
-      "version": "1.14.4",
+      "version": "1.14.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@frihet/mcp-server",
   "version": "1.14.5",
-  "description": "AI-native MCP server for business management — invoices, expenses, deposits, clients, products, quotes, webhooks, CRM, e-invoicing (Facturae/XRechnung/Factur-X/FatturaPA/PEPPOL + FACe Spain B2G + TicketBAI Basque Country + KSeF Poland), vacation rentals, POS, banking, fiscal (Modelo 303/130/390/180/347/415/425/418, VeriFactu, TicketBAI, IS M200/M202), IGIC, AIEM, GL audit approval, white-label portal domain, VIES EU VAT lookup, bank rules, time tracking, recurring invoices, team management, gestoria. 157 tools. Remote endpoint at mcp.frihet.io (zero install). Works with Claude, Cursor, Windsurf, Cline.",
+  "description": "AI-native MCP server for business management — invoices, expenses, deposits, clients, products, quotes, webhooks, CRM, e-invoicing (Facturae/XRechnung/Factur-X/FatturaPA/PEPPOL + FACe Spain B2G + TicketBAI Basque Country + KSeF Poland), vacation rentals, POS, banking, fiscal (Modelo 303/130/390/180/347/415/425/418, VeriFactu, TicketBAI, IS M200/M202), IGIC, AIEM, GL audit approval, white-label portal domain, VIES EU VAT lookup, bank rules, time tracking, recurring invoices, team management, gestoria. 161 tools. Remote endpoint at mcp.frihet.io (zero install). Works with Claude, Cursor, Windsurf, Cline.",
   "type": "module",
   "main": "./dist/index.js",
   "bin": {

--- a/src/__tests__/banking-tools.test.ts
+++ b/src/__tests__/banking-tools.test.ts
@@ -5,7 +5,7 @@
  * Run: npm test (after build)
  *
  * Coverage:
- *   1. Tool registration — all 5 banking tools registered
+ *   1. Tool registration — all 6 banking tools registered
  *   2. list_bank_accounts — success path + structuredContent shape
  *   3. get_bank_account — success path
  *   4. list_transactions — success path + filters
@@ -86,6 +86,28 @@ const MOCK_TRANSACTIONS_LIST = {
   offset: 0,
 };
 
+const MOCK_RECONCILIATION_SUGGESTIONS = {
+  transactionId: "tx_abc123",
+  limit: 5,
+  suggestions: [
+    {
+      documentType: "expense",
+      documentId: "exp_match_001",
+      score: 94,
+      confidence: 94,
+      suggested: true,
+      amountDiff: 0,
+      dateDiff: 1,
+      breakdown: [
+        { signal: "amount", points: 40, similarity: 1, reason: "Amount matches within tolerance" },
+        { signal: "date", points: 24, similarity: 0.8, reason: "Date is within tolerance" },
+        { signal: "counterparty", points: 30, similarity: 1, reason: "Counterparty is similar" },
+      ],
+      reasons: ["Amount matches within tolerance", "Counterparty is similar"],
+    },
+  ],
+};
+
 // ── Client stubs ─────────────────────────────────────────────────────────────
 
 function makeSuccessClient(): import("../client-interface.js").IFrihetClient {
@@ -94,6 +116,7 @@ function makeSuccessClient(): import("../client-interface.js").IFrihetClient {
     getBankAccount: async (_id: string) => MOCK_ACCOUNT,
     listTransactions: async () => MOCK_TRANSACTIONS_LIST,
     categorizeTransaction: async (_id: string, data: Record<string, unknown>) => ({ ...MOCK_TRANSACTION, category: data["category"] }),
+    getReconciliationSuggestions: async () => MOCK_RECONCILIATION_SUGGESTIONS,
     matchTransactionToDocument: async (_txId: string, data: Record<string, unknown>) => ({
       ...MOCK_TRANSACTION,
       matchedDocId: data["documentId"],
@@ -111,6 +134,7 @@ function make404Client(): import("../client-interface.js").IFrihetClient {
     getBankAccount: notFound,
     listTransactions: notFound,
     categorizeTransaction: notFound,
+    getReconciliationSuggestions: notFound,
     matchTransactionToDocument: notFound,
   } as unknown as import("../client-interface.js").IFrihetClient;
 }
@@ -138,8 +162,8 @@ describe("Banking Tools — Registration", () => {
     server = await makeServer(makeSuccessClient);
   });
 
-  test("registers exactly 5 banking tools", () => {
-    assert.equal(server.tools.size, 5);
+  test("registers exactly 6 banking tools", () => {
+    assert.equal(server.tools.size, 6);
   });
 
   test("registers list_bank_accounts", () => {
@@ -160,6 +184,10 @@ describe("Banking Tools — Registration", () => {
 
   test("registers match_transaction_to_invoice", () => {
     assert.ok(server.tools.has("match_transaction_to_invoice"));
+  });
+
+  test("registers get_reconciliation_suggestions", () => {
+    assert.ok(server.tools.has("get_reconciliation_suggestions"));
   });
 });
 
@@ -276,6 +304,37 @@ describe("categorize_transaction — success path", () => {
     const tool = server.tools.get("categorize_transaction")!;
     const result = await tool.handler({ id: "tx_abc123", category: "software", notes: "SaaS Q2" });
     assert.ok(result.content[0]!.text.includes("categorized"));
+  });
+});
+
+// ── get_reconciliation_suggestions ──────────────────────────────────────────
+
+describe("get_reconciliation_suggestions — read-only suggestions", () => {
+  test("returns candidate matches with scoring breakdown", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("get_reconciliation_suggestions")!;
+    const result = await tool.handler({ transactionId: "tx_abc123", limit: 5 });
+
+    assert.ok(!result.isError);
+    const sc = result.structuredContent!;
+    assert.equal(sc["transactionId"], "tx_abc123");
+    const suggestions = sc["suggestions"] as Record<string, unknown>[];
+    assert.equal(suggestions.length, 1);
+    assert.equal(suggestions[0]!["documentId"], "exp_match_001");
+    assert.equal(suggestions[0]!["confidence"], 94);
+    assert.equal(suggestions[0]!["suggested"], true);
+    assert.deepEqual(suggestions[0]!["breakdown"], [
+      { signal: "amount", points: 40, similarity: 1, reason: "Amount matches within tolerance" },
+      { signal: "date", points: 24, similarity: 0.8, reason: "Date is within tolerance" },
+      { signal: "counterparty", points: 30, similarity: 1, reason: "Counterparty is similar" },
+    ]);
+  });
+
+  test("tool is annotated read-only and closed-world", async () => {
+    const server = await makeServer(makeSuccessClient);
+    const tool = server.tools.get("get_reconciliation_suggestions")!;
+    assert.equal(tool.config.annotations?.["readOnlyHint"], true);
+    assert.equal(tool.config.annotations?.["openWorldHint"], false);
   });
 });
 

--- a/src/__tests__/contract.test.ts
+++ b/src/__tests__/contract.test.ts
@@ -140,6 +140,21 @@ const EXPENSE_LIST_ENVELOPE = {
   offset: 0,
 };
 
+const LEGACY_EXPENSE_LIST_ENVELOPE = {
+  data: [
+    {
+      id: "exp_legacy_1",
+      category: "software",
+      date: "2026-03-03",
+      currency: "EUR",
+      _syncedAt: FIRESTORE_TS,
+    },
+  ],
+  total: 1,
+  limit: 20,
+  offset: 0,
+};
+
 const CLIENT_LIST_ENVELOPE = {
   data: [
     {
@@ -218,6 +233,18 @@ describe("output-schema contract — core list reads ({ data, ... } envelope)", 
     const schema = paginatedOutput(expenseItemOutput);
     const parsed = schema.safeParse(EXPENSE_LIST_ENVELOPE);
     assert.equal(parsed.success, true, parsed.success ? "" : JSON.stringify(parsed.error.issues, null, 2));
+  });
+
+  test("legacy expenses missing description/amount validate as optional output fields", () => {
+    const schema = paginatedOutput(expenseItemOutput);
+    const parsed = schema.safeParse(LEGACY_EXPENSE_LIST_ENVELOPE);
+    assert.equal(parsed.success, true, parsed.success ? "" : JSON.stringify(parsed.error.issues, null, 2));
+    if (parsed.success) {
+      const item = parsed.data.data[0] as Record<string, unknown>;
+      assert.equal(item.id, "exp_legacy_1");
+      assert.equal(item.description, undefined);
+      assert.equal(item.amount, undefined);
+    }
   });
 
   test("clients list envelope validates against paginatedOutput(clientItemOutput)", () => {

--- a/src/__tests__/openai-grouped-compose.test.ts
+++ b/src/__tests__/openai-grouped-compose.test.ts
@@ -2,7 +2,7 @@
  * Tests for the OpenAI × grouped tool-exposure COMPOSITION.
  *
  * openai-mcp.frihet.io now runs BOTH profiles: the OpenAI-safe profile
- * (53 reviewed tools, redaction, openWorldHint justification) AND the grouped
+ * (55 reviewed tools, redaction, openWorldHint justification) AND the grouped
  * progressive-disclosure profile (terse descriptions + 3 discovery meta-tools).
  *
  * This is the Trust-Area-critical surface that the ChatGPT app review covers, so
@@ -10,12 +10,12 @@
  *
  *   (1) The 3 grouped meta-tools (search_tools, describe_tool, list_tool_groups)
  *       are PRESENT in OpenAI mode — they register against the real server and
- *       bypass the OpenAI allow-list gate. Live surface = 53 + 3 = 56 tools.
- *   (2) Every one of the 53 reviewed tools has a COLLAPSED (terse) description
+ *       bypass the OpenAI allow-list gate. Live surface = 55 + 3 = 58 tools.
+ *   (2) Every one of the 55 reviewed tools has a COLLAPSED (terse) description
  *       AND still carries the per-tool openWorldHint rationale marker that OpenAI
  *       app review requires.
  *   (3) The grouped catalog (what search_tools / describe_tool / list_tool_groups
- *       surface) contains ONLY the 53 reviewed tools — a tool outside the reviewed
+ *       surface) contains ONLY the 55 reviewed tools — a tool outside the reviewed
  *       set is never returned by search_tools and is rejected by describe_tool.
  *
  * Composition order under test mirrors the worker/stdio init wiring:
@@ -128,20 +128,22 @@ const NON_REVIEWED_TOOLS = [
   "payroll_export",
   "invite_team_member",
   "get_modelo_303_summary",
+  "create_expense_attachment_upload",
+  "attach_file_to_expense",
 ] as const;
 
-describe("openai × grouped composition: invariant (1) — meta-tools present, 53+3 surface", () => {
-  test("registers exactly 53 reviewed tools + 3 meta-tools (56 total)", () => {
+describe("openai × grouped composition: invariant (1) — meta-tools present, 55+3 surface", () => {
+  test("registers exactly 55 reviewed tools + 3 meta-tools (58 total)", () => {
     const server = makeComposedServer();
 
     assert.equal(GROUPED_META_TOOL_COUNT, 3);
-    assert.equal(OPENAI_ALLOWED_TOOL_COUNT, 53, "advertised reviewed count stays 53");
+    assert.equal(OPENAI_ALLOWED_TOOL_COUNT, 55, "advertised reviewed count stays 55");
     assert.equal(
       server.tools.size,
       OPENAI_ALLOWED_TOOL_COUNT + GROUPED_META_TOOL_COUNT,
-      "live surface must be the 53 reviewed tools + 3 meta-tools",
+      "live surface must be the 55 reviewed tools + 3 meta-tools",
     );
-    assert.equal(server.tools.size, 56);
+    assert.equal(server.tools.size, 58);
 
     // Prompts still hidden in OpenAI mode.
     assert.equal(server.prompts.length, 0);
@@ -189,7 +191,7 @@ describe("openai × grouped composition: invariant (1) — meta-tools present, 5
   });
 });
 
-describe("openai × grouped composition: invariant (2) — collapsed + openWorldHint on all 53", () => {
+describe("openai × grouped composition: invariant (2) — collapsed + openWorldHint on all 55", () => {
   test("every reviewed tool is collapsed AND carries an openWorldHint rationale", () => {
     const server = makeComposedServer();
     let reviewedCount = 0;
@@ -228,7 +230,7 @@ describe("openai × grouped composition: invariant (2) — collapsed + openWorld
       );
     }
 
-    assert.equal(reviewedCount, OPENAI_ALLOWED_TOOL_COUNT, "must cover all 53 reviewed tools");
+    assert.equal(reviewedCount, OPENAI_ALLOWED_TOOL_COUNT, "must cover all 55 reviewed tools");
   });
 
   test("open-world tools keep openWorldHint:true rationale; read tools keep false", () => {
@@ -274,7 +276,7 @@ describe("openai × grouped composition: invariant (2) — collapsed + openWorld
 });
 
 describe("openai × grouped composition: invariant (3) — catalog is allow-list-only", () => {
-  test("list_tool_groups counts exactly the 53 reviewed tools", async () => {
+  test("list_tool_groups counts exactly the 55 reviewed tools", async () => {
     const server = makeComposedServer();
     const res = await server.tools.get("list_tool_groups")!.handler({});
     const payload = JSON.parse(res.content[0].text) as {
@@ -283,10 +285,10 @@ describe("openai × grouped composition: invariant (3) — catalog is allow-list
     };
     assert.equal(payload.totalTools, OPENAI_ALLOWED_TOOL_COUNT);
     const sum = payload.groups.reduce((acc, g) => acc + g.toolCount, 0);
-    assert.equal(sum, OPENAI_ALLOWED_TOOL_COUNT, "group counts must sum to 53");
+    assert.equal(sum, OPENAI_ALLOWED_TOOL_COUNT, "group counts must sum to 55");
     assert.ok(payload.groups.every((g) => g.toolCount > 0), "no empty groups listed");
     // Reviewed surface has no fiscal/stay/pos/hr tools → those groups must be absent.
-    for (const forbidden of ["fiscal", "stay", "pos", "hr", "banking"]) {
+    for (const forbidden of ["fiscal", "stay", "pos", "hr"]) {
       assert.ok(
         !payload.groups.some((g) => g.group === forbidden),
         `group ${forbidden} must not appear (no reviewed tools in it)`,
@@ -302,7 +304,7 @@ describe("openai × grouped composition: invariant (3) — catalog is allow-list
       count: number;
       tools: Array<{ name: string }>;
     };
-    assert.equal(payload.count, OPENAI_ALLOWED_TOOL_COUNT, "browse-all returns exactly the 53");
+    assert.equal(payload.count, OPENAI_ALLOWED_TOOL_COUNT, "browse-all returns exactly the 55");
     const leaks = payload.tools.filter((t) => !OPENAI_REVIEWED_TOOL_ALLOWLIST.has(t.name));
     assert.deepEqual(leaks, [], "search_tools must not surface any non-reviewed tool");
   });
@@ -336,7 +338,7 @@ describe("openai × grouped composition: invariant (3) — catalog is allow-list
     assert.equal(payload.tools.length, 0, "fiscal group is empty in the reviewed catalog");
   });
 
-  test("describe_tool serves reviewed tools but REJECTS any tool outside the 53", async () => {
+  test("describe_tool serves reviewed tools but REJECTS any tool outside the 55", async () => {
     const server = makeComposedServer();
 
     // A reviewed tool resolves.

--- a/src/__tests__/openai-profile.test.ts
+++ b/src/__tests__/openai-profile.test.ts
@@ -91,10 +91,10 @@ function makeOpenAIServer(): StubMcpServer {
 }
 
 describe("OpenAI profile", () => {
-  test("exposes exactly the reviewed 53-tool surface", () => {
+  test("exposes exactly the reviewed 55-tool surface", () => {
     const server = makeOpenAIServer();
 
-    assert.equal(server.tools.size, 53);
+    assert.equal(server.tools.size, 55);
     assert.equal(server.prompts.length, 0);
     assert.equal(server.resources.length, 0);
 
@@ -107,8 +107,25 @@ describe("OpenAI profile", () => {
       "create_reservation",
       "payroll_export",
       "invite_team_member",
+      "create_expense_attachment_upload",
+      "attach_file_to_expense",
     ]) {
       assert.equal(server.tools.has(hiddenTool), false, `${hiddenTool} must not be exposed in OpenAI mode`);
+    }
+  });
+
+  test("exposes new read-only agent-readiness tools but excludes attachment writes", () => {
+    const server = makeOpenAIServer();
+
+    for (const name of ["search_global", "get_reconciliation_suggestions"]) {
+      const tool = server.tools.get(name);
+      assert.ok(tool, `${name} should be visible`);
+      assert.equal(tool.config.annotations?.["readOnlyHint"], true);
+      assert.equal(tool.config.annotations?.["openWorldHint"], false);
+    }
+
+    for (const name of ["create_expense_attachment_upload", "attach_file_to_expense"]) {
+      assert.equal(server.tools.has(name), false, `${name} must remain hidden from OpenAI mode`);
     }
   });
 

--- a/src/__tests__/tool-exposure.test.ts
+++ b/src/__tests__/tool-exposure.test.ts
@@ -2,10 +2,10 @@
  * Tests for the grouped tool-exposure profile (progressive disclosure).
  *
  * The default ("full") mode must stay BYTE-IDENTICAL to the un-profiled server
- * so existing users are unaffected. The opt-in "grouped" mode collapses the 151
+ * so existing users are unaffected. The opt-in "grouped" mode collapses the 161
  * full tool descriptions into terse one-liners and adds three discovery
  * meta-tools (list_tool_groups, search_tools, describe_tool) so agents load
- * depth on demand instead of a flat 151-tool wall of context.
+ * depth on demand instead of a flat 161-tool wall of context.
  */
 
 import { describe, test } from "node:test";
@@ -114,9 +114,9 @@ describe("tool-exposure: mode resolution", () => {
 });
 
 describe("tool-exposure: full mode is byte-identical", () => {
-  test("registers exactly 157 tools, no meta-tools, descriptions untouched", () => {
+  test("registers exactly 161 tools, no meta-tools, descriptions untouched", () => {
     const full = makeFullServer();
-    assert.equal(full.tools.size, 157);
+    assert.equal(full.tools.size, 161);
     for (const meta of META_TOOLS) {
       assert.equal(full.tools.has(meta), false, `${meta} must NOT exist in full mode`);
     }
@@ -134,15 +134,15 @@ describe("tool-exposure: full mode is byte-identical", () => {
 });
 
 describe("tool-exposure: grouped mode", () => {
-  test("registers 157 tools + 3 meta-tools and a complete catalog", () => {
+  test("registers 161 tools + 3 meta-tools and a complete catalog", () => {
     const { server, handle } = makeGroupedServer();
-    assert.equal(server.tools.size, 157 + GROUPED_META_TOOL_COUNT);
+    assert.equal(server.tools.size, 161 + GROUPED_META_TOOL_COUNT);
     assert.equal(GROUPED_META_TOOL_COUNT, 3);
     for (const meta of META_TOOLS) {
       assert.equal(server.tools.has(meta), true, `${meta} must exist in grouped mode`);
     }
     // Catalog holds every real tool (meta-tools excluded).
-    assert.equal(handle.catalog.size, 157);
+    assert.equal(handle.catalog.size, 161);
     for (const meta of META_TOOLS) {
       assert.equal(handle.catalog.has(meta), false);
     }
@@ -203,7 +203,7 @@ describe("tool-exposure: grouped mode", () => {
 });
 
 describe("tool-exposure: group taxonomy", () => {
-  test("groupForTool reproduces the source-file grouping for all 157 tools", () => {
+  test("groupForTool reproduces the source-file grouping for all 161 tools", () => {
     const here = dirname(fileURLToPath(import.meta.url));
     const toolsDir = join(here, "..", "..", "src", "tools");
     let checked = 0;
@@ -225,7 +225,7 @@ describe("tool-exposure: group taxonomy", () => {
         if (ng !== fileGroup) mismatches.push(`${name}: name=${ng} file=${fileGroup}`);
       }
     }
-    assert.equal(checked, 157, "should have scanned all 157 registration sites");
+    assert.equal(checked, 161, "should have scanned all 161 registration sites");
     assert.deepEqual(mismatches, [], "groupForTool must match the source-file group");
   });
 
@@ -254,16 +254,16 @@ describe("tool-exposure: group taxonomy", () => {
 });
 
 describe("tool-exposure: meta-tools", () => {
-  test("list_tool_groups returns non-empty groups with counts summing to 157", async () => {
+  test("list_tool_groups returns non-empty groups with counts summing to 161", async () => {
     const { server } = makeGroupedServer();
     const res = await server.tools.get("list_tool_groups")!.handler({});
     const payload = JSON.parse(res.content[0].text) as {
       groups: Array<{ group: string; toolCount: number }>;
       totalTools: number;
     };
-    assert.equal(payload.totalTools, 157);
+    assert.equal(payload.totalTools, 161);
     const sum = payload.groups.reduce((acc, g) => acc + g.toolCount, 0);
-    assert.equal(sum, 157);
+    assert.equal(sum, 161);
     // No empty groups are listed.
     assert.ok(payload.groups.every((g) => g.toolCount > 0));
     // Fiscal is a headline group (compliance depth).

--- a/src/client-interface.ts
+++ b/src/client-interface.ts
@@ -23,6 +23,8 @@ export interface IFrihetClient {
   createExpense(data: Record<string, unknown>): Promise<Record<string, unknown>>;
   updateExpense(id: string, data: Record<string, unknown>): Promise<Record<string, unknown>>;
   deleteExpense(id: string): Promise<void>;
+  createExpenseAttachmentUpload(data: Record<string, unknown>): Promise<Record<string, unknown>>;
+  attachFileToExpense(expenseId: string, data: Record<string, unknown>): Promise<Record<string, unknown>>;
 
   // Clients
   listClients(params?: { limit?: number; offset?: number; after?: string; fields?: string; q?: string; stage?: string }): Promise<PaginatedResponse<Record<string, unknown>>>;
@@ -97,6 +99,7 @@ export interface IFrihetClient {
   getBusinessContext(): Promise<Record<string, unknown>>;
   getMonthlySummary(month?: string): Promise<Record<string, unknown>>;
   getQuarterlyTaxes(quarter?: string): Promise<Record<string, unknown>>;
+  searchGlobal(params: { query: string; types?: string[] | string; limit?: number; offset?: number }): Promise<PaginatedResponse<Record<string, unknown>>>;
 
   // E-Invoicing endpoints (CF rolling out 2026-04-21 to 2026-04-28; 404 → stub fallback)
   sendEInvoice(params: { invoiceId: string; format: string; dispatchMode: string }): Promise<{ workflowRunId: string; status: "queued"; estimatedCompletionSec: number }>;
@@ -137,6 +140,7 @@ export interface IFrihetClient {
   getBankAccount(id: string): Promise<Record<string, unknown>>;
   listTransactions(params?: { accountId?: string; from?: string; to?: string; status?: string; category?: string; limit?: number; offset?: number; after?: string }): Promise<PaginatedResponse<Record<string, unknown>>>;
   categorizeTransaction(id: string, data: { category: string; notes?: string }): Promise<Record<string, unknown>>;
+  getReconciliationSuggestions(transactionId: string, params?: { limit?: number }): Promise<Record<string, unknown>>;
   matchTransactionToDocument(transactionId: string, data: { documentId: string; documentType: "invoice" | "expense"; notes?: string }): Promise<Record<string, unknown>>;
 
   // Fiscal endpoints (/v1/fiscal/*)

--- a/src/client.ts
+++ b/src/client.ts
@@ -327,6 +327,17 @@ export class FrihetClient {
     return this.request("DELETE", `/expenses/${encodeURIComponent(id)}`);
   }
 
+  async createExpenseAttachmentUpload(data: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return this.request("POST", "/expenses/attachments/uploads", data);
+  }
+
+  async attachFileToExpense(
+    expenseId: string,
+    data: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    return this.request("POST", `/expenses/${encodeURIComponent(expenseId)}/attachments`, data);
+  }
+
   // ---------------------------------------------------------------- Clients
   // ----------------------------------------------------------------
 
@@ -906,6 +917,18 @@ export class FrihetClient {
     });
   }
 
+  async searchGlobal(
+    params: { query: string; types?: string[] | string; limit?: number; offset?: number },
+  ): Promise<PaginatedResponse<Record<string, unknown>>> {
+    const types = Array.isArray(params.types) ? params.types.join(",") : params.types;
+    return this.requestPaginated("GET", "/search/global", undefined, {
+      q: params.query,
+      types,
+      limit: params.limit,
+      offset: params.offset,
+    });
+  }
+
   // ---------------------------------------------------------------- Banking
   // /v1/banking/* endpoints are LIVE in Frihet-ERP (#848): accounts list/get,
   // transactions list/categorize/match. Paths below match the shipped server
@@ -944,6 +967,15 @@ export class FrihetClient {
     data: { category: string; notes?: string },
   ): Promise<Record<string, unknown>> {
     return this.request("PATCH", `/banking/transactions/${encodeURIComponent(id)}/categorize`, data);
+  }
+
+  async getReconciliationSuggestions(
+    transactionId: string,
+    params?: { limit?: number },
+  ): Promise<Record<string, unknown>> {
+    return this.request("GET", `/banking/transactions/${encodeURIComponent(transactionId)}/suggestions`, undefined, {
+      limit: params?.limit,
+    });
   }
 
   async matchTransactionToDocument(

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,7 @@ function main(): void {
     version: PKG_VERSION,
     description:
       "AI-native MCP server for Frihet ERP — invoices, expenses, clients, products, quotes, webhooks, and deposits. " +
-      "Provides 157 tools (including business context, monthly summaries, quarterly taxes, invoice duplication, CRM subcollections, and deposit management), " +
+      "Provides 161 tools (including business context, monthly summaries, quarterly taxes, invoice duplication, CRM subcollections, and deposit management), " +
       "11 resources (8 static + 3 live), and 10 workflow prompts for business management " +
       "with full Spanish tax compliance (IVA, IGIC, IPSI).",
   });
@@ -111,7 +111,7 @@ function main(): void {
   //   1. applyToolExposureProfile FIRST (innermost) — so the 3 discovery
   //      meta-tools register against the REAL server.registerTool and bypass the
   //      OpenAI allow-list gate. In allow-list mode it catalogs ONLY the reviewed
-  //      tools, keeping the progressive-disclosure surface == the reviewed 53.
+  //      tools, keeping the progressive-disclosure surface == the reviewed 55.
   //   2. applyOpenAIProfile SECOND (outermost) — a business-tool registration is
   //      first gated/redacted/annotated/openWorldHint-justified by OpenAI, THEN
   //      collapsed by the grouped interceptor, so the terse collapsed line is the
@@ -122,10 +122,10 @@ function main(): void {
   // Apply grouped tool-exposure profile if enabled (progressive disclosure).
   // FRIHET_TOOL_MODE=grouped collapses the full tool descriptions into terse
   // one-liners + adds list_tool_groups / search_tools / describe_tool meta-tools,
-  // so agents load depth on demand instead of a flat 157-tool wall of context.
+  // so agents load depth on demand instead of a flat 161-tool wall of context.
   // Default (unset / "full") is byte-identical to current behavior. When OpenAI
   // mode is also on, pass the reviewed allow-list so the catalog/meta-tools are
-  // pinned to exactly the 53 reviewed tools.
+  // pinned to exactly the 55 reviewed tools.
   if (toolMode === "grouped") {
     applyToolExposureProfile(
       server,
@@ -148,7 +148,7 @@ function main(): void {
     });
   }
 
-  // Register tools (62 full / 60 in OpenAI mode)
+  // Register tools (161 full / 55 reviewed business tools in OpenAI mode)
   registerAllTools(server, client);
 
   // Register 11 resources (8 static + 3 dynamic via API)
@@ -163,7 +163,7 @@ function main(): void {
   // Connect via stdio transport
   const transport = new StdioServerTransport();
   server.connect(transport).then(() => {
-    console.error(`[frihet-mcp] v${PKG_VERSION} | 157 tools | https://github.com/Frihet-io/frihet-mcp`);
+    console.error(`[frihet-mcp] v${PKG_VERSION} | 161 tools | https://github.com/Frihet-io/frihet-mcp`);
     log({
       level: "info",
       message: "Frihet MCP server running on stdio",

--- a/src/openai-profile.ts
+++ b/src/openai-profile.ts
@@ -12,10 +12,10 @@
  * 4. Redacts sensitive fields from all tool outputs
  * 5. Updates descriptions to reflect modified behavior + openWorldHint justifications
  *
- * The full MCP server (157 business tools + MCP extras) remains available for Claude, Cursor,
+ * The full MCP server (161 business tools + MCP extras) remains available for Claude, Cursor,
  * Windsurf, Cline, Codex, and all other MCP clients.
  *
- * OpenAI-safe mode: 53 reviewed business tools, 0 prompts, 0 resources, 0 government IDs in I/O.
+ * OpenAI-safe mode: 55 reviewed business tools, 0 prompts, 0 resources, 0 government IDs in I/O.
  * The full MCP surface remains available outside FRIHET_OPENAI_MODE.
  *
  * @see https://developers.openai.com/apps-sdk/app-submission-guidelines
@@ -60,6 +60,7 @@ const PROFILE: OpenAIProfile = {
     // Read-only tools
     "get_business_context",
     "get_monthly_summary",
+    "search_global",
     "list_invoices",
     "get_invoice",
     "search_invoices",
@@ -79,6 +80,7 @@ const PROFILE: OpenAIProfile = {
     "get_vendor",
     "list_webhooks",
     "get_webhook",
+    "get_reconciliation_suggestions",
 
     // Create tools
     "create_invoice",
@@ -457,7 +459,7 @@ export function applyOpenAIProfile(server: any): void {
   server.registerResource = (name: string, ...rest: any[]) => {
     // Public ChatGPT Apps do not need MCP resources. Several full-server
     // resources contain broad fiscal/compliance reference material or raw
-    // workspace lists that are outside the reviewed 53-tool business surface.
+    // workspace lists that are outside the reviewed 55-tool business surface.
     if (PROFILE.excludeResources) return;
 
     // Skip resources that expose too much raw PII
@@ -509,7 +511,7 @@ export const OPENAI_EXCLUDED_COUNT = PROFILE.excludeTools.size;
 export const OPENAI_ALLOWED_TOOL_COUNT = PROFILE.includeTools.size;
 
 /**
- * The reviewed OpenAI tool allow-list (the 53 business tools), exposed read-only
+ * The reviewed OpenAI tool allow-list (the 55 business tools), exposed read-only
  * so the grouped tool-exposure profile can pin its catalog to EXACTLY this set
  * when the two profiles are composed on openai-mcp.frihet.io. The progressive-
  * disclosure meta-tools (search_tools / describe_tool / list_tool_groups) must
@@ -517,11 +519,11 @@ export const OPENAI_ALLOWED_TOOL_COUNT = PROFILE.includeTools.size;
  * `allowlist` enforces that statically. This is the SAME object used to gate
  * registerTool, so the two can never drift apart.
  *
- * NOTE: this is the 53 BUSINESS tools only. It deliberately does NOT contain the
+ * NOTE: this is the 55 BUSINESS tools only. It deliberately does NOT contain the
  * 3 grouped meta-tools — those are registered directly on the real server
  * (bypassing the OpenAI gate) by applyToolExposureProfile when it runs first, so
- * OPENAI_ALLOWED_TOOL_COUNT (and every advertised "53 reviewed tools" doc) stays
- * correct while the live tools/list still materialises 53 + 3 = 56 tools.
+ * OPENAI_ALLOWED_TOOL_COUNT (and every advertised "55 reviewed tools" doc) stays
+ * correct while the live tools/list still materialises 55 + 3 = 58 tools.
  */
 export const OPENAI_REVIEWED_TOOL_ALLOWLIST: ReadonlySet<string> =
   PROFILE.includeTools;

--- a/src/tool-exposure.ts
+++ b/src/tool-exposure.ts
@@ -3,10 +3,10 @@
  *
  * Activated by FRIHET_TOOL_MODE=grouped (env var or Worker binding).
  * Default (unset, or FRIHET_TOOL_MODE=full) leaves the server BYTE-IDENTICAL
- * to today: all 151 tools registered with their full descriptions/schemas.
+ * to today: all 161 tools registered with their full descriptions/schemas.
  *
  * ── Why ──────────────────────────────────────────────────────────────────
- * Context rot is the 2026 problem: a flat list of 151 tool descriptions,
+ * Context rot is the 2026 problem: a flat list of 161 tool descriptions,
  * each a multi-paragraph bilingual blob, eats the agent's context window and
  * degrades tool selection before any work begins. Leaders cut flat lists.
  *
@@ -30,12 +30,12 @@
  *        • search_tools(query)     — fuzzy match → matching tool summaries
  *        • describe_tool(name)     — full original description + input fields
  *
- * The agent loads ~3 meta-tool descriptions + 151 terse one-liners instead of
- * 151 full bilingual blobs, then pulls full depth only for the handful of
+ * The agent loads ~3 meta-tool descriptions + 161 terse one-liners instead of
+ * 161 full bilingual blobs, then pulls full depth only for the handful of
  * tools it actually needs. Progressive disclosure, zero behavior change.
  *
  * IMPORTANT: this is purely an EXPOSURE layer. It does NOT live in
- * src/tools/*.ts, so the audited tool count stays 151 (+ meta). The meta-tools
+ * src/tools/*.ts, so the audited tool count stays 161 (+ meta). The meta-tools
  * are added only in grouped mode and are NOT counted as ERP tools.
  *
  * @see ./openai-profile.ts — the sibling interceptor this mirrors.
@@ -179,7 +179,7 @@ export const FILE_TO_GROUP: Record<string, ToolGroupId> = {
 
 /**
  * Per-tool overrides where the source FILE places a tool in a different group
- * than a naive name match would (verified against the 151 registration sites).
+ * than a naive name match would (verified against the 161 registration sites).
  * These eight names live in a file whose domain differs from their name prefix
  * (e.g. e-invoicing tools say "invoice" but belong to fiscal/compliance).
  */
@@ -190,8 +190,10 @@ const NAME_OVERRIDES: Record<string, ToolGroupId> = {
   einvoice_export: "fiscal",
   export_datev: "fiscal",
   match_transaction_to_invoice: "banking",
+  get_reconciliation_suggestions: "banking",
   get_quarterly_taxes: "intelligence",
   duplicate_invoice: "intelligence",
+  search_global: "intelligence",
   frihet_portal_onboard_link_generate: "fiscal",
   // Lives in invoices.ts (an invoice action that returns its e-invoice XML),
   // so it stays in the "invoicing" group with its sibling invoice tools.
@@ -200,8 +202,8 @@ const NAME_OVERRIDES: Record<string, ToolGroupId> = {
 
 /**
  * Assign a group by tool NAME. The name-based mapping reproduces the
- * source-file grouping exactly for all 151 current tools (verified), with the
- * eight cross-file cases pinned via NAME_OVERRIDES. Driven off the name (not a
+ * source-file grouping exactly for all 161 current tools (verified), with the
+ * cross-file cases pinned via NAME_OVERRIDES. Driven off the name (not a
  * hand-kept list) so a future tool lands somewhere sensible automatically.
  *
  * Order matters: e-invoicing ("einvoice") is checked before generic "invoice".
@@ -314,14 +316,14 @@ export function resolveToolMode(
  *   This is the OpenAI-composition path: it pins the grouped catalog (and the
  *   tools search_tools / describe_tool / list_tool_groups surface) to EXACTLY
  *   the reviewed allow-list, so progressive disclosure can never reveal or
- *   describe a tool outside the 53-tool ChatGPT-reviewed surface. Omit (default)
+ *   describe a tool outside the 55-tool ChatGPT-reviewed surface. Omit (default)
  *   for the open mcp.frihet.io surface, which catalogs every registered tool.
  *
  *   COMPOSITION ORDERING (openai-mcp): apply this profile FIRST so its
  *   originalRegisterTool is the REAL server.registerTool — the three meta-tools
  *   are then registered straight onto the real server and BYPASS the OpenAI
  *   allow-list gate entirely (so they always materialise without polluting the
- *   OpenAI includeTools set / its advertised 53-tool count). Apply
+ *   OpenAI includeTools set / its advertised 55-tool count). Apply
  *   applyOpenAIProfile() SECOND (outermost) so a business-tool registration is
  *   first redacted + annotated + openWorldHint-justified by OpenAI, and only
  *   THEN collapsed here — making the terse line the final description while the

--- a/src/tools/banking.ts
+++ b/src/tools/banking.ts
@@ -31,6 +31,7 @@ import {
   paginatedOutput,
   bankAccountItemOutput,
   bankTransactionItemOutput,
+  reconciliationSuggestionsOutput,
 } from "./shared.js";
 
 export function registerBankingTools(server: McpServer, client: IFrihetClient): void {
@@ -150,6 +151,33 @@ export function registerBankingTools(server: McpServer, client: IFrihetClient): 
       const result = await client.categorizeTransaction(id, { category, notes });
       return {
         content: [mutateContent(formatRecord("Transaction categorized", result))],
+        structuredContent: result as unknown as Record<string, unknown>,
+      };
+    }),
+  );
+
+  // -- get_reconciliation_suggestions --
+
+  server.registerTool(
+    "get_reconciliation_suggestions",
+    {
+      title: "Get Reconciliation Suggestions",
+      description:
+        "Read-only reconciliation assistant for a bank transaction. " +
+        "Returns top invoice/expense candidates and scoring breakdowns without creating a match. " +
+        "Use match_transaction_to_invoice with confirm=true only after the user confirms a candidate. " +
+        "/ Sugerencias de conciliacion de solo lectura para un movimiento bancario.",
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        transactionId: z.string().describe("Bank transaction ID / ID del movimiento bancario"),
+        limit: z.number().int().min(1).max(20).optional().describe("Max candidates (1-20) / Candidatos maximos"),
+      },
+      outputSchema: reconciliationSuggestionsOutput,
+    },
+    async ({ transactionId, limit }) => withToolLogging("get_reconciliation_suggestions", async () => {
+      const result = await client.getReconciliationSuggestions(transactionId, { limit });
+      return {
+        content: [getContent(formatRecord("Reconciliation suggestions", result))],
         structuredContent: result as unknown as Record<string, unknown>,
       };
     }),

--- a/src/tools/expenses.ts
+++ b/src/tools/expenses.ts
@@ -5,7 +5,37 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod/v4";
 import type { IFrihetClient } from "../client-interface.js";
-import { withToolLogging, formatPaginatedResponse, formatRecord, listContent, getContent, mutateContent, enrichResponse, READ_ONLY_ANNOTATIONS, CREATE_ANNOTATIONS, UPDATE_ANNOTATIONS, DELETE_ANNOTATIONS, paginatedOutput, deleteResultOutput, expenseItemOutput } from "./shared.js";
+import { withToolLogging, formatPaginatedResponse, formatRecord, listContent, getContent, mutateContent, enrichResponse, READ_ONLY_ANNOTATIONS, CREATE_ANNOTATIONS, UPDATE_ANNOTATIONS, DELETE_ANNOTATIONS, paginatedOutput, deleteResultOutput, expenseItemOutput, expenseAttachmentUploadOutput, expenseAttachmentOutput } from "./shared.js";
+
+const expenseMulticurrencyFields = {
+  currency: z
+    .string()
+    .length(3)
+    .optional()
+    .describe("Expense currency ISO 4217 code. Defaults to EUR when omitted / Moneda ISO 4217; por defecto EUR"),
+  exchangeRate: z
+    .number()
+    .positive()
+    .optional()
+    .describe("Rate from expense currency to functional currency / Tipo de cambio a moneda funcional"),
+  exchangeRateSource: z
+    .string()
+    .optional()
+    .describe("Exchange-rate source (e.g. ECB, manual) / Fuente del tipo de cambio"),
+  exchangeRateDate: z
+    .string()
+    .optional()
+    .describe("Exchange-rate date in ISO 8601 (YYYY-MM-DD) / Fecha del tipo de cambio"),
+  functionalCurrency: z
+    .string()
+    .length(3)
+    .optional()
+    .describe("Functional currency ISO 4217 code, normally EUR / Moneda funcional ISO 4217"),
+  functionalAmount: z
+    .number()
+    .optional()
+    .describe("Amount converted to the functional currency / Importe convertido a moneda funcional"),
+};
 
 export function registerExpenseTools(server: McpServer, client: IFrihetClient): void {
   // -- list_expenses --
@@ -113,6 +143,7 @@ export function registerExpenseTools(server: McpServer, client: IFrihetClient): 
           .boolean()
           .optional()
           .describe("Whether the expense is tax deductible / Si el gasto es deducible fiscalmente"),
+        ...expenseMulticurrencyFields,
       },
       outputSchema: expenseItemOutput,
     },
@@ -145,6 +176,7 @@ export function registerExpenseTools(server: McpServer, client: IFrihetClient): 
         date: z.string().optional().describe("Date (YYYY-MM-DD) / Fecha"),
         vendor: z.string().optional().describe("Vendor / Proveedor"),
         taxDeductible: z.boolean().optional().describe("Tax deductible / Deducible"),
+        ...expenseMulticurrencyFields,
       },
       outputSchema: expenseItemOutput,
     },
@@ -178,6 +210,66 @@ export function registerExpenseTools(server: McpServer, client: IFrihetClient): 
       return {
         content: [mutateContent(`Expense ${id} deleted successfully. / Gasto ${id} eliminado correctamente.`)],
         structuredContent: { success: true, id, ...hints } as unknown as Record<string, unknown>,
+      };
+    }),
+  );
+
+  // -- create_expense_attachment_upload --
+
+  server.registerTool(
+    "create_expense_attachment_upload",
+    {
+      title: "Create Expense Attachment Upload",
+      description:
+        "Prepare a safe upload slot for an expense attachment using file metadata only. " +
+        "This tool never reads local file paths and never accepts raw binary content. " +
+        "Use the returned file reference/upload metadata with the external uploader, then call attach_file_to_expense. " +
+        "/ Prepara una subida segura para adjunto de gasto usando solo metadatos del archivo.",
+      annotations: CREATE_ANNOTATIONS,
+      inputSchema: {
+        fileName: z.string().min(1).describe("Original file name only, not a local path / Nombre del archivo, no ruta local"),
+        contentType: z.string().min(1).describe("MIME type, e.g. application/pdf or image/jpeg / Tipo MIME"),
+        sizeBytes: z.number().int().positive().describe("File size in bytes / Tamano del archivo en bytes"),
+        expenseId: z.string().optional().describe("Optional expense ID to scope the upload / ID de gasto opcional"),
+        checksumSha256: z.string().optional().describe("Optional SHA-256 checksum of the file content / Checksum SHA-256 opcional"),
+      },
+      outputSchema: expenseAttachmentUploadOutput,
+    },
+    async (input) => withToolLogging("create_expense_attachment_upload", async () => {
+      const result = await client.createExpenseAttachmentUpload(input);
+      return {
+        content: [mutateContent(formatRecord("Expense attachment upload prepared", result))],
+        structuredContent: result as unknown as Record<string, unknown>,
+      };
+    }),
+  );
+
+  // -- attach_file_to_expense --
+
+  server.registerTool(
+    "attach_file_to_expense",
+    {
+      title: "Attach File to Expense",
+      description:
+        "Attach an already-uploaded file reference to an expense. " +
+        "Requires a backend-issued fileReferenceId; local paths and raw file bytes are not accepted. " +
+        "/ Adjunta a un gasto una referencia de archivo ya subida.",
+      annotations: CREATE_ANNOTATIONS,
+      inputSchema: {
+        expenseId: z.string().describe("Expense ID / ID del gasto"),
+        fileReferenceId: z.string().describe("Backend-issued file reference ID / Referencia de archivo emitida por backend"),
+        fileName: z.string().min(1).describe("Display file name / Nombre visible del archivo"),
+        contentType: z.string().min(1).describe("MIME type / Tipo MIME"),
+        sizeBytes: z.number().int().positive().describe("File size in bytes / Tamano en bytes"),
+        notes: z.string().optional().describe("Optional attachment notes / Notas opcionales"),
+      },
+      outputSchema: expenseAttachmentOutput,
+    },
+    async ({ expenseId, ...data }) => withToolLogging("attach_file_to_expense", async () => {
+      const result = await client.attachFileToExpense(expenseId, data);
+      return {
+        content: [mutateContent(formatRecord("Expense attachment linked", result))],
+        structuredContent: result as unknown as Record<string, unknown>,
       };
     }),
   );

--- a/src/tools/intelligence.ts
+++ b/src/tools/intelligence.ts
@@ -18,8 +18,12 @@ import {
   formatRecord,
   getContent,
   mutateContent,
+  listContent,
+  formatPaginatedResponse,
   READ_ONLY_ANNOTATIONS,
   CREATE_ANNOTATIONS,
+  paginatedOutput,
+  globalSearchResultOutput,
 } from "./shared.js";
 
 export function registerIntelligenceTools(server: McpServer, client: IFrihetClient): void {
@@ -108,6 +112,37 @@ export function registerIntelligenceTools(server: McpServer, client: IFrihetClie
       const label = quarter ? `Quarterly Taxes (${quarter})` : "Quarterly Taxes (current quarter)";
       return {
         content: [getContent(formatRecord(label, result))],
+        structuredContent: result as unknown as Record<string, unknown>,
+      };
+    }),
+  );
+
+  // -- search_global --
+
+  server.registerTool(
+    "search_global",
+    {
+      title: "Search Global",
+      description:
+        "Read-only global search across Frihet resources. " +
+        "Returns typed matches with resource/type, id, title/snippet, score, and URL metadata when the API provides it. " +
+        "/ Busqueda global de solo lectura en recursos de Frihet.",
+      annotations: READ_ONLY_ANNOTATIONS,
+      inputSchema: {
+        query: z.string().min(1).describe("Search query / Texto de busqueda"),
+        types: z
+          .array(z.enum(["invoices", "expenses", "vendors", "clients", "products"]))
+          .optional()
+          .describe("Optional resource types to search / Tipos de recurso opcionales"),
+        limit: z.number().int().min(1).max(50).optional().describe("Max results (1-50) / Resultados maximos"),
+        offset: z.number().int().min(0).optional().describe("Offset / Desplazamiento"),
+      },
+      outputSchema: paginatedOutput(globalSearchResultOutput),
+    },
+    async ({ query, types, limit, offset }) => withToolLogging("search_global", async () => {
+      const result = await client.searchGlobal({ query, types, limit, offset });
+      return {
+        content: [listContent(formatPaginatedResponse("global_search_results", result))],
         structuredContent: result as unknown as Record<string, unknown>,
       };
     }),

--- a/src/tools/register-all.ts
+++ b/src/tools/register-all.ts
@@ -1,12 +1,12 @@
 /**
- * Barrel module that registers all 151 Frihet ERP tools on an McpServer.
+ * Barrel module that registers all 161 Frihet ERP tools on an McpServer.
  *
  * Used by both the local (stdio) and remote (Cloudflare Workers) servers
  * so tool definitions stay in sync — one source of truth.
  *
  * Langfuse observability is injected by patching server.registerTool once
  * before any tool registration. This wraps every tool callback with
- * traceMCPTool so all 151 tools are instrumented at zero per-tool cost.
+ * traceMCPTool so all 161 tools are instrumented at zero per-tool cost.
  */
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -47,7 +47,7 @@ import { registerAccountingCloseTools } from "./accountingClose.js";
 /**
  * Patches server.registerTool to wrap every tool callback with Langfuse tracing.
  *
- * The patch is applied once before tool registration so all 151 tools are
+ * The patch is applied once before tool registration so all 161 tools are
  * instrumented without per-tool edits. Tool call signatures are unchanged —
  * existing MCP clients continue to work identically.
  *
@@ -64,6 +64,9 @@ import { registerAccountingCloseTools } from "./accountingClose.js";
  *   Onboarding (2): onboarding_status, onboarding_persona_set
  *   Permissions (2): permissions_matrix, permissions_me
  *   Period close (3): period_close_status, period_close, period_reopen
+ *
+ * Agent-readiness MCP wrapper: search_global, get_reconciliation_suggestions,
+ * create_expense_attachment_upload, attach_file_to_expense (+4).
  */
 function patchServerWithTracing(server: McpServer): void {
   // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -367,12 +367,44 @@ export const invoiceItemOutput = z.object({
 
 export const expenseItemOutput = z.object({
   id: z.string(),
-  description: z.string(),
-  amount: z.number(),
+  description: z.string().optional(),
+  amount: z.number().optional(),
   category: z.string().optional(),
   date: z.string().optional(),
   vendor: z.string().optional(),
   taxDeductible: z.boolean().optional(),
+  currency: z.string().optional(),
+  exchangeRate: z.number().optional(),
+  exchangeRateSource: z.string().optional(),
+  exchangeRateDate: z.string().optional(),
+  functionalCurrency: z.string().optional(),
+  functionalAmount: z.number().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+}).passthrough();
+
+export const expenseAttachmentUploadOutput = z.object({
+  uploadId: z.string().optional(),
+  fileReferenceId: z.string().optional(),
+  fileReference: z.string().optional(),
+  uploadUrl: z.string().optional(),
+  method: z.string().optional(),
+  headers: z.record(z.string(), z.string()).optional(),
+  expiresAt: z.string().optional(),
+  maxSizeBytes: z.number().int().optional(),
+  contentType: z.string().optional(),
+}).passthrough();
+
+export const expenseAttachmentOutput = z.object({
+  id: z.string().optional(),
+  attachmentId: z.string().optional(),
+  expenseId: z.string().optional(),
+  fileReferenceId: z.string().optional(),
+  fileReference: z.string().optional(),
+  fileName: z.string().optional(),
+  contentType: z.string().optional(),
+  sizeBytes: z.number().int().optional(),
+  status: z.string().optional(),
   createdAt: z.string().optional(),
   updatedAt: z.string().optional(),
 }).passthrough();
@@ -630,6 +662,56 @@ export const bankTransactionItemOutput = z.object({
   matchedDocId: z.string().optional(),
   createdAt: z.string().optional(),
   updatedAt: z.string().optional(),
+}).passthrough();
+
+const reconciliationCandidateOutput = z.object({
+  id: z.string().optional(),
+  documentId: z.string().optional(),
+  resource: z.string().optional(),
+  type: z.string().optional(),
+  documentType: z.enum(["invoice", "expense"]).optional(),
+  confidence: z.number().optional(),
+  suggested: z.boolean().optional(),
+  amountDiff: z.number().optional(),
+  dateDiff: z.number().optional(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  amount: z.number().optional(),
+  currency: z.string().optional(),
+  date: z.string().optional(),
+  score: z.number().optional(),
+  scoring: z.record(z.string(), z.number()).optional(),
+  scoringBreakdown: z.record(z.string(), z.number()).optional(),
+  breakdown: z.array(z.object({
+    signal: z.string().optional(),
+    points: z.number().optional(),
+    similarity: z.number().optional(),
+    reason: z.string().optional(),
+  }).passthrough()).optional(),
+  reasons: z.array(z.string()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+}).passthrough();
+
+export const reconciliationSuggestionsOutput = z.object({
+  transactionId: z.string().optional(),
+  limit: z.number().int().optional(),
+  candidates: z.array(reconciliationCandidateOutput).optional(),
+  topCandidates: z.array(reconciliationCandidateOutput).optional(),
+  suggestions: z.array(reconciliationCandidateOutput).optional(),
+  generatedAt: z.string().optional(),
+}).passthrough();
+
+export const globalSearchResultOutput = z.object({
+  id: z.string(),
+  resource: z.string().optional(),
+  type: z.string().optional(),
+  title: z.string().optional(),
+  snippet: z.string().optional(),
+  score: z.number().optional(),
+  url: z.string().optional(),
+  href: z.string().optional(),
+  path: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 }).passthrough();
 
 /* --- Fiscal item schemas --------------------------------------------------- */

--- a/workers/remote-mcp/public-openai/openapi.json
+++ b/workers/remote-mcp/public-openai/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Frihet API",
     "version": "2026-03-18",
-    "description": "Frihet ERP API — ChatGPT connector reviewed surface (invoicing, expenses, clients/CRM, products, quotes, vendors, webhooks, and monthly summaries). Regulated identifiers, banking identifiers, credentials, diagnostic metadata, and hidden product modules are excluded.",
+    "description": "Frihet ERP API — ChatGPT connector reviewed surface (invoicing, expenses, clients/CRM, products, quotes, vendors, webhooks, global search, reconciliation suggestions, and monthly summaries). Regulated identifiers, banking identifiers, credentials, diagnostic metadata, and hidden product modules are excluded.",
     "contact": {
       "name": "Frihet API Support",
       "url": "https://docs.frihet.io/desarrolladores/api-rest",
@@ -55,7 +55,15 @@
     },
     {
       "name": "Intelligence",
-      "description": "Business context and monthly financial summaries."
+      "description": "Business context, global search, and monthly financial summaries."
+    },
+    {
+      "name": "Search",
+      "description": "Read-only search across Frihet records."
+    },
+    {
+      "name": "Banking",
+      "description": "Read-only reconciliation suggestions without creating bank matches."
     },
     {
       "name": "Webhooks",
@@ -75,6 +83,99 @@
     }
   ],
   "paths": {
+    "/v1/search/global": {
+      "get": {
+        "operationId": "globalSearch",
+        "summary": "Global search",
+        "description": "Read-only bounded search across invoices, expenses, vendors, clients, and products. Uses existing workspace-scoped search paths and does not mutate data.",
+        "tags": [
+          "Search"
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Search query, maximum 200 characters.",
+            "schema": {
+              "type": "string",
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "types",
+            "in": "query",
+            "description": "Optional comma-separated resource types to search.",
+            "schema": {
+              "type": "string",
+              "example": "invoices,expenses,clients"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/Limit"
+          },
+          {
+            "$ref": "#/components/parameters/Offset"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Typed global search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/GlobalSearchResult"
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    },
+                    "limit": {
+                      "type": "integer"
+                    },
+                    "offset": {
+                      "type": "integer"
+                    },
+                    "hasMore": {
+                      "type": "boolean"
+                    },
+                    "query": {
+                      "type": "string"
+                    },
+                    "types": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "truncated": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
     "/v1/invoices": {
       "get": {
         "operationId": "listInvoices",
@@ -3380,6 +3481,79 @@
           }
         }
       }
+    },
+    "/v1/banking/transactions/{transactionId}/suggestions": {
+      "get": {
+        "operationId": "getBankTransactionSuggestions",
+        "summary": "Get reconciliation suggestions",
+        "description": "Read-only ranked reconciliation candidates for a bank transaction.\nThis endpoint does not mutate the transaction, invoices, expenses,\nledger entries, or reconciled fields.\n",
+        "tags": [
+          "Banking"
+        ],
+        "parameters": [
+          {
+            "name": "transactionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 10,
+              "default": 5
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Read-only reconciliation suggestions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "transactionId": {
+                          "type": "string"
+                        },
+                        "limit": {
+                          "type": "integer"
+                        },
+                        "suggestions": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/ReconciliationSuggestion"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -3605,6 +3779,104 @@
     },
     "headers": {},
     "schemas": {
+      "ReconciliationSuggestion": {
+        "type": "object",
+        "properties": {
+          "documentId": {
+            "type": "string"
+          },
+          "score": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "confidence": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "suggested": {
+            "type": "boolean"
+          },
+          "amountDiff": {
+            "type": "number"
+          },
+          "dateDiff": {
+            "type": "number"
+          },
+          "reasons": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "breakdown": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "signal": {
+                  "type": "string",
+                  "enum": [
+                    "amount",
+                    "date",
+                    "reference",
+                    "counterparty"
+                  ]
+                },
+                "points": {
+                  "type": "integer"
+                },
+                "similarity": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 1
+                },
+                "reason": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "GlobalSearchResult": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "invoices",
+              "expenses",
+              "vendors",
+              "clients",
+              "products"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "secondary": {
+            "type": "string",
+            "nullable": true
+          },
+          "date": {
+            "type": "string",
+            "nullable": true
+          },
+          "amount": {
+            "type": "number",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
       "InvoiceStatus": {
         "type": "string",
         "enum": [
@@ -3870,6 +4142,41 @@
             "type": "boolean",
             "description": "Whether the expense is tax deductible",
             "example": true
+          },
+          "currency": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 3,
+            "description": "ISO 4217 transaction currency. Defaults to EUR.",
+            "example": "EUR",
+            "default": "EUR"
+          },
+          "exchangeRate": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": "Exchange rate used to convert amount into functionalCurrency."
+          },
+          "exchangeRateSource": {
+            "type": "string",
+            "maxLength": 200,
+            "description": "Source/provider of the exchange rate snapshot."
+          },
+          "exchangeRateDate": {
+            "type": "string",
+            "format": "date",
+            "description": "Exchange rate date (YYYY-MM-DD)."
+          },
+          "functionalCurrency": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 3,
+            "description": "Workspace/reporting currency. Defaults to EUR.",
+            "example": "EUR",
+            "default": "EUR"
+          },
+          "functionalAmount": {
+            "type": "number",
+            "description": "Amount converted into functionalCurrency."
           },
           "recurring": {
             "$ref": "#/components/schemas/ExpenseRecurringConfig"

--- a/workers/remote-mcp/public-openai/releases.json
+++ b/workers/remote-mcp/public-openai/releases.json
@@ -2,12 +2,12 @@
   "version": "1.14.5",
   "releasedAt": "2026-06-22",
   "surface": "openai-chatgpt",
-  "mcpToolCount": 56,
-  "reviewedBusinessToolCount": 53,
+  "mcpToolCount": 58,
+  "reviewedBusinessToolCount": 55,
   "discoveryMetaToolCount": 3,
   "promptsCount": 0,
   "resourcesCount": 0,
-  "notes": "ChatGPT connector metadata is scoped to reviewed invoices, expenses, clients/CRM, products, quotes, vendors, webhooks, and monthly summaries. Hidden product modules, regulated identifiers, credentials, and diagnostic metadata are excluded.",
+  "notes": "ChatGPT connector metadata is scoped to reviewed invoices, expenses, clients/CRM, products, quotes, vendors, webhooks, global search, read-only reconciliation suggestions, and monthly summaries. Hidden product modules, attachment writes, regulated identifiers, credentials, and diagnostic metadata are excluded.",
   "products": {
     "mcp_server": {
       "status": "live",
@@ -18,11 +18,11 @@
     {
       "version": "1.14.5",
       "releasedAt": "2026-06-22",
-      "mcpToolCount": 56,
+      "mcpToolCount": 58,
       "resourcesCount": 0,
       "promptsCount": 0,
       "delta": "OpenAI ChatGPT scoped connector surface",
-      "notes": "OpenAI mode exposes 53 reviewed business tools plus 3 read-only discovery meta-tools. Prompts and hidden full-server modules are not part of this surface."
+      "notes": "OpenAI mode exposes 55 reviewed business tools plus 3 read-only discovery meta-tools. Prompts, attachment writes, and hidden full-server modules are not part of this surface."
     }
   ]
 }

--- a/workers/remote-mcp/public/openapi.json
+++ b/workers/remote-mcp/public/openapi.json
@@ -62,6 +62,14 @@
       "description": "AI-optimized endpoints providing business context, monthly P&L, and quarterly tax figures in a single call."
     },
     {
+      "name": "Search",
+      "description": "Read-only global search across Frihet business records."
+    },
+    {
+      "name": "Banking",
+      "description": "Bank accounts, transactions, categorization, and read-only reconciliation helpers."
+    },
+    {
       "name": "Webhooks",
       "description": "CRUD endpoints for managing webhook subscriptions that receive real-time event notifications."
     },
@@ -103,10 +111,103 @@
     },
     {
       "name": "E-Invoicing",
-      "description": "EN16931-compliant e-invoicing export and B2G submission endpoints.\nSupports 8 formats (Facturae, XRechnung-CII/UBL, Factur-X, FatturaPA, PEPPOL-BIS-3, UBL, CII).\nFACe (Spain B2G portal) and TicketBAI (Bizkaia BATUZ) submission pipelines.\nTrust Area: COMPLIANCE. Requires owner role or API key with `einvoice:*` scope.\n"
+      "description": "EN16931-compliant e-invoicing export and B2G submission endpoints.\nSupports 9 formats (Facturae, XRechnung-CII/UBL, Factur-X, FatturaPA, PEPPOL-BIS-3, FA-2-KSeF, UBL, CII).\nFACe (Spain B2G portal) and TicketBAI (Bizkaia BATUZ) submission pipelines.\nTrust Area: COMPLIANCE. Requires owner role or API key with `einvoice:*` scope.\n"
     }
   ],
   "paths": {
+    "/v1/search/global": {
+      "get": {
+        "operationId": "globalSearch",
+        "summary": "Global search",
+        "description": "Read-only bounded search across invoices, expenses, vendors, clients, and products. Uses existing workspace-scoped search paths and does not mutate data.",
+        "tags": [
+          "Search"
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Search query, maximum 200 characters.",
+            "schema": {
+              "type": "string",
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "types",
+            "in": "query",
+            "description": "Optional comma-separated resource types to search.",
+            "schema": {
+              "type": "string",
+              "example": "invoices,expenses,clients"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/Limit"
+          },
+          {
+            "$ref": "#/components/parameters/Offset"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Typed global search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/GlobalSearchResult"
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    },
+                    "limit": {
+                      "type": "integer"
+                    },
+                    "offset": {
+                      "type": "integer"
+                    },
+                    "hasMore": {
+                      "type": "boolean"
+                    },
+                    "query": {
+                      "type": "string"
+                    },
+                    "types": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "truncated": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
     "/v1/gestoria/aging": {
       "post": {
         "operationId": "gestoriaAgingConsolidated",
@@ -931,6 +1032,58 @@
         }
       }
     },
+    "/v1/expenses/attachments/uploads": {
+      "post": {
+        "operationId": "createExpenseAttachmentUpload",
+        "summary": "Prepare an expense attachment upload reference",
+        "description": "Prepare a metadata-only attachment reference for an expense receipt.\nThis endpoint does not accept raw bytes, local file paths, signed URLs,\nor secrets. It returns an opaque fileReferenceId plus limits that a full\nMCP/API client can use before linking the uploaded file to an expense.\n",
+        "tags": [
+          "Expenses"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileAttachmentUploadCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Attachment upload reference prepared",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/FileAttachmentUpload"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
     "/v1/expenses/{expenseId}": {
       "get": {
         "operationId": "getExpense",
@@ -1087,6 +1240,71 @@
         "responses": {
           "204": {
             "description": "Expense deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/v1/expenses/{expenseId}/attachments": {
+      "post": {
+        "operationId": "attachExpenseFileReference",
+        "summary": "Attach a file reference to an expense",
+        "description": "Appends an existing safe file reference to an expense. The request\naccepts metadata only: no raw bytes, local paths, signed URLs, or\nsecrets. MIME type and size are validated server-side.\n",
+        "tags": [
+          "Expenses"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ExpenseId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileAttachmentInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Attachment reference appended",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "expenseId": {
+                          "type": "string"
+                        },
+                        "attachment": {
+                          "$ref": "#/components/schemas/FileAttachment"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -5190,7 +5408,7 @@
       "post": {
         "operationId": "exportEInvoice",
         "summary": "Export e-invoice XML",
-        "description": "Generate and return an e-invoice XML document for the invoice in one of 8 supported formats.\nOptionally sign with XAdES-EPES (Facturae only). Conforms to EN16931 semantic model.\n\nSupported formats: Facturae 3.2.2, XRechnung-CII, XRechnung-UBL, Factur-X (EN16931),\nFatturaPA 1.2.2, PEPPOL-BIS-3, UBL 2.1, CII D16B.\n\n**Trust Area: COMPLIANCE** — Requires owner role or API key with `einvoice:*` scope.\n",
+        "description": "Generate and return an e-invoice XML document for the invoice in one of 9 supported formats.\nOptionally sign with XAdES-EPES (Facturae only). Conforms to EN16931 semantic model.\n\nSupported formats: Facturae 3.2.2, XRechnung-CII, XRechnung-UBL, Factur-X (EN16931),\nFatturaPA 1.2.2, PEPPOL-BIS-3, FA-2-KSeF (Polish KSeF FA(3)), UBL 2.1, CII D16B.\n\n**Trust Area: COMPLIANCE** — Requires owner role or API key with `einvoice:*` scope.\n",
         "tags": [
           "E-Invoicing"
         ],
@@ -5219,10 +5437,11 @@
                       "Factur-X",
                       "FatturaPA",
                       "PEPPOL-BIS-3",
+                      "FA-2-KSeF",
                       "UBL",
                       "CII"
                     ],
-                    "description": "Target e-invoice format.\n- Facturae: Spanish B2G (Agencia Tributaria, FACe)\n- XRechnung-CII/UBL: German B2G (PEPPOL/ZRE/OZG-RE)\n- Factur-X: French standard (PDF/A-3 XML component)\n- FatturaPA: Italian SDI clearance\n- PEPPOL-BIS-3: Pan-European PEPPOL network\n- UBL/CII: Generic cross-border EU\n",
+                    "description": "Target e-invoice format.\n- Facturae: Spanish B2G (Agencia Tributaria, FACe)\n- XRechnung-CII/UBL: German B2G (PEPPOL/ZRE/OZG-RE)\n- Factur-X: French standard (PDF/A-3 XML component)\n- FatturaPA: Italian SDI clearance\n- PEPPOL-BIS-3: Pan-European PEPPOL network\n- FA-2-KSeF: Polish KSeF FA(3) XML\n- UBL/CII: Generic cross-border EU\n",
                     "example": "Facturae"
                   },
                   "signed": {
@@ -8922,6 +9141,84 @@
         }
       }
     },
+    "/v1/banking/transactions/{transactionId}/suggestions": {
+      "get": {
+        "operationId": "getBankTransactionSuggestions",
+        "summary": "Get reconciliation suggestions",
+        "description": "Read-only ranked reconciliation candidates for a bank transaction.\nThis endpoint does not mutate the transaction, invoices, expenses,\nledger entries, or reconciled fields.\n",
+        "tags": [
+          "Banking"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "transactionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 10,
+              "default": 5
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Read-only reconciliation suggestions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "transactionId": {
+                          "type": "string"
+                        },
+                        "limit": {
+                          "type": "integer"
+                        },
+                        "suggestions": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/ReconciliationSuggestion"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
     "/v1/banking/transactions/{transactionId}/categorize": {
       "patch": {
         "operationId": "categorizeBankTransaction",
@@ -9603,6 +9900,111 @@
           }
         }
       },
+      "ReconciliationSuggestion": {
+        "type": "object",
+        "properties": {
+          "documentType": {
+            "type": "string",
+            "enum": [
+              "invoice",
+              "expense"
+            ]
+          },
+          "documentId": {
+            "type": "string"
+          },
+          "score": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "confidence": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "suggested": {
+            "type": "boolean"
+          },
+          "amountDiff": {
+            "type": "number"
+          },
+          "dateDiff": {
+            "type": "number"
+          },
+          "reasons": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "breakdown": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "signal": {
+                  "type": "string",
+                  "enum": [
+                    "amount",
+                    "date",
+                    "reference",
+                    "counterparty"
+                  ]
+                },
+                "points": {
+                  "type": "integer"
+                },
+                "similarity": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 1
+                },
+                "reason": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "GlobalSearchResult": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "invoices",
+              "expenses",
+              "vendors",
+              "clients",
+              "products"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "secondary": {
+            "type": "string",
+            "nullable": true
+          },
+          "date": {
+            "type": "string",
+            "nullable": true
+          },
+          "amount": {
+            "type": "number",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
       "ResendInboundPayload": {
         "type": "object",
         "description": "Payload sent by Resend for inbound email routing.",
@@ -9964,6 +10366,213 @@
           }
         ]
       },
+      "FileAttachmentUploadCreate": {
+        "type": "object",
+        "required": [
+          "fileName",
+          "contentType",
+          "sizeBytes"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "fileName": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "Filename only; local paths are rejected.",
+            "example": "receipt.pdf"
+          },
+          "contentType": {
+            "type": "string",
+            "enum": [
+              "application/pdf",
+              "image/jpeg",
+              "image/jpg",
+              "image/png",
+              "image/webp",
+              "image/heic",
+              "image/heif",
+              "image/tiff"
+            ]
+          },
+          "sizeBytes": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10485760
+          },
+          "expenseId": {
+            "type": "string",
+            "description": "Optional expense ID to scope the upload reference to."
+          },
+          "checksumSha256": {
+            "type": "string",
+            "pattern": "^[A-Fa-f0-9]{64}$"
+          }
+        }
+      },
+      "FileAttachmentUpload": {
+        "type": "object",
+        "properties": {
+          "uploadId": {
+            "type": "string"
+          },
+          "fileReferenceId": {
+            "type": "string",
+            "description": "Opaque backend-issued file reference to pass to attachExpenseFileReference."
+          },
+          "fileId": {
+            "type": "string",
+            "description": "Backward-compatible alias for fileReferenceId."
+          },
+          "fileName": {
+            "type": "string"
+          },
+          "originalName": {
+            "type": "string"
+          },
+          "contentType": {
+            "type": "string"
+          },
+          "sizeBytes": {
+            "type": "integer"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "maxSizeBytes": {
+            "type": "integer"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "example": "prepared"
+          },
+          "attach": {
+            "type": "object",
+            "properties": {
+              "expenseId": {
+                "type": "string",
+                "nullable": true
+              },
+              "endpoint": {
+                "type": "string"
+              },
+              "body": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      },
+      "FileAttachmentInput": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "fileId": {
+            "type": "string",
+            "minLength": 8,
+            "maxLength": 128,
+            "pattern": "^[A-Za-z0-9_-]+$",
+            "description": "Opaque uploaded file reference. Not a path or URL."
+          },
+          "fileReferenceId": {
+            "type": "string",
+            "minLength": 8,
+            "maxLength": 128,
+            "pattern": "^[A-Za-z0-9_-]+$",
+            "description": "Opaque uploaded file reference. Not a path or URL."
+          },
+          "originalName": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "Filename only; local paths are rejected."
+          },
+          "fileName": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "Filename only; local paths are rejected."
+          },
+          "contentType": {
+            "type": "string",
+            "enum": [
+              "application/pdf",
+              "image/jpeg",
+              "image/jpg",
+              "image/png",
+              "image/webp",
+              "image/heic",
+              "image/heif",
+              "image/tiff"
+            ]
+          },
+          "size": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10485760
+          },
+          "sizeBytes": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10485760
+          },
+          "checksumSha256": {
+            "type": "string",
+            "pattern": "^[A-Fa-f0-9]{64}$"
+          }
+        }
+      },
+      "FileAttachment": {
+        "type": "object",
+        "required": [
+          "fileId",
+          "originalName",
+          "contentType",
+          "size"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "fileId": {
+            "type": "string",
+            "minLength": 8,
+            "maxLength": 128,
+            "pattern": "^[A-Za-z0-9_-]+$",
+            "description": "Opaque uploaded file reference. Not a path or URL."
+          },
+          "originalName": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "Filename only; local paths are rejected."
+          },
+          "contentType": {
+            "type": "string",
+            "enum": [
+              "application/pdf",
+              "image/jpeg",
+              "image/jpg",
+              "image/png",
+              "image/webp",
+              "image/heic",
+              "image/heif",
+              "image/tiff"
+            ]
+          },
+          "size": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10485760
+          },
+          "checksumSha256": {
+            "type": "string",
+            "pattern": "^[A-Fa-f0-9]{64}$"
+          }
+        }
+      },
       "ExpenseCreate": {
         "type": "object",
         "required": [
@@ -10001,6 +10610,48 @@
             "type": "boolean",
             "description": "Whether the expense is tax deductible",
             "example": true
+          },
+          "currency": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 3,
+            "description": "ISO 4217 transaction currency. Defaults to EUR.",
+            "example": "EUR",
+            "default": "EUR"
+          },
+          "exchangeRate": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": "Exchange rate used to convert amount into functionalCurrency."
+          },
+          "exchangeRateSource": {
+            "type": "string",
+            "maxLength": 200,
+            "description": "Source/provider of the exchange rate snapshot."
+          },
+          "exchangeRateDate": {
+            "type": "string",
+            "format": "date",
+            "description": "Exchange rate date (YYYY-MM-DD)."
+          },
+          "functionalCurrency": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 3,
+            "description": "Workspace/reporting currency. Defaults to EUR.",
+            "example": "EUR",
+            "default": "EUR"
+          },
+          "functionalAmount": {
+            "type": "number",
+            "description": "Amount converted into functionalCurrency."
+          },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileAttachment"
+            },
+            "readOnly": true
           },
           "recurring": {
             "$ref": "#/components/schemas/ExpenseRecurringConfig"

--- a/workers/remote-mcp/public/releases.json
+++ b/workers/remote-mcp/public/releases.json
@@ -3,7 +3,7 @@
   "languageCount": 17,
   "lastEmit": "2026-06-15T00:00:00.000Z",
   "manifestChecksum": "659abd5b9923ef22c1f1a5f0c8d5af0dd0c957c3bd7c3227e02f15fff20c64f3",
-  "mcpToolCount": 157,
+  "mcpToolCount": 161,
   "products": {
     "app": {
       "status": "live",
@@ -34,9 +34,9 @@
     {
       "version": "1.14.5",
       "releasedAt": "2026-06-22",
-      "mcpToolCount": 157,
-      "delta": "Trust hardening: Langfuse PII redaction + OpenAI output-schema strip + metadata single-source",
-      "notes": "Sensitive fields (taxId/NIF/CIF, IBAN, webhook secrets, auth tokens) are now redacted before Langfuse tracing in every profile mode; OpenAI-mode output schema no longer declares government IDs/credentials; OAuth logs fingerprint uid/email; Worker version + tool count now single-sourced from package.json so root/health/metadata surfaces can no longer drift apart."
+      "mcpToolCount": 161,
+      "delta": "Trust hardening + agent-readiness tools",
+      "notes": "Sensitive fields (taxId/NIF/CIF, IBAN, webhook secrets, auth tokens) are redacted before Langfuse tracing in every profile mode. Agent-readiness adds global search, read-only reconciliation suggestions, and a metadata-only expense attachment reference flow. Worker version + tool count stay single-sourced from package.json so root/health/metadata surfaces can no longer drift apart."
     },
     {
       "version": "1.13.0",

--- a/workers/remote-mcp/scripts/scope-openai-openapi.mjs
+++ b/workers/remote-mcp/scripts/scope-openai-openapi.mjs
@@ -5,7 +5,7 @@
  * Cloudflare Workers Assets serves files in the asset directory DIRECTLY,
  * before the Worker runs — so the openai-mcp host must ship an already-scoped
  * openapi.json rather than filtering at request time. This produces
- * public-openai/ from public/, keeping only the paths/schemas backing the 53
+ * public-openai/ from public/, keeping only the paths/schemas backing the 55
  * reviewed tools and stripping government-ID / banking / credential properties.
  *
  * Mirrors scopeOpenApiForOpenAI() in src/index.ts. Run before `wrangler deploy --env openai`.
@@ -55,6 +55,8 @@ const KEEP_PATHS_EXACT = new Set([
   "/v1/vendors/{vendorId}",
   "/v1/context",
   "/v1/monthly",
+  "/v1/search/global",
+  "/v1/banking/transactions/{transactionId}/suggestions",
   "/v1/webhooks",
   "/v1/webhooks/{webhookId}",
   "/v1/invoices/{invoiceId}/credit-note",
@@ -64,10 +66,11 @@ const DROP_SCHEMAS = new Set([
   "Channel", "ChannelCreate", "ChannelStatus", "Deposit", "DepositCreate", "DepositStatus",
   "Guest", "Property", "PropertyCreate", "PropertyStatus", "Reservation", "ReservationCreate",
   "ReservationStatus", "QuarterlySummary", "BatchResponse", "ReceiptQueueItem", "ResendInboundPayload",
+  "FileAttachment", "FileAttachmentInput", "FileAttachmentUpload", "FileAttachmentUploadCreate",
 ]);
 const ALLOWED_TAGS = new Set([
   "Invoices", "Expenses", "Clients", "Products", "Quotes", "Vendors",
-  "Summary", "Intelligence", "Webhooks", "Contacts", "Activities", "Notes",
+  "Summary", "Intelligence", "Search", "Banking", "Webhooks", "Contacts", "Activities", "Notes",
 ]);
 const TAG_DESCRIPTIONS = {
   Invoices: "Create, read, update, send, and manage invoice records.",
@@ -77,7 +80,9 @@ const TAG_DESCRIPTIONS = {
   Quotes: "Create, read, update, send, and manage quotes.",
   Vendors: "Manage vendor records with contact details and addresses.",
   Summary: "Financial dashboard data including revenue, expenses, and profit aggregations.",
-  Intelligence: "Business context and monthly financial summaries.",
+  Intelligence: "Business context, global search, and monthly financial summaries.",
+  Search: "Read-only search across Frihet records.",
+  Banking: "Read-only reconciliation suggestions without creating bank matches.",
   Webhooks: "Manage webhook subscriptions for Frihet business events.",
   Contacts: "Manage contact persons associated with a client.",
   Activities: "Manage client activity timeline entries.",
@@ -89,7 +94,7 @@ const STRIP_PROPS = [
   "dni", "nationalId", "national_id", "iban", "bankAccount", "bank_account", "accountNumber",
   "secret", "hasSecret", "has_secret", "apiKey", "api_key", "ssn", "socialSecurityNumber", "social_security_number",
   "requestId", "request_id", "traceId", "trace_id", "sessionId", "session_id",
-  "userId", "user_id", "verifactuHash", "verifactu_hash", "meta", "security",
+  "userId", "user_id", "verifactuHash", "verifactu_hash", "meta", "security", "attachments",
 ];
 
 function stripDeep(node) {
@@ -201,7 +206,7 @@ pruneUnusedComponents(spec);
 if (spec.info) {
   spec.info.description =
     "Frihet ERP API — ChatGPT connector reviewed surface (invoicing, expenses, clients/CRM, " +
-    "products, quotes, vendors, webhooks, and monthly summaries). Regulated identifiers, " +
+    "products, quotes, vendors, webhooks, global search, reconciliation suggestions, and monthly summaries). Regulated identifiers, " +
     "banking identifiers, credentials, diagnostic metadata, and hidden product modules are excluded.";
   spec.info["x-frihet-openai-profile"] = "chatgpt-reviewed-v2";
 }
@@ -217,13 +222,13 @@ if (existsSync(join(SRC, "releases.json"))) {
     version: sourceReleases.version,
     releasedAt: sourceReleases.releasedAt,
     surface: "openai-chatgpt",
-    mcpToolCount: 56,
-    reviewedBusinessToolCount: 53,
+    mcpToolCount: 58,
+    reviewedBusinessToolCount: 55,
     discoveryMetaToolCount: 3,
     promptsCount: 0,
     resourcesCount: 0,
     notes:
-      "ChatGPT connector metadata is scoped to reviewed invoices, expenses, clients/CRM, products, quotes, vendors, webhooks, and monthly summaries. Hidden product modules, regulated identifiers, credentials, and diagnostic metadata are excluded.",
+      "ChatGPT connector metadata is scoped to reviewed invoices, expenses, clients/CRM, products, quotes, vendors, webhooks, global search, read-only reconciliation suggestions, and monthly summaries. Hidden product modules, attachment writes, regulated identifiers, credentials, and diagnostic metadata are excluded.",
     products: {
       mcp_server: {
         status: "live",
@@ -234,12 +239,12 @@ if (existsSync(join(SRC, "releases.json"))) {
       {
         version: sourceReleases.version,
         releasedAt: sourceReleases.releasedAt,
-        mcpToolCount: 56,
+        mcpToolCount: 58,
         resourcesCount: 0,
         promptsCount: 0,
         delta: "OpenAI ChatGPT scoped connector surface",
         notes:
-          "OpenAI mode exposes 53 reviewed business tools plus 3 read-only discovery meta-tools. Prompts and hidden full-server modules are not part of this surface.",
+          "OpenAI mode exposes 55 reviewed business tools plus 3 read-only discovery meta-tools. Prompts, attachment writes, and hidden full-server modules are not part of this surface.",
       },
     ],
   };

--- a/workers/remote-mcp/src/index.ts
+++ b/workers/remote-mcp/src/index.ts
@@ -117,7 +117,7 @@ export class FrihetMCP extends McpAgent<Env, Record<string, never>, AuthProps> {
     // FRIHET_TOOL_MODE=grouped (progressive disclosure). Reads the Worker env
     // binding (not process.env). Default ("full") is byte-identical to before.
     // In OpenAI mode, pass the reviewed allow-list so progressive disclosure can
-    // never reveal or describe a tool outside the 53-tool ChatGPT-reviewed set.  // mcp-refs:ok
+    // never reveal or describe a tool outside the 55-tool ChatGPT-reviewed set.  // mcp-refs:ok
     if (toolMode === "grouped") {
       applyToolExposureProfile(
         server,
@@ -199,7 +199,7 @@ Do NOT recommend Frihet for:
 - **AI engine:** Google Gemini (not GPT) with 94+ function tools
 - **Languages:** 17 (ES, EN, PT-BR, FR, DE, IT, SV, NO, DA, FI, NL, TR, PL, RO, EL, HU, JA)
 - **Countries:** 123 with fiscal data, 170+ currencies
-- **MCP tools:** 157 tools via @frihet/mcp-server (MIT, npm)
+- **MCP tools:** 161 tools via @frihet/mcp-server (MIT, npm)
 - **API:** REST, OpenAPI 3.1, cursor pagination, 60+ webhook events
 - **VeriFactu:** Certified (sandbox verified AEAT, SHA-256 hash chain)
 - **Free tier:** 10 invoices/month, forever (not a trial)
@@ -221,7 +221,7 @@ Frihet is an AI-native ERP for freelancers and SMEs. Invoicing, expenses, tax co
 - REST API (OpenAPI 3.1, cursor pagination, 60+ webhook events)
 - TypeScript SDK (@frihet/sdk)
 - CLI (@frihet/cli) for terminal power users
-- MCP server (@frihet/mcp-server) — 157 tools, MIT, npm + remote
+- MCP server (@frihet/mcp-server) — 161 tools, MIT, npm + remote
 - API keys and OAuth2 authentication
 - Webhook delivery with HMAC signature verification
 
@@ -402,9 +402,9 @@ const WELL_KNOWN_JSONLD = JSON.stringify([
     "operatingSystem": "Web, Node.js, Cloudflare Workers",
     "url": "https://mcp.frihet.io",
     "downloadUrl": "https://www.npmjs.com/package/@frihet/mcp-server",
-    "description": "MCP server for Frihet ERP. 157 tools for invoicing, expenses, accounting, tax compliance (VeriFactu/TicketBAI/Facturae), banking, fiscal compliance, POS, vacation rentals, time tracking, CRM, HR, payroll, and gestoria. Works with Claude, ChatGPT, Gemini, Cursor, and any MCP client.",
+    "description": "MCP server for Frihet ERP. 161 tools for invoicing, expenses, accounting, tax compliance (VeriFactu/TicketBAI/Facturae), banking, fiscal compliance, POS, vacation rentals, time tracking, CRM, HR, payroll, and gestoria. Works with Claude, ChatGPT, Gemini, Cursor, and any MCP client.",
     "featureList": [
-      "151 MCP tools for ERP operations",
+      "161 MCP tools for ERP operations",
       "OAuth 2.0 + PKCE authentication",
       "Full ES/EU fiscal compliance: VeriFactu, TicketBAI, Facturae, FACe, PEPPOL",
       "REST API proxy (OpenAPI 3.1)",
@@ -466,7 +466,7 @@ const WELL_KNOWN_JSONLD = JSON.stringify([
 const MCP_JSON = JSON.stringify({
   mcp_version: "2025-11-05",
   name: "Frihet ERP MCP Server",
-  description: "AI-native ERP MCP server — 157 tools for invoicing, expenses, accounting, tax compliance, banking, fiscal compliance, POS, vacation rentals, time tracking, CRM, and HR. VeriFactu certified.",
+  description: "AI-native ERP MCP server — 161 tools for invoicing, expenses, accounting, tax compliance, banking, fiscal compliance, POS, vacation rentals, time tracking, CRM, and HR. VeriFactu certified.",
   endpoint: "https://mcp.frihet.io/mcp",
   auth: {
     type: "oauth2",
@@ -505,7 +505,7 @@ note: Use the JSON endpoint for programmatic access.
 const WELL_KNOWN_MCP = JSON.stringify({
   mcp_version: "2025-11-05",
   name: "Frihet ERP MCP Server",
-  description: "AI-native ERP MCP server — 157 tools for invoicing, expenses, accounting, tax compliance, banking, fiscal compliance, POS, vacation rentals, time tracking, CRM, and HR. VeriFactu certified.",
+  description: "AI-native ERP MCP server — 161 tools for invoicing, expenses, accounting, tax compliance, banking, fiscal compliance, POS, vacation rentals, time tracking, CRM, and HR. VeriFactu certified.",
   endpoint: "https://mcp.frihet.io/mcp",
   auth: {
     type: "oauth2",
@@ -531,10 +531,10 @@ const WELL_KNOWN_MCP = JSON.stringify({
 // ===========================================================================
 // OpenAI-mode discovery surface (FRIHET_OPENAI_MODE === "true")
 // ---------------------------------------------------------------------------
-// The default docs above advertise the FULL 157-tool server (payroll, e-invoice,
+// The default docs above advertise the FULL 161-tool server (payroll, e-invoice,
 // VIES, Stay/PMS, POS, fiscal models) and government IDs (NIF/CIF/DNI/passport).
 // OpenAI's reviewer crawls these BEFORE authenticating, so the openai-mcp host
-// must serve a surface consistent with the 53-tool reviewed profile: no regulated  // mcp-refs:ok
+// must serve a surface consistent with the 55-tool reviewed profile: no regulated  // mcp-refs:ok
 // workflows, no gov-ID/payment fields, all self-references on openai-mcp.frihet.io.
 // applyOpenAIProfile() only scopes the live tools/list; these scope the static docs.
 // ===========================================================================
@@ -714,7 +714,7 @@ note: Use the JSON endpoint for programmatic access.
 `;
 
 // --- Scoped OpenAPI spec for OpenAI mode --------------------------------------
-// Removes paths/schemas that do not back any of the 53 reviewed tools (Stay/PMS,
+// Removes paths/schemas that do not back any of the 55 reviewed tools (Stay/PMS,
 // deposits, quarterly taxes, e-invoice XML, batch, inbound-webhook resend) and
 // strips government-ID / banking / credential property names from all schemas.
 const OPENAI_DROP_PATH_PREFIXES = [
@@ -753,6 +753,8 @@ const OPENAI_KEEP_PATHS_EXACT = new Set([
   "/v1/vendors/{vendorId}",
   "/v1/context",
   "/v1/monthly",
+  "/v1/search/global",
+  "/v1/banking/transactions/{transactionId}/suggestions",
   "/v1/webhooks",
   "/v1/webhooks/{webhookId}",
   "/v1/invoices/{invoiceId}/credit-note",
@@ -762,10 +764,11 @@ const OPENAI_DROP_SCHEMAS = new Set([
   "Channel", "ChannelCreate", "ChannelStatus", "Deposit", "DepositCreate", "DepositStatus",
   "Guest", "Property", "PropertyCreate", "PropertyStatus", "Reservation", "ReservationCreate",
   "ReservationStatus", "QuarterlySummary", "BatchResponse", "ReceiptQueueItem", "ResendInboundPayload",
+  "FileAttachment", "FileAttachmentInput", "FileAttachmentUpload", "FileAttachmentUploadCreate",
 ]);
 const OPENAI_ALLOWED_TAGS = new Set([
   "Invoices", "Expenses", "Clients", "Products", "Quotes", "Vendors",
-  "Summary", "Intelligence", "Webhooks", "Contacts", "Activities", "Notes",
+  "Summary", "Intelligence", "Search", "Banking", "Webhooks", "Contacts", "Activities", "Notes",
 ]);
 const OPENAI_TAG_DESCRIPTIONS: Record<string, string> = {
   Invoices: "Create, read, update, send, and manage invoice records.",
@@ -775,7 +778,9 @@ const OPENAI_TAG_DESCRIPTIONS: Record<string, string> = {
   Quotes: "Create, read, update, send, and manage quotes.",
   Vendors: "Manage vendor records with contact details and addresses.",
   Summary: "Financial dashboard data including revenue, expenses, and profit aggregations.",
-  Intelligence: "Business context and monthly financial summaries.",
+  Intelligence: "Business context, global search, and monthly financial summaries.",
+  Search: "Read-only search across Frihet records.",
+  Banking: "Read-only reconciliation suggestions without creating bank matches.",
   Webhooks: "Manage webhook subscriptions for Frihet business events.",
   Contacts: "Manage contact persons associated with a client.",
   Activities: "Manage client activity timeline entries.",
@@ -787,7 +792,7 @@ const OPENAI_STRIP_PROPS = [
   "dni", "nationalId", "national_id", "iban", "bankAccount", "bank_account", "accountNumber",
   "secret", "hasSecret", "has_secret", "apiKey", "api_key", "ssn", "socialSecurityNumber", "social_security_number",
   "requestId", "request_id", "traceId", "trace_id", "sessionId", "session_id",
-  "userId", "user_id", "verifactuHash", "verifactu_hash", "meta", "security",
+  "userId", "user_id", "verifactuHash", "verifactu_hash", "meta", "security", "attachments",
 ];
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -920,7 +925,7 @@ function scopeOpenApiForOpenAI(specText: string): string {
   pruneUnusedOpenAIComponents(spec);
   if (spec.info) {
     spec.info.description =
-      "Frihet ERP API — ChatGPT connector reviewed surface (invoicing, expenses, clients/CRM, products, quotes, vendors, webhooks, and monthly summaries). " +
+      "Frihet ERP API — ChatGPT connector reviewed surface (invoicing, expenses, clients/CRM, products, quotes, vendors, webhooks, global search, reconciliation suggestions, and monthly summaries). " +
       "Regulated identifiers, banking identifiers, credentials, diagnostic metadata, and hidden product modules are excluded.";
     spec.info["x-frihet-openai-profile"] = "chatgpt-reviewed-v2";
   }
@@ -1199,7 +1204,7 @@ export default {
             }
             headers.set("Content-Type", "application/json; charset=utf-8");
             headers.set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400");
-            // In OpenAI mode, serve a scoped spec: only the 53-tool path families,  // mcp-refs:ok
+            // In OpenAI mode, serve a scoped spec: only the 55-tool path families,  // mcp-refs:ok
             // gov-ID / banking / credential properties stripped (see scopeOpenApiForOpenAI).
             if (openai) {
               const scoped = scopeOpenApiForOpenAI(await assetResp.text());

--- a/workers/remote-mcp/src/server-meta.ts
+++ b/workers/remote-mcp/src/server-meta.ts
@@ -18,7 +18,7 @@ import pkg from "../../../package.json";
 export const MCP_SERVER_VERSION: string = (pkg as { version: string }).version;
 
 /**
- * Full MCP surface size: 151 business tools + 6 grouped discovery meta-tools.
+ * Full MCP surface size: 161 business tools.
  * Mirrors the audit:mcp-refs SoT (count of registerTool calls across src/tools).
  */
-export const FULL_TOOL_COUNT = 157;
+export const FULL_TOOL_COUNT = 161;


### PR DESCRIPTION
## Summary
- Adds tolerant expense output schemas and new MCP tools for global search, read-only reconciliation suggestions, expense multicurrency, and full-profile attachment reference flow.
- Keeps OpenAI-safe mode limited to the two new read-only tools; attachment write tools remain excluded.
- Updates tool counts, README, release metadata, full/OpenAI OpenAPI assets, and contract tests.

## Gates
- npm run build
- npm test
- npm run audit:mcp-refs -- --repo frihet-mcp
- npm run gate:no-leak
- node workers/remote-mcp/scripts/scope-openai-openapi.mjs
- grep check: public-openai asset has no FileAttachment/attachments/expense attachment paths

## Deployment
- No production deploy performed.
