### PR TITLE
fix(docs): sync stale 151-tool references to canonical 157

### DIFF
--- a/docs/tool-exposure-modes.md
+++ b/docs/tool-exposure-modes.md
@@ -51,8 +51,8 @@ Then it adds **three discovery meta-tools** as the entry point:
 | `search_tools(query, group?, limit?)` | Tools matching a free-text query across name/title/summary/group, with their group, summary, read-only flag and input fields. Ranked, with the exact-name match on top. |
 | `describe_tool(name)` | The **full original description** and input fields for one tool, on demand. |
 
-The agent now loads three meta-tool descriptions plus ~151 terse one-liners
-instead of 151 multi-paragraph bilingual blobs, and pulls full depth only for
+The agent now loads three meta-tool descriptions plus ~157 terse one-liners
+instead of 157 multi-paragraph bilingual blobs, and pulls full depth only for
 the handful of tools it actually needs.
 
 ```
@@ -94,8 +94,8 @@ tools that say "invoice" but belong to fiscal/compliance) are pinned via a small
 - **No behavior change in `grouped`.** Names, input schemas, annotations and
   handlers are untouched; only the *description string* the agent loads up front
   is collapsed. The real tools stay fully invocable.
-- **Audited tool count stays 151.** The exposure layer lives in `src/`, not
-  `src/tools/*.ts`, so `npm run audit:mcp-refs` still counts 151 ERP tools. The
+- **Audited tool count stays 157.** The exposure layer lives in `src/`, not
+  `src/tools/*.ts`, so `npm run audit:mcp-refs` still counts 157 ERP tools. The
   three meta-tools are discovery helpers, not ERP tools, and are added only in
   grouped mode.
 - **Composes with `FRIHET_OPENAI_MODE`.** If both are set, the OpenAI allowlist
@@ -110,9 +110,9 @@ depth stays usable inside an agent's context budget as the surface grows.
 ## Tests
 
 `src/__tests__/tool-exposure.test.ts` covers: mode resolution; full mode is
-byte-identical (151 tools, no meta-tools, descriptions untouched); grouped mode
-adds 3 meta-tools + a 151-entry catalog and collapses descriptions; names,
+byte-identical (157 tools, no meta-tools, descriptions untouched); grouped mode
+adds 3 meta-tools + a 157-entry catalog and collapses descriptions; names,
 annotations, schemas and handler behavior are preserved; `groupForTool`
-reproduces `FILE_TO_GROUP` for all 151 tools; and each meta-tool's runtime
+reproduces `FILE_TO_GROUP` for all 157 tools; and each meta-tool's runtime
 behavior (`list_tool_groups`, `search_tools` with group filter, `describe_tool`
 including the unknown-name error path).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@frihet/mcp-server",
-  "version": "1.14.4",
+  "version": "1.14.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@frihet/mcp-server",
-      "version": "1.14.4",
+      "version": "1.14.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/__tests__/tool-exposure.test.ts
+++ b/src/__tests__/tool-exposure.test.ts
@@ -2,10 +2,10 @@
  * Tests for the grouped tool-exposure profile (progressive disclosure).
  *
  * The default ("full") mode must stay BYTE-IDENTICAL to the un-profiled server
- * so existing users are unaffected. The opt-in "grouped" mode collapses the 151
+ * so existing users are unaffected. The opt-in "grouped" mode collapses the 157
  * full tool descriptions into terse one-liners and adds three discovery
  * meta-tools (list_tool_groups, search_tools, describe_tool) so agents load
- * depth on demand instead of a flat 151-tool wall of context.
+ * depth on demand instead of a flat 157-tool wall of context.
  */
 
 import { describe, test } from "node:test";

--- a/src/tool-exposure.ts
+++ b/src/tool-exposure.ts
@@ -3,10 +3,10 @@
  *
  * Activated by FRIHET_TOOL_MODE=grouped (env var or Worker binding).
  * Default (unset, or FRIHET_TOOL_MODE=full) leaves the server BYTE-IDENTICAL
- * to today: all 151 tools registered with their full descriptions/schemas.
+ * to today: all 157 tools registered with their full descriptions/schemas.
  *
  * ── Why ──────────────────────────────────────────────────────────────────
- * Context rot is the 2026 problem: a flat list of 151 tool descriptions,
+ * Context rot is the 2026 problem: a flat list of 157 tool descriptions,
  * each a multi-paragraph bilingual blob, eats the agent's context window and
  * degrades tool selection before any work begins. Leaders cut flat lists.
  *
@@ -30,12 +30,12 @@
  *        • search_tools(query)     — fuzzy match → matching tool summaries
  *        • describe_tool(name)     — full original description + input fields
  *
- * The agent loads ~3 meta-tool descriptions + 151 terse one-liners instead of
- * 151 full bilingual blobs, then pulls full depth only for the handful of
+ * The agent loads ~3 meta-tool descriptions + 157 terse one-liners instead of
+ * 157 full bilingual blobs, then pulls full depth only for the handful of
  * tools it actually needs. Progressive disclosure, zero behavior change.
  *
  * IMPORTANT: this is purely an EXPOSURE layer. It does NOT live in
- * src/tools/*.ts, so the audited tool count stays 151 (+ meta). The meta-tools
+ * src/tools/*.ts, so the audited tool count stays 157 (+ meta). The meta-tools
  * are added only in grouped mode and are NOT counted as ERP tools.
  *
  * @see ./openai-profile.ts — the sibling interceptor this mirrors.
@@ -179,7 +179,7 @@ export const FILE_TO_GROUP: Record<string, ToolGroupId> = {
 
 /**
  * Per-tool overrides where the source FILE places a tool in a different group
- * than a naive name match would (verified against the 151 registration sites).
+ * than a naive name match would (verified against the 157 registration sites).
  * These eight names live in a file whose domain differs from their name prefix
  * (e.g. e-invoicing tools say "invoice" but belong to fiscal/compliance).
  */
@@ -200,7 +200,7 @@ const NAME_OVERRIDES: Record<string, ToolGroupId> = {
 
 /**
  * Assign a group by tool NAME. The name-based mapping reproduces the
- * source-file grouping exactly for all 151 current tools (verified), with the
+ * source-file grouping exactly for all 157 current tools (verified), with the
  * eight cross-file cases pinned via NAME_OVERRIDES. Driven off the name (not a
  * hand-kept list) so a future tool lands somewhere sensible automatically.
  *

--- a/src/tools/register-all.ts
+++ b/src/tools/register-all.ts
@@ -1,12 +1,12 @@
 /**
- * Barrel module that registers all 151 Frihet ERP tools on an McpServer.
+ * Barrel module that registers all 157 Frihet ERP tools on an McpServer.
  *
  * Used by both the local (stdio) and remote (Cloudflare Workers) servers
  * so tool definitions stay in sync — one source of truth.
  *
  * Langfuse observability is injected by patching server.registerTool once
  * before any tool registration. This wraps every tool callback with
- * traceMCPTool so all 151 tools are instrumented at zero per-tool cost.
+ * traceMCPTool so all 157 tools are instrumented at zero per-tool cost.
  */
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -47,7 +47,7 @@ import { registerAccountingCloseTools } from "./accountingClose.js";
 /**
  * Patches server.registerTool to wrap every tool callback with Langfuse tracing.
  *
- * The patch is applied once before tool registration so all 151 tools are
+ * The patch is applied once before tool registration so all 157 tools are
  * instrumented without per-tool edits. Tool call signatures are unchanged —
  * existing MCP clients continue to work identically.
  *


### PR DESCRIPTION
## Summary
- Comments in `src/tools/register-all.ts`, `src/tool-exposure.ts`, `docs/tool-exposure-modes.md` and `src/__tests__/tool-exposure.test.ts` still said "151 tools" from before the ERP tool count grew to 157. Comment/doc drift only — no behavior change.
- `package-lock.json` had a stale `1.14.4` while `package.json` was already `1.14.5`; `npm install` synced it.
- `docs/RELEASE_NOTES_1.13.0.md`'s "151 tools" is left untouched — legitimate historical record of that release.

## Investigation note for `npm run audit:mcp-refs`
Ran the audit script — it is **not** a hardcoded assertion, it dynamically computes `TOOL_COUNT` (157) from live `registerTool` calls in `src/tools/*.ts` and `VERSION` (1.14.5) from `package.json`. So the "151"/"1.14.1" comments fixed here were stale prose describing a dynamic value, not executable assertions — safe to edit freely.

However, the audit's `REPOS` file allowlist does **not** include the files fixed in this PR (`register-all.ts`, `tool-exposure.ts`, `tool-exposure-modes.md`, the test file), nor the files fixed in the sister-repo PRs (`public/llms.txt` in Frihet-Saas-Website, `static/llms.txt`/`static/llms-full.txt` in frihet-docs) — so drift here won't be caught automatically going forward. Recommend extending `REPOS` in `scripts/audit-mcp-refs.mjs` to cover these paths.

Running the audit against the live sister repos surfaced one unrelated finding out of my assigned scope: `Frihet-ERP/docs/dev/mcp-tools-coverage.md:3` still says `v1.14.3` (should be `1.14.5`) — flagging for a separate fix, not touched here.

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 344/344 pass
- [x] `grep -rn 151 src/ docs/` — only remaining hits are the intentionally-untouched `RELEASE_NOTES_1.13.0.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)